### PR TITLE
Move Pokedex definitions

### DIFF
--- a/json.go
+++ b/json.go
@@ -10,21 +10,6 @@ import (
 )
 
 func generate_json() {
-	var pokedexes = []Pokedex{ 
-		Pokedex{"I", "red-blue-yellow", "Kanto dex", []string{ "Red", "Blue", "Yellow" }, "Kanto", 151, []Pokemon{} },
-		Pokedex{"II", "gold-silver-crystal", "National Johto dex", []string{ "Gold", "Silver", "Crystal" }, "Johto", 251, []Pokemon{} },
-		Pokedex{"III", "ruby-sapphire-emerald", "National Hoenn dex", []string{ "Ruby", "Sapphire", "Emerald" }, "Hoenn", 386, []Pokemon{} },
-		Pokedex{"III", "firered-leafgreen", "National updated Kanto dex", []string{ "FireRed", "Leafgreen" }, "Kanto", 386, []Pokemon{} },
-		Pokedex{"IV", "diamond-pearl-platinum", "National Sinnoh dex", []string{ "Diamond", "Pearl", "Platinum" }, "Sinnoh", 490, []Pokemon{} },
-		Pokedex{"IV", "heartgold-soulsilver", "National updated Johto dex", []string{ "HeartGold", "SoulSilver" }, "Johto", 490, []Pokemon{} },
-		Pokedex{"V", "black-white-black-2-white-2", "National Unova dex", []string{ "Black", "White", "Black 2", "White 2" }, "Unova", 649, []Pokemon{} },
-		Pokedex{"VI", "x-y", "National Kalos dex", []string{ "X", "Y" }, "Kalos", 718, []Pokemon{} },
-		Pokedex{"VI", "omega-ruby-alpha-sapphire", "Nation updated Hoenn dex", []string{ "Omega Ruby", "Alpha Sapphire" }, "Hoenn", 718, []Pokemon{} },
-		Pokedex{"VII", "sun-moon", "Nation Alola dex", []string{ "Sun", "Moon" }, "Alola", 802, []Pokemon{} },
-		Pokedex{"VII", "ultra-sun-ultra-moon", "National updated Alola dex", []string{ "Ultra Sun", "Ultra Moon" }, "Alola", 807, []Pokemon{} },
-		// generation VIII is not yet available in Veekun, these are generated manually for now
-	}
-
 	db, err := sql.Open("sqlite3", "./pokedex.sqlite")
 	if err != nil {
 		log.Fatal(err)
@@ -34,6 +19,11 @@ func generate_json() {
 	fmt.Printf("Connected to database (%T)\n", db)
 
 	for _, pokedex := range pokedexes {
+		if pokedex.MaxNationalDex == 0 {
+			fmt.Printf("No maximal national dex number defined for '%s', skipping...\n", pokedex.Name)
+			continue
+		}
+
 		rows, err := db.Query(`
 			select
 				pokemon_species.id as id,

--- a/models.go
+++ b/models.go
@@ -16,3 +16,19 @@ type Pokemon struct {
 	Identifier string     `json:"identifier"`
 	Name string           `json:"name"`
 }
+
+var pokedexes = []Pokedex{ 
+	Pokedex{"I", "red-blue-yellow", "Kanto dex", []string{ "Red", "Blue", "Yellow" }, "Kanto", 151, []Pokemon{} },
+	Pokedex{"II", "gold-silver-crystal", "National Johto dex", []string{ "Gold", "Silver", "Crystal" }, "Johto", 251, []Pokemon{} },
+	Pokedex{"III", "ruby-sapphire-emerald", "National Hoenn dex", []string{ "Ruby", "Sapphire", "Emerald" }, "Hoenn", 386, []Pokemon{} },
+	Pokedex{"III", "firered-leafgreen", "National updated Kanto dex", []string{ "FireRed", "Leafgreen" }, "Kanto", 386, []Pokemon{} },
+	Pokedex{"IV", "diamond-pearl-platinum", "National Sinnoh dex", []string{ "Diamond", "Pearl", "Platinum" }, "Sinnoh", 490, []Pokemon{} },
+	Pokedex{"IV", "heartgold-soulsilver", "National updated Johto dex", []string{ "HeartGold", "SoulSilver" }, "Johto", 490, []Pokemon{} },
+	Pokedex{"V", "black-white-black-2-white-2", "National Unova dex", []string{ "Black", "White", "Black 2", "White 2" }, "Unova", 649, []Pokemon{} },
+	Pokedex{"VI", "x-y", "National Kalos dex", []string{ "X", "Y" }, "Kalos", 718, []Pokemon{} },
+	Pokedex{"VI", "omega-ruby-alpha-sapphire", "Nation updated Hoenn dex", []string{ "Omega Ruby", "Alpha Sapphire" }, "Hoenn", 718, []Pokemon{} },
+	Pokedex{"VII", "sun-moon", "Nation Alola dex", []string{ "Sun", "Moon" }, "Alola", 802, []Pokemon{} },
+	Pokedex{"VII", "ultra-sun-ultra-moon", "National updated Alola dex", []string{ "Ultra Sun", "Ultra Moon" }, "Alola", 807, []Pokemon{} },
+	Pokedex{"VIII", "sword-shield-galar", "Galar dex", []string{ "Sword", "Shield"}, "Galar", 0, []Pokemon{} },
+	Pokedex{"VIII", "sword-shield-isle-of-armor", "Isle of Armor dex", []string{ "Sword", "Shield"}, "Galar", 0, []Pokemon{} },
+}


### PR DESCRIPTION
- move Pokedex definitions to `models.go` so these can be used to generate and index.html in a later stage
- added the implication that a max national dex of `0` means the JSON should not be generated from the Veekun data. Maybe I'll change this to a more explicit specification later.