### PR TITLE
Add `alt` attributes to images

### DIFF
--- a/docs/black-white-black-2-white-2.html
+++ b/docs/black-white-black-2-white-2.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Bulbasaur
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Ivysaur
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Venusaur
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Charmander
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Charmeleon
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Charizard
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Squirtle
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Wartortle
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Blastoise
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Caterpie
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Metapod
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Butterfree
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="Weedle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="View Weedle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" alt="Weedle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Weedle
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="Kakuna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="View Kakuna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" alt="Kakuna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Kakuna
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="Beedrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="View Beedrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" alt="Beedrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Beedrill
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="Pidgey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="View Pidgey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" alt="Pidgey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Pidgey
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="Pidgeotto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="View Pidgeotto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" alt="Pidgeotto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Pidgeotto
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="Pidgeot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="View Pidgeot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" alt="Pidgeot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Pidgeot
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="Rattata">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="View Rattata on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" alt="Rattata" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Rattata
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="Raticate">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="View Raticate on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" alt="Raticate" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Raticate
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="Spearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="View Spearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" alt="Spearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Spearow
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="Fearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="View Fearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" alt="Fearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fearow
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="Ekans">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="View Ekans on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" alt="Ekans" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Ekans
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="Arbok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="View Arbok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" alt="Arbok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Arbok
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Pikachu
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Raichu
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Sandshrew
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Sandslash
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="Nidoran♀">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="View Nidoran♀ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" alt="Nidoran♀" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nidoran♀
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="Nidorina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="View Nidorina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" alt="Nidorina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Nidorina
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="Nidoqueen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="View Nidoqueen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" alt="Nidoqueen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Nidoqueen
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="Nidoran♂">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="View Nidoran♂ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" alt="Nidoran♂" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Nidoran♂
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="Nidorino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="View Nidorino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" alt="Nidorino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Nidorino
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="Nidoking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="View Nidoking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" alt="Nidoking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Nidoking
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Clefairy
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Clefable
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Vulpix
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ninetales
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Jigglypuff
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Wigglytuff
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="Zubat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="View Zubat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" alt="Zubat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Zubat
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="Golbat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="View Golbat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" alt="Golbat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Golbat
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Oddish
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Gloom
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Vileplume
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="Paras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="View Paras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" alt="Paras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Paras
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="Parasect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="View Parasect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" alt="Parasect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Parasect
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="Venonat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="View Venonat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" alt="Venonat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Venonat
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="Venomoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="View Venomoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" alt="Venomoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Venomoth
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Diglett
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Dugtrio
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Meowth
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Persian
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Psyduck
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Golduck
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="Mankey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="View Mankey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" alt="Mankey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Mankey
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="Primeape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="View Primeape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" alt="Primeape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Primeape
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Growlithe
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Arcanine
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Poliwag
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Poliwhirl
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Poliwrath
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Abra
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Kadabra
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Alakazam
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Machop
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Machoke
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Machamp
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="Bellsprout">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="View Bellsprout on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" alt="Bellsprout" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Bellsprout
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="Weepinbell">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="View Weepinbell on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" alt="Weepinbell" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Weepinbell
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="Victreebel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="View Victreebel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" alt="Victreebel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Victreebel
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Tentacool
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Tentacruel
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="Geodude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="View Geodude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" alt="Geodude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Geodude
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="Graveler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="View Graveler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" alt="Graveler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Graveler
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="Golem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="View Golem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" alt="Golem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Golem
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Ponyta
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Rapidash
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Slowpoke
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Slowbro
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Magnemite
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Magneton
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="Farfetch’d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="View Farfetch’d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch’d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Farfetch’d
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="Doduo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="View Doduo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" alt="Doduo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Doduo
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="Dodrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="View Dodrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" alt="Dodrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Dodrio
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="Seel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="View Seel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" alt="Seel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Seel
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="Dewgong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="View Dewgong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" alt="Dewgong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Dewgong
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="Grimer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="View Grimer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" alt="Grimer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Grimer
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="Muk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="View Muk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" alt="Muk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Muk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Shellder
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Cloyster
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Gastly
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Haunter
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Gengar
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Onix
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="Drowzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="View Drowzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" alt="Drowzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Drowzee
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="Hypno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="View Hypno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" alt="Hypno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Hypno
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="Voltorb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="View Voltorb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" alt="Voltorb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Voltorb
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="Electrode">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="View Electrode on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" alt="Electrode" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Electrode
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Exeggcute
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Exeggutor
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Cubone
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Marowak
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Hitmonlee
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Hitmonchan
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Lickitung
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Koffing
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Weezing
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Rhyhorn
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Rhydon
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Chansey
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Tangela
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Kangaskhan
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Horsea
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Seadra
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Goldeen
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Seaking
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Staryu
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Starmie
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Mr. Mime
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Scyther
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="Jynx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="View Jynx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" alt="Jynx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Jynx
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="Electabuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="View Electabuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" alt="Electabuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Electabuzz
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="Magmar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="View Magmar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" alt="Magmar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Magmar
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Pinsir
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Tauros
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Magikarp
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Gyarados
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Lapras
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Ditto
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Eevee
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Vaporeon
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Jolteon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Flareon
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Porygon
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="Omanyte">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="View Omanyte on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" alt="Omanyte" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Omanyte
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="Omastar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="View Omastar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" alt="Omastar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Omastar
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="Kabuto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="View Kabuto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" alt="Kabuto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Kabuto
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="Kabutops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="View Kabutops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" alt="Kabutops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Kabutops
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="Aerodactyl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="View Aerodactyl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" alt="Aerodactyl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Aerodactyl
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Snorlax
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="Articuno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="View Articuno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" alt="Articuno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Articuno
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="Zapdos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="View Zapdos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" alt="Zapdos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Zapdos
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="Moltres">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="View Moltres on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" alt="Moltres" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Moltres
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="Dratini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="View Dratini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" alt="Dratini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Dratini
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="Dragonair">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="View Dragonair on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" alt="Dragonair" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Dragonair
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="Dragonite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="View Dragonite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" alt="Dragonite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Dragonite
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="Mewtwo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="View Mewtwo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" alt="Mewtwo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Mewtwo
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="Mew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="View Mew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" alt="Mew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Mew
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="Chikorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="View Chikorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" alt="Chikorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Chikorita
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="Bayleef">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="View Bayleef on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" alt="Bayleef" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Bayleef
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="Meganium">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="View Meganium on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" alt="Meganium" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Meganium
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="Cyndaquil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="View Cyndaquil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" alt="Cyndaquil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Cyndaquil
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="Quilava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="View Quilava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" alt="Quilava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Quilava
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="Typhlosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="View Typhlosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" alt="Typhlosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Typhlosion
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="Totodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="View Totodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" alt="Totodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Totodile
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="Croconaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="View Croconaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" alt="Croconaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Croconaw
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="Feraligatr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="View Feraligatr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" alt="Feraligatr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Feraligatr
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="Sentret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="View Sentret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" alt="Sentret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Sentret
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="Furret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="View Furret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" alt="Furret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Furret
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="Hoothoot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="View Hoothoot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" alt="Hoothoot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Hoothoot
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="Noctowl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="View Noctowl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" alt="Noctowl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Noctowl
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="Ledyba">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="View Ledyba on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" alt="Ledyba" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Ledyba
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="Ledian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="View Ledian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" alt="Ledian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Ledian
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="Spinarak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="View Spinarak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" alt="Spinarak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Spinarak
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="Ariados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="View Ariados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" alt="Ariados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Ariados
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="Crobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="View Crobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" alt="Crobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Crobat
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Chinchou
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Lanturn
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Pichu
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="Cleffa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="View Cleffa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" alt="Cleffa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Cleffa
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="Igglybuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="View Igglybuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" alt="Igglybuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Igglybuff
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="Togepi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="View Togepi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" alt="Togepi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Togepi
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="Togetic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="View Togetic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" alt="Togetic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Togetic
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="Natu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="View Natu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" alt="Natu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Natu
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="Xatu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="View Xatu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" alt="Xatu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Xatu
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="Mareep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="View Mareep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" alt="Mareep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Mareep
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="Flaaffy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="View Flaaffy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" alt="Flaaffy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Flaaffy
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="Ampharos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="View Ampharos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" alt="Ampharos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Ampharos
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="Bellossom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="View Bellossom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" alt="Bellossom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Bellossom
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="Marill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="View Marill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" alt="Marill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Marill
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="Azumarill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="View Azumarill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" alt="Azumarill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Azumarill
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="Sudowoodo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="View Sudowoodo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" alt="Sudowoodo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Sudowoodo
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="Politoed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="View Politoed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" alt="Politoed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Politoed
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="Hoppip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="View Hoppip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" alt="Hoppip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Hoppip
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="Skiploom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="View Skiploom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" alt="Skiploom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Skiploom
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="Jumpluff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="View Jumpluff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" alt="Jumpluff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Jumpluff
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="Aipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="View Aipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" alt="Aipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Aipom
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="Sunkern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="View Sunkern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" alt="Sunkern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Sunkern
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="Sunflora">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="View Sunflora on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" alt="Sunflora" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Sunflora
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="Yanma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="View Yanma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" alt="Yanma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Yanma
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Wooper
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Quagsire
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="Espeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="View Espeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" alt="Espeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Espeon
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="Umbreon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="View Umbreon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" alt="Umbreon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Umbreon
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="Murkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="View Murkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" alt="Murkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Murkrow
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="Slowking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="View Slowking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" alt="Slowking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Slowking
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="Misdreavus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="View Misdreavus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" alt="Misdreavus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Misdreavus
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="Unown">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="View Unown on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" alt="Unown" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Unown
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="Wobbuffet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="View Wobbuffet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" alt="Wobbuffet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Wobbuffet
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="Girafarig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="View Girafarig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" alt="Girafarig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Girafarig
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="Pineco">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="View Pineco on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" alt="Pineco" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Pineco
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="Forretress">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="View Forretress on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" alt="Forretress" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Forretress
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="Dunsparce">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="View Dunsparce on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" alt="Dunsparce" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Dunsparce
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="Gligar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="View Gligar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" alt="Gligar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Gligar
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="Steelix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="View Steelix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" alt="Steelix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Steelix
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="Snubbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="View Snubbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" alt="Snubbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Snubbull
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="Granbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="View Granbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" alt="Granbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Granbull
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="Qwilfish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="View Qwilfish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" alt="Qwilfish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Qwilfish
@@ -2184,8 +2184,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="Scizor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="View Scizor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" alt="Scizor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">212</span>
                             Scizor
@@ -2194,8 +2194,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="Shuckle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="View Shuckle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" alt="Shuckle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">213</span>
                             Shuckle
@@ -2204,8 +2204,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="Heracross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="View Heracross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" alt="Heracross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">214</span>
                             Heracross
@@ -2214,8 +2214,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="Sneasel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="View Sneasel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" alt="Sneasel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">215</span>
                             Sneasel
@@ -2224,8 +2224,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="Teddiursa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="View Teddiursa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" alt="Teddiursa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">216</span>
                             Teddiursa
@@ -2234,8 +2234,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="Ursaring">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="View Ursaring on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" alt="Ursaring" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">217</span>
                             Ursaring
@@ -2244,8 +2244,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="Slugma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="View Slugma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" alt="Slugma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">218</span>
                             Slugma
@@ -2254,8 +2254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="Magcargo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="View Magcargo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" alt="Magcargo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">219</span>
                             Magcargo
@@ -2264,8 +2264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="Swinub">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="View Swinub on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" alt="Swinub" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">220</span>
                             Swinub
@@ -2274,8 +2274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="Piloswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="View Piloswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" alt="Piloswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">221</span>
                             Piloswine
@@ -2284,8 +2284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="Corsola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="View Corsola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" alt="Corsola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">222</span>
                             Corsola
@@ -2294,8 +2294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">223</span>
                             Remoraid
@@ -2304,8 +2304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">224</span>
                             Octillery
@@ -2314,8 +2314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="Delibird">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="View Delibird on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" alt="Delibird" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">225</span>
                             Delibird
@@ -2324,8 +2324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">226</span>
                             Mantine
@@ -2334,8 +2334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="Skarmory">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="View Skarmory on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" alt="Skarmory" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">227</span>
                             Skarmory
@@ -2344,8 +2344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="Houndour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="View Houndour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" alt="Houndour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">228</span>
                             Houndour
@@ -2354,8 +2354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="Houndoom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="View Houndoom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" alt="Houndoom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">229</span>
                             Houndoom
@@ -2364,8 +2364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="Kingdra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="View Kingdra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" alt="Kingdra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">230</span>
                             Kingdra
@@ -2374,8 +2374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="Phanpy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="View Phanpy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" alt="Phanpy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">231</span>
                             Phanpy
@@ -2384,8 +2384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="Donphan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="View Donphan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" alt="Donphan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">232</span>
                             Donphan
@@ -2394,8 +2394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="Porygon2">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="View Porygon2 on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" alt="Porygon2" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">233</span>
                             Porygon2
@@ -2404,8 +2404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="Stantler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="View Stantler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" alt="Stantler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">234</span>
                             Stantler
@@ -2414,8 +2414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="Smeargle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="View Smeargle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" alt="Smeargle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">235</span>
                             Smeargle
@@ -2424,8 +2424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="Tyrogue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="View Tyrogue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" alt="Tyrogue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">236</span>
                             Tyrogue
@@ -2434,8 +2434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="Hitmontop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="View Hitmontop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" alt="Hitmontop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">237</span>
                             Hitmontop
@@ -2444,8 +2444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="Smoochum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="View Smoochum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" alt="Smoochum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">238</span>
                             Smoochum
@@ -2454,8 +2454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="Elekid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="View Elekid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" alt="Elekid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">239</span>
                             Elekid
@@ -2464,8 +2464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="Magby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="View Magby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" alt="Magby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">240</span>
                             Magby
@@ -2481,8 +2481,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="Miltank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="View Miltank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" alt="Miltank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">241</span>
                             Miltank
@@ -2491,8 +2491,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="Blissey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="View Blissey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" alt="Blissey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">242</span>
                             Blissey
@@ -2501,8 +2501,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="Raikou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="View Raikou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" alt="Raikou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">243</span>
                             Raikou
@@ -2511,8 +2511,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="Entei">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="View Entei on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" alt="Entei" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">244</span>
                             Entei
@@ -2521,8 +2521,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="Suicune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="View Suicune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" alt="Suicune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">245</span>
                             Suicune
@@ -2531,8 +2531,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="Larvitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="View Larvitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" alt="Larvitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">246</span>
                             Larvitar
@@ -2541,8 +2541,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="Pupitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="View Pupitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" alt="Pupitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">247</span>
                             Pupitar
@@ -2551,8 +2551,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="Tyranitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="View Tyranitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" alt="Tyranitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">248</span>
                             Tyranitar
@@ -2561,8 +2561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="Lugia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="View Lugia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" alt="Lugia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">249</span>
                             Lugia
@@ -2571,8 +2571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="Ho-Oh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="View Ho-Oh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" alt="Ho-Oh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">250</span>
                             Ho-Oh
@@ -2581,8 +2581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="Celebi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="View Celebi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" alt="Celebi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">251</span>
                             Celebi
@@ -2591,8 +2591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="Treecko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="View Treecko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" alt="Treecko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">252</span>
                             Treecko
@@ -2601,8 +2601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="Grovyle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="View Grovyle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" alt="Grovyle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">253</span>
                             Grovyle
@@ -2611,8 +2611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="Sceptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="View Sceptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" alt="Sceptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">254</span>
                             Sceptile
@@ -2621,8 +2621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="Torchic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="View Torchic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" alt="Torchic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">255</span>
                             Torchic
@@ -2631,8 +2631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="Combusken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="View Combusken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" alt="Combusken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">256</span>
                             Combusken
@@ -2641,8 +2641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="Blaziken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="View Blaziken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" alt="Blaziken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">257</span>
                             Blaziken
@@ -2651,8 +2651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="Mudkip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="View Mudkip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" alt="Mudkip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">258</span>
                             Mudkip
@@ -2661,8 +2661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="Marshtomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="View Marshtomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" alt="Marshtomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">259</span>
                             Marshtomp
@@ -2671,8 +2671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="Swampert">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="View Swampert on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" alt="Swampert" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">260</span>
                             Swampert
@@ -2681,8 +2681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="Poochyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="View Poochyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" alt="Poochyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">261</span>
                             Poochyena
@@ -2691,8 +2691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="Mightyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="View Mightyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" alt="Mightyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">262</span>
                             Mightyena
@@ -2701,8 +2701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="Zigzagoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="View Zigzagoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" alt="Zigzagoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">263</span>
                             Zigzagoon
@@ -2711,8 +2711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="Linoone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="View Linoone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" alt="Linoone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">264</span>
                             Linoone
@@ -2721,8 +2721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="Wurmple">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="View Wurmple on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" alt="Wurmple" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">265</span>
                             Wurmple
@@ -2731,8 +2731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="Silcoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="View Silcoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" alt="Silcoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">266</span>
                             Silcoon
@@ -2741,8 +2741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="Beautifly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="View Beautifly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" alt="Beautifly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">267</span>
                             Beautifly
@@ -2751,8 +2751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="Cascoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="View Cascoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" alt="Cascoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">268</span>
                             Cascoon
@@ -2761,8 +2761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="Dustox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="View Dustox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" alt="Dustox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">269</span>
                             Dustox
@@ -2771,8 +2771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="Lotad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="View Lotad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" alt="Lotad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">270</span>
                             Lotad
@@ -2788,8 +2788,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="Lombre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="View Lombre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" alt="Lombre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">271</span>
                             Lombre
@@ -2798,8 +2798,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="Ludicolo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="View Ludicolo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" alt="Ludicolo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">272</span>
                             Ludicolo
@@ -2808,8 +2808,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="Seedot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="View Seedot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" alt="Seedot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">273</span>
                             Seedot
@@ -2818,8 +2818,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="Nuzleaf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="View Nuzleaf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" alt="Nuzleaf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">274</span>
                             Nuzleaf
@@ -2828,8 +2828,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="Shiftry">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="View Shiftry on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" alt="Shiftry" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">275</span>
                             Shiftry
@@ -2838,8 +2838,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="Taillow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="View Taillow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" alt="Taillow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">276</span>
                             Taillow
@@ -2848,8 +2848,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="Swellow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="View Swellow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" alt="Swellow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">277</span>
                             Swellow
@@ -2858,8 +2858,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="Wingull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="View Wingull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" alt="Wingull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">278</span>
                             Wingull
@@ -2868,8 +2868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="Pelipper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="View Pelipper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" alt="Pelipper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">279</span>
                             Pelipper
@@ -2878,8 +2878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="Ralts">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="View Ralts on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" alt="Ralts" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">280</span>
                             Ralts
@@ -2888,8 +2888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="Kirlia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="View Kirlia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" alt="Kirlia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">281</span>
                             Kirlia
@@ -2898,8 +2898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="Gardevoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="View Gardevoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" alt="Gardevoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">282</span>
                             Gardevoir
@@ -2908,8 +2908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="Surskit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="View Surskit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" alt="Surskit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">283</span>
                             Surskit
@@ -2918,8 +2918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="Masquerain">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="View Masquerain on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" alt="Masquerain" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">284</span>
                             Masquerain
@@ -2928,8 +2928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="Shroomish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="View Shroomish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" alt="Shroomish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">285</span>
                             Shroomish
@@ -2938,8 +2938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="Breloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="View Breloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" alt="Breloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">286</span>
                             Breloom
@@ -2948,8 +2948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="Slakoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="View Slakoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" alt="Slakoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">287</span>
                             Slakoth
@@ -2958,8 +2958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="Vigoroth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="View Vigoroth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" alt="Vigoroth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">288</span>
                             Vigoroth
@@ -2968,8 +2968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="Slaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="View Slaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" alt="Slaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">289</span>
                             Slaking
@@ -2978,8 +2978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="Nincada">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="View Nincada on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" alt="Nincada" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">290</span>
                             Nincada
@@ -2988,8 +2988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="Ninjask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="View Ninjask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" alt="Ninjask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">291</span>
                             Ninjask
@@ -2998,8 +2998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="Shedinja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="View Shedinja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" alt="Shedinja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">292</span>
                             Shedinja
@@ -3008,8 +3008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="Whismur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="View Whismur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" alt="Whismur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">293</span>
                             Whismur
@@ -3018,8 +3018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="Loudred">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="View Loudred on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" alt="Loudred" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">294</span>
                             Loudred
@@ -3028,8 +3028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="Exploud">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="View Exploud on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" alt="Exploud" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">295</span>
                             Exploud
@@ -3038,8 +3038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="Makuhita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="View Makuhita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" alt="Makuhita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">296</span>
                             Makuhita
@@ -3048,8 +3048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="Hariyama">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="View Hariyama on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" alt="Hariyama" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">297</span>
                             Hariyama
@@ -3058,8 +3058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="Azurill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="View Azurill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" alt="Azurill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">298</span>
                             Azurill
@@ -3068,8 +3068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="Nosepass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="View Nosepass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" alt="Nosepass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">299</span>
                             Nosepass
@@ -3078,8 +3078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="Skitty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="View Skitty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" alt="Skitty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">300</span>
                             Skitty
@@ -3095,8 +3095,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="Delcatty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="View Delcatty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" alt="Delcatty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">301</span>
                             Delcatty
@@ -3105,8 +3105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="Sableye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="View Sableye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" alt="Sableye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">302</span>
                             Sableye
@@ -3115,8 +3115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="Mawile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="View Mawile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" alt="Mawile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">303</span>
                             Mawile
@@ -3125,8 +3125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="Aron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="View Aron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" alt="Aron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">304</span>
                             Aron
@@ -3135,8 +3135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="Lairon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="View Lairon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" alt="Lairon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">305</span>
                             Lairon
@@ -3145,8 +3145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="Aggron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="View Aggron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" alt="Aggron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">306</span>
                             Aggron
@@ -3155,8 +3155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="Meditite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="View Meditite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" alt="Meditite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">307</span>
                             Meditite
@@ -3165,8 +3165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="Medicham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="View Medicham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" alt="Medicham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">308</span>
                             Medicham
@@ -3175,8 +3175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="Electrike">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="View Electrike on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" alt="Electrike" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">309</span>
                             Electrike
@@ -3185,8 +3185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="Manectric">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="View Manectric on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" alt="Manectric" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">310</span>
                             Manectric
@@ -3195,8 +3195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="Plusle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="View Plusle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" alt="Plusle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">311</span>
                             Plusle
@@ -3205,8 +3205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="Minun">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="View Minun on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" alt="Minun" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">312</span>
                             Minun
@@ -3215,8 +3215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="Volbeat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="View Volbeat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" alt="Volbeat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">313</span>
                             Volbeat
@@ -3225,8 +3225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="Illumise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="View Illumise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" alt="Illumise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">314</span>
                             Illumise
@@ -3235,8 +3235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="Roselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="View Roselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" alt="Roselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">315</span>
                             Roselia
@@ -3245,8 +3245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="Gulpin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="View Gulpin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" alt="Gulpin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">316</span>
                             Gulpin
@@ -3255,8 +3255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="Swalot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="View Swalot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" alt="Swalot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">317</span>
                             Swalot
@@ -3265,8 +3265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="Carvanha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="View Carvanha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" alt="Carvanha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">318</span>
                             Carvanha
@@ -3275,8 +3275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="Sharpedo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="View Sharpedo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" alt="Sharpedo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">319</span>
                             Sharpedo
@@ -3285,8 +3285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="Wailmer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="View Wailmer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" alt="Wailmer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">320</span>
                             Wailmer
@@ -3295,8 +3295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="Wailord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="View Wailord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" alt="Wailord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">321</span>
                             Wailord
@@ -3305,8 +3305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="Numel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="View Numel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" alt="Numel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">322</span>
                             Numel
@@ -3315,8 +3315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="Camerupt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="View Camerupt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" alt="Camerupt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">323</span>
                             Camerupt
@@ -3325,8 +3325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="Torkoal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="View Torkoal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" alt="Torkoal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">324</span>
                             Torkoal
@@ -3335,8 +3335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="Spoink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="View Spoink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" alt="Spoink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">325</span>
                             Spoink
@@ -3345,8 +3345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="Grumpig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="View Grumpig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" alt="Grumpig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">326</span>
                             Grumpig
@@ -3355,8 +3355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="Spinda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="View Spinda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" alt="Spinda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">327</span>
                             Spinda
@@ -3365,8 +3365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="Trapinch">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="View Trapinch on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" alt="Trapinch" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">328</span>
                             Trapinch
@@ -3375,8 +3375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="Vibrava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="View Vibrava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" alt="Vibrava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">329</span>
                             Vibrava
@@ -3385,8 +3385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="Flygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="View Flygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" alt="Flygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">330</span>
                             Flygon
@@ -3402,8 +3402,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="Cacnea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="View Cacnea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" alt="Cacnea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">331</span>
                             Cacnea
@@ -3412,8 +3412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="Cacturne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="View Cacturne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" alt="Cacturne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">332</span>
                             Cacturne
@@ -3422,8 +3422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="Swablu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="View Swablu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" alt="Swablu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">333</span>
                             Swablu
@@ -3432,8 +3432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="Altaria">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="View Altaria on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" alt="Altaria" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">334</span>
                             Altaria
@@ -3442,8 +3442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="Zangoose">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="View Zangoose on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" alt="Zangoose" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">335</span>
                             Zangoose
@@ -3452,8 +3452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="Seviper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="View Seviper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" alt="Seviper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">336</span>
                             Seviper
@@ -3462,8 +3462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="Lunatone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="View Lunatone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" alt="Lunatone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">337</span>
                             Lunatone
@@ -3472,8 +3472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="Solrock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="View Solrock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" alt="Solrock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">338</span>
                             Solrock
@@ -3482,8 +3482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="Barboach">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="View Barboach on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" alt="Barboach" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">339</span>
                             Barboach
@@ -3492,8 +3492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="Whiscash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="View Whiscash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" alt="Whiscash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">340</span>
                             Whiscash
@@ -3502,8 +3502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="Corphish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="View Corphish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" alt="Corphish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">341</span>
                             Corphish
@@ -3512,8 +3512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="Crawdaunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="View Crawdaunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" alt="Crawdaunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">342</span>
                             Crawdaunt
@@ -3522,8 +3522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="Baltoy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="View Baltoy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" alt="Baltoy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">343</span>
                             Baltoy
@@ -3532,8 +3532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="Claydol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="View Claydol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" alt="Claydol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">344</span>
                             Claydol
@@ -3542,8 +3542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="Lileep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="View Lileep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" alt="Lileep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">345</span>
                             Lileep
@@ -3552,8 +3552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="Cradily">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="View Cradily on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" alt="Cradily" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">346</span>
                             Cradily
@@ -3562,8 +3562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="Anorith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="View Anorith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" alt="Anorith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">347</span>
                             Anorith
@@ -3572,8 +3572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="Armaldo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="View Armaldo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" alt="Armaldo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">348</span>
                             Armaldo
@@ -3582,8 +3582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="Feebas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="View Feebas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" alt="Feebas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">349</span>
                             Feebas
@@ -3592,8 +3592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="Milotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="View Milotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" alt="Milotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">350</span>
                             Milotic
@@ -3602,8 +3602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="Castform">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="View Castform on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" alt="Castform" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">351</span>
                             Castform
@@ -3612,8 +3612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="Kecleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="View Kecleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" alt="Kecleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">352</span>
                             Kecleon
@@ -3622,8 +3622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="Shuppet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="View Shuppet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" alt="Shuppet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">353</span>
                             Shuppet
@@ -3632,8 +3632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="Banette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="View Banette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" alt="Banette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">354</span>
                             Banette
@@ -3642,8 +3642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="Duskull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="View Duskull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" alt="Duskull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">355</span>
                             Duskull
@@ -3652,8 +3652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="Dusclops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="View Dusclops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" alt="Dusclops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">356</span>
                             Dusclops
@@ -3662,8 +3662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="Tropius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="View Tropius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" alt="Tropius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">357</span>
                             Tropius
@@ -3672,8 +3672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="Chimecho">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="View Chimecho on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" alt="Chimecho" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">358</span>
                             Chimecho
@@ -3682,8 +3682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="Absol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="View Absol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" alt="Absol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">359</span>
                             Absol
@@ -3692,8 +3692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="Wynaut">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="View Wynaut on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" alt="Wynaut" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">360</span>
                             Wynaut
@@ -3709,8 +3709,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="Snorunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="View Snorunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" alt="Snorunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">361</span>
                             Snorunt
@@ -3719,8 +3719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="Glalie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="View Glalie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" alt="Glalie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">362</span>
                             Glalie
@@ -3729,8 +3729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="Spheal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="View Spheal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" alt="Spheal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">363</span>
                             Spheal
@@ -3739,8 +3739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="Sealeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="View Sealeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" alt="Sealeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">364</span>
                             Sealeo
@@ -3749,8 +3749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="Walrein">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="View Walrein on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" alt="Walrein" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">365</span>
                             Walrein
@@ -3759,8 +3759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="Clamperl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="View Clamperl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" alt="Clamperl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">366</span>
                             Clamperl
@@ -3769,8 +3769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="Huntail">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="View Huntail on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" alt="Huntail" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">367</span>
                             Huntail
@@ -3779,8 +3779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="Gorebyss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="View Gorebyss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" alt="Gorebyss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">368</span>
                             Gorebyss
@@ -3789,8 +3789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="Relicanth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="View Relicanth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" alt="Relicanth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">369</span>
                             Relicanth
@@ -3799,8 +3799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="Luvdisc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="View Luvdisc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" alt="Luvdisc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">370</span>
                             Luvdisc
@@ -3809,8 +3809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="Bagon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="View Bagon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" alt="Bagon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">371</span>
                             Bagon
@@ -3819,8 +3819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="Shelgon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="View Shelgon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" alt="Shelgon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">372</span>
                             Shelgon
@@ -3829,8 +3829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="Salamence">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="View Salamence on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" alt="Salamence" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">373</span>
                             Salamence
@@ -3839,8 +3839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="Beldum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="View Beldum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" alt="Beldum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">374</span>
                             Beldum
@@ -3849,8 +3849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="Metang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="View Metang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" alt="Metang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">375</span>
                             Metang
@@ -3859,8 +3859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="Metagross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="View Metagross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" alt="Metagross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">376</span>
                             Metagross
@@ -3869,8 +3869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="Regirock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="View Regirock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" alt="Regirock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">377</span>
                             Regirock
@@ -3879,8 +3879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="Regice">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="View Regice on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" alt="Regice" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">378</span>
                             Regice
@@ -3889,8 +3889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="Registeel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="View Registeel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" alt="Registeel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">379</span>
                             Registeel
@@ -3899,8 +3899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="Latias">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="View Latias on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" alt="Latias" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">380</span>
                             Latias
@@ -3909,8 +3909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="Latios">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="View Latios on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" alt="Latios" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">381</span>
                             Latios
@@ -3919,8 +3919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="Kyogre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="View Kyogre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" alt="Kyogre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">382</span>
                             Kyogre
@@ -3929,8 +3929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="Groudon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="View Groudon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" alt="Groudon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">383</span>
                             Groudon
@@ -3939,8 +3939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="Rayquaza">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="View Rayquaza on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" alt="Rayquaza" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">384</span>
                             Rayquaza
@@ -3949,8 +3949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="Jirachi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="View Jirachi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" alt="Jirachi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">385</span>
                             Jirachi
@@ -3959,8 +3959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="Deoxys">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="View Deoxys on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" alt="Deoxys" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">386</span>
                             Deoxys
@@ -3969,8 +3969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="Turtwig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="View Turtwig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" alt="Turtwig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">387</span>
                             Turtwig
@@ -3979,8 +3979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="Grotle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="View Grotle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" alt="Grotle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">388</span>
                             Grotle
@@ -3989,8 +3989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="Torterra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="View Torterra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" alt="Torterra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">389</span>
                             Torterra
@@ -3999,8 +3999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="Chimchar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="View Chimchar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" alt="Chimchar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">390</span>
                             Chimchar
@@ -4016,8 +4016,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="Monferno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="View Monferno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" alt="Monferno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">391</span>
                             Monferno
@@ -4026,8 +4026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="Infernape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="View Infernape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" alt="Infernape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">392</span>
                             Infernape
@@ -4036,8 +4036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="Piplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="View Piplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" alt="Piplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">393</span>
                             Piplup
@@ -4046,8 +4046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="Prinplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="View Prinplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" alt="Prinplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">394</span>
                             Prinplup
@@ -4056,8 +4056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="Empoleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="View Empoleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" alt="Empoleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">395</span>
                             Empoleon
@@ -4066,8 +4066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="Starly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="View Starly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" alt="Starly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">396</span>
                             Starly
@@ -4076,8 +4076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="Staravia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="View Staravia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" alt="Staravia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">397</span>
                             Staravia
@@ -4086,8 +4086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="Staraptor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="View Staraptor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" alt="Staraptor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">398</span>
                             Staraptor
@@ -4096,8 +4096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="Bidoof">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="View Bidoof on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" alt="Bidoof" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">399</span>
                             Bidoof
@@ -4106,8 +4106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="Bibarel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="View Bibarel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" alt="Bibarel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">400</span>
                             Bibarel
@@ -4116,8 +4116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="Kricketot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="View Kricketot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" alt="Kricketot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">401</span>
                             Kricketot
@@ -4126,8 +4126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="Kricketune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="View Kricketune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" alt="Kricketune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">402</span>
                             Kricketune
@@ -4136,8 +4136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="Shinx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="View Shinx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" alt="Shinx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">403</span>
                             Shinx
@@ -4146,8 +4146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="Luxio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="View Luxio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" alt="Luxio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">404</span>
                             Luxio
@@ -4156,8 +4156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="Luxray">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="View Luxray on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" alt="Luxray" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">405</span>
                             Luxray
@@ -4166,8 +4166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="Budew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="View Budew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" alt="Budew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">406</span>
                             Budew
@@ -4176,8 +4176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="Roserade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="View Roserade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" alt="Roserade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">407</span>
                             Roserade
@@ -4186,8 +4186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="Cranidos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="View Cranidos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" alt="Cranidos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">408</span>
                             Cranidos
@@ -4196,8 +4196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="Rampardos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="View Rampardos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" alt="Rampardos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">409</span>
                             Rampardos
@@ -4206,8 +4206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="Shieldon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="View Shieldon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" alt="Shieldon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">410</span>
                             Shieldon
@@ -4216,8 +4216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="Bastiodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="View Bastiodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" alt="Bastiodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">411</span>
                             Bastiodon
@@ -4226,8 +4226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="Burmy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="View Burmy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" alt="Burmy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">412</span>
                             Burmy
@@ -4236,8 +4236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="Wormadam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="View Wormadam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" alt="Wormadam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">413</span>
                             Wormadam
@@ -4246,8 +4246,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="Mothim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="View Mothim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" alt="Mothim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">414</span>
                             Mothim
@@ -4256,8 +4256,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="Combee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="View Combee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" alt="Combee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">415</span>
                             Combee
@@ -4266,8 +4266,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="Vespiquen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="View Vespiquen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" alt="Vespiquen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">416</span>
                             Vespiquen
@@ -4276,8 +4276,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="Pachirisu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="View Pachirisu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" alt="Pachirisu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">417</span>
                             Pachirisu
@@ -4286,8 +4286,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="Buizel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="View Buizel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" alt="Buizel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">418</span>
                             Buizel
@@ -4296,8 +4296,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="Floatzel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="View Floatzel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" alt="Floatzel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">419</span>
                             Floatzel
@@ -4306,8 +4306,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="Cherubi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="View Cherubi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" alt="Cherubi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">420</span>
                             Cherubi
@@ -4323,8 +4323,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="Cherrim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="View Cherrim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" alt="Cherrim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">421</span>
                             Cherrim
@@ -4333,8 +4333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="Shellos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="View Shellos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" alt="Shellos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">422</span>
                             Shellos
@@ -4343,8 +4343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="Gastrodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="View Gastrodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" alt="Gastrodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">423</span>
                             Gastrodon
@@ -4353,8 +4353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="Ambipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="View Ambipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" alt="Ambipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">424</span>
                             Ambipom
@@ -4363,8 +4363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="Drifloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="View Drifloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" alt="Drifloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">425</span>
                             Drifloon
@@ -4373,8 +4373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="Drifblim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="View Drifblim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" alt="Drifblim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">426</span>
                             Drifblim
@@ -4383,8 +4383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="Buneary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="View Buneary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" alt="Buneary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">427</span>
                             Buneary
@@ -4393,8 +4393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="Lopunny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="View Lopunny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" alt="Lopunny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">428</span>
                             Lopunny
@@ -4403,8 +4403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="Mismagius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="View Mismagius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" alt="Mismagius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">429</span>
                             Mismagius
@@ -4413,8 +4413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="Honchkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="View Honchkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" alt="Honchkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">430</span>
                             Honchkrow
@@ -4423,8 +4423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="Glameow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="View Glameow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" alt="Glameow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">431</span>
                             Glameow
@@ -4433,8 +4433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="Purugly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="View Purugly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" alt="Purugly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">432</span>
                             Purugly
@@ -4443,8 +4443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="Chingling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="View Chingling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" alt="Chingling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">433</span>
                             Chingling
@@ -4453,8 +4453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="Stunky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="View Stunky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" alt="Stunky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">434</span>
                             Stunky
@@ -4463,8 +4463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="Skuntank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="View Skuntank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" alt="Skuntank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">435</span>
                             Skuntank
@@ -4473,8 +4473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="Bronzor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="View Bronzor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" alt="Bronzor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">436</span>
                             Bronzor
@@ -4483,8 +4483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="Bronzong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="View Bronzong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" alt="Bronzong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">437</span>
                             Bronzong
@@ -4493,8 +4493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="Bonsly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="View Bonsly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" alt="Bonsly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">438</span>
                             Bonsly
@@ -4503,8 +4503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="Mime Jr.">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="View Mime Jr. on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" alt="Mime Jr." loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">439</span>
                             Mime Jr.
@@ -4513,8 +4513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="Happiny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="View Happiny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" alt="Happiny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">440</span>
                             Happiny
@@ -4523,8 +4523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="Chatot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="View Chatot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" alt="Chatot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">441</span>
                             Chatot
@@ -4533,8 +4533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="Spiritomb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="View Spiritomb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" alt="Spiritomb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">442</span>
                             Spiritomb
@@ -4543,8 +4543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="Gible">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="View Gible on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" alt="Gible" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">443</span>
                             Gible
@@ -4553,8 +4553,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="Gabite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="View Gabite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" alt="Gabite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">444</span>
                             Gabite
@@ -4563,8 +4563,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="Garchomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="View Garchomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" alt="Garchomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">445</span>
                             Garchomp
@@ -4573,8 +4573,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="Munchlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="View Munchlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" alt="Munchlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">446</span>
                             Munchlax
@@ -4583,8 +4583,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="Riolu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="View Riolu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" alt="Riolu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">447</span>
                             Riolu
@@ -4593,8 +4593,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="Lucario">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="View Lucario on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" alt="Lucario" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">448</span>
                             Lucario
@@ -4603,8 +4603,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="Hippopotas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="View Hippopotas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" alt="Hippopotas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">449</span>
                             Hippopotas
@@ -4613,8 +4613,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="Hippowdon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="View Hippowdon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" alt="Hippowdon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">450</span>
                             Hippowdon
@@ -4630,8 +4630,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="Skorupi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="View Skorupi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" alt="Skorupi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">451</span>
                             Skorupi
@@ -4640,8 +4640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="Drapion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="View Drapion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" alt="Drapion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">452</span>
                             Drapion
@@ -4650,8 +4650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="Croagunk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="View Croagunk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" alt="Croagunk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">453</span>
                             Croagunk
@@ -4660,8 +4660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="Toxicroak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="View Toxicroak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" alt="Toxicroak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">454</span>
                             Toxicroak
@@ -4670,8 +4670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="Carnivine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="View Carnivine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" alt="Carnivine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">455</span>
                             Carnivine
@@ -4680,8 +4680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="Finneon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="View Finneon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" alt="Finneon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">456</span>
                             Finneon
@@ -4690,8 +4690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="Lumineon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="View Lumineon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" alt="Lumineon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">457</span>
                             Lumineon
@@ -4700,8 +4700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="Mantyke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="View Mantyke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" alt="Mantyke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">458</span>
                             Mantyke
@@ -4710,8 +4710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="Snover">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="View Snover on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" alt="Snover" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">459</span>
                             Snover
@@ -4720,8 +4720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="Abomasnow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="View Abomasnow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" alt="Abomasnow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">460</span>
                             Abomasnow
@@ -4730,8 +4730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="Weavile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="View Weavile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" alt="Weavile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">461</span>
                             Weavile
@@ -4740,8 +4740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="Magnezone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="View Magnezone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" alt="Magnezone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">462</span>
                             Magnezone
@@ -4750,8 +4750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="Lickilicky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="View Lickilicky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" alt="Lickilicky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">463</span>
                             Lickilicky
@@ -4760,8 +4760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="Rhyperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="View Rhyperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" alt="Rhyperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">464</span>
                             Rhyperior
@@ -4770,8 +4770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="Tangrowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="View Tangrowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" alt="Tangrowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">465</span>
                             Tangrowth
@@ -4780,8 +4780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="Electivire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="View Electivire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" alt="Electivire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">466</span>
                             Electivire
@@ -4790,8 +4790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="Magmortar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="View Magmortar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" alt="Magmortar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">467</span>
                             Magmortar
@@ -4800,8 +4800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="Togekiss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="View Togekiss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" alt="Togekiss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">468</span>
                             Togekiss
@@ -4810,8 +4810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="Yanmega">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="View Yanmega on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" alt="Yanmega" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">469</span>
                             Yanmega
@@ -4820,8 +4820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="Leafeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="View Leafeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" alt="Leafeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">470</span>
                             Leafeon
@@ -4830,8 +4830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="Glaceon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="View Glaceon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" alt="Glaceon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">471</span>
                             Glaceon
@@ -4840,8 +4840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="Gliscor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="View Gliscor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" alt="Gliscor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">472</span>
                             Gliscor
@@ -4850,8 +4850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="Mamoswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="View Mamoswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" alt="Mamoswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">473</span>
                             Mamoswine
@@ -4860,8 +4860,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="Porygon-Z">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="View Porygon-Z on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" alt="Porygon-Z" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">474</span>
                             Porygon-Z
@@ -4870,8 +4870,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="Gallade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="View Gallade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" alt="Gallade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">475</span>
                             Gallade
@@ -4880,8 +4880,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="Probopass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="View Probopass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" alt="Probopass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">476</span>
                             Probopass
@@ -4890,8 +4890,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="Dusknoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="View Dusknoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" alt="Dusknoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">477</span>
                             Dusknoir
@@ -4900,8 +4900,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="Froslass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="View Froslass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" alt="Froslass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">478</span>
                             Froslass
@@ -4910,8 +4910,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="Rotom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="View Rotom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" alt="Rotom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">479</span>
                             Rotom
@@ -4920,8 +4920,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="Uxie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="View Uxie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" alt="Uxie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">480</span>
                             Uxie
@@ -4937,8 +4937,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="Mesprit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="View Mesprit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" alt="Mesprit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">481</span>
                             Mesprit
@@ -4947,8 +4947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="Azelf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="View Azelf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" alt="Azelf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">482</span>
                             Azelf
@@ -4957,8 +4957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="Dialga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="View Dialga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" alt="Dialga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">483</span>
                             Dialga
@@ -4967,8 +4967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="Palkia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="View Palkia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" alt="Palkia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">484</span>
                             Palkia
@@ -4977,8 +4977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="Heatran">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="View Heatran on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" alt="Heatran" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">485</span>
                             Heatran
@@ -4987,8 +4987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="Regigigas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="View Regigigas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" alt="Regigigas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">486</span>
                             Regigigas
@@ -4997,8 +4997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="Giratina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="View Giratina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" alt="Giratina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">487</span>
                             Giratina
@@ -5007,8 +5007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="Cresselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="View Cresselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" alt="Cresselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">488</span>
                             Cresselia
@@ -5017,8 +5017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="Phione">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="View Phione on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" alt="Phione" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">489</span>
                             Phione
@@ -5027,8 +5027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="Manaphy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="View Manaphy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" alt="Manaphy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">490</span>
                             Manaphy
@@ -5037,8 +5037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darkrai/" title="Darkrai">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/491.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darkrai/" title="View Darkrai on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/491.png" alt="Darkrai" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">491</span>
                             Darkrai
@@ -5047,8 +5047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shaymin/" title="Shaymin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/492.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shaymin/" title="View Shaymin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/492.png" alt="Shaymin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">492</span>
                             Shaymin
@@ -5057,8 +5057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arceus/" title="Arceus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/493.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arceus/" title="View Arceus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/493.png" alt="Arceus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">493</span>
                             Arceus
@@ -5067,8 +5067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victini/" title="Victini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/494.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victini/" title="View Victini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/494.png" alt="Victini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">494</span>
                             Victini
@@ -5077,8 +5077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snivy/" title="Snivy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/495.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snivy/" title="View Snivy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/495.png" alt="Snivy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">495</span>
                             Snivy
@@ -5087,8 +5087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/servine/" title="Servine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/496.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/servine/" title="View Servine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/496.png" alt="Servine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">496</span>
                             Servine
@@ -5097,8 +5097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/serperior/" title="Serperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/497.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/serperior/" title="View Serperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/497.png" alt="Serperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">497</span>
                             Serperior
@@ -5107,8 +5107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tepig/" title="Tepig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/498.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tepig/" title="View Tepig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/498.png" alt="Tepig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">498</span>
                             Tepig
@@ -5117,8 +5117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pignite/" title="Pignite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/499.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pignite/" title="View Pignite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/499.png" alt="Pignite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">499</span>
                             Pignite
@@ -5127,8 +5127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/emboar/" title="Emboar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/500.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/emboar/" title="View Emboar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/500.png" alt="Emboar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">500</span>
                             Emboar
@@ -5137,8 +5137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oshawott/" title="Oshawott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/501.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oshawott/" title="View Oshawott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/501.png" alt="Oshawott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">501</span>
                             Oshawott
@@ -5147,8 +5147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewott/" title="Dewott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/502.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewott/" title="View Dewott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/502.png" alt="Dewott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">502</span>
                             Dewott
@@ -5157,8 +5157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/samurott/" title="Samurott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/503.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/samurott/" title="View Samurott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/503.png" alt="Samurott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">503</span>
                             Samurott
@@ -5167,8 +5167,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/patrat/" title="Patrat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/504.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/patrat/" title="View Patrat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/504.png" alt="Patrat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">504</span>
                             Patrat
@@ -5177,8 +5177,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/watchog/" title="Watchog">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/505.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/watchog/" title="View Watchog on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/505.png" alt="Watchog" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">505</span>
                             Watchog
@@ -5187,8 +5187,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="Lillipup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="View Lillipup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" alt="Lillipup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">506</span>
                             Lillipup
@@ -5197,8 +5197,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="Herdier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="View Herdier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" alt="Herdier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">507</span>
                             Herdier
@@ -5207,8 +5207,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="Stoutland">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="View Stoutland on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" alt="Stoutland" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">508</span>
                             Stoutland
@@ -5217,8 +5217,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="Purrloin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="View Purrloin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" alt="Purrloin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">509</span>
                             Purrloin
@@ -5227,8 +5227,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="Liepard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="View Liepard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" alt="Liepard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">510</span>
                             Liepard
@@ -5244,8 +5244,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pansage/" title="Pansage">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/511.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pansage/" title="View Pansage on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/511.png" alt="Pansage" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">511</span>
                             Pansage
@@ -5254,8 +5254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simisage/" title="Simisage">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/512.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simisage/" title="View Simisage on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/512.png" alt="Simisage" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">512</span>
                             Simisage
@@ -5264,8 +5264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pansear/" title="Pansear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/513.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pansear/" title="View Pansear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/513.png" alt="Pansear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">513</span>
                             Pansear
@@ -5274,8 +5274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simisear/" title="Simisear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/514.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simisear/" title="View Simisear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/514.png" alt="Simisear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">514</span>
                             Simisear
@@ -5284,8 +5284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/panpour/" title="Panpour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/515.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/panpour/" title="View Panpour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/515.png" alt="Panpour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">515</span>
                             Panpour
@@ -5294,8 +5294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simipour/" title="Simipour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/516.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simipour/" title="View Simipour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/516.png" alt="Simipour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">516</span>
                             Simipour
@@ -5304,8 +5304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="Munna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="View Munna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" alt="Munna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">517</span>
                             Munna
@@ -5314,8 +5314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="Musharna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="View Musharna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" alt="Musharna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">518</span>
                             Musharna
@@ -5324,8 +5324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="Pidove">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="View Pidove on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" alt="Pidove" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">519</span>
                             Pidove
@@ -5334,8 +5334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="Tranquill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="View Tranquill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" alt="Tranquill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">520</span>
                             Tranquill
@@ -5344,8 +5344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="Unfezant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="View Unfezant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" alt="Unfezant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">521</span>
                             Unfezant
@@ -5354,8 +5354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blitzle/" title="Blitzle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/522.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blitzle/" title="View Blitzle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/522.png" alt="Blitzle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">522</span>
                             Blitzle
@@ -5364,8 +5364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zebstrika/" title="Zebstrika">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/523.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zebstrika/" title="View Zebstrika on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/523.png" alt="Zebstrika" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">523</span>
                             Zebstrika
@@ -5374,8 +5374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="Roggenrola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="View Roggenrola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" alt="Roggenrola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">524</span>
                             Roggenrola
@@ -5384,8 +5384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="Boldore">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="View Boldore on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" alt="Boldore" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">525</span>
                             Boldore
@@ -5394,8 +5394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="Gigalith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="View Gigalith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" alt="Gigalith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">526</span>
                             Gigalith
@@ -5404,8 +5404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="Woobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="View Woobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" alt="Woobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">527</span>
                             Woobat
@@ -5414,8 +5414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="Swoobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="View Swoobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" alt="Swoobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">528</span>
                             Swoobat
@@ -5424,8 +5424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="Drilbur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="View Drilbur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" alt="Drilbur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">529</span>
                             Drilbur
@@ -5434,8 +5434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="Excadrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="View Excadrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" alt="Excadrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">530</span>
                             Excadrill
@@ -5444,8 +5444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/audino/" title="Audino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/531.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/audino/" title="View Audino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/531.png" alt="Audino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">531</span>
                             Audino
@@ -5454,8 +5454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="Timburr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="View Timburr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" alt="Timburr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">532</span>
                             Timburr
@@ -5464,8 +5464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="Gurdurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="View Gurdurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" alt="Gurdurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">533</span>
                             Gurdurr
@@ -5474,8 +5474,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="Conkeldurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="View Conkeldurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" alt="Conkeldurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">534</span>
                             Conkeldurr
@@ -5484,8 +5484,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="Tympole">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="View Tympole on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" alt="Tympole" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">535</span>
                             Tympole
@@ -5494,8 +5494,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="Palpitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="View Palpitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" alt="Palpitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">536</span>
                             Palpitoad
@@ -5504,8 +5504,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="Seismitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="View Seismitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" alt="Seismitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">537</span>
                             Seismitoad
@@ -5514,8 +5514,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="Throh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="View Throh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" alt="Throh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">538</span>
                             Throh
@@ -5524,8 +5524,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="Sawk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="View Sawk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" alt="Sawk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">539</span>
                             Sawk
@@ -5534,8 +5534,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sewaddle/" title="Sewaddle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/540.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sewaddle/" title="View Sewaddle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/540.png" alt="Sewaddle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">540</span>
                             Sewaddle
@@ -5551,8 +5551,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swadloon/" title="Swadloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/541.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swadloon/" title="View Swadloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/541.png" alt="Swadloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">541</span>
                             Swadloon
@@ -5561,8 +5561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leavanny/" title="Leavanny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/542.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leavanny/" title="View Leavanny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/542.png" alt="Leavanny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">542</span>
                             Leavanny
@@ -5571,8 +5571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="Venipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="View Venipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" alt="Venipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">543</span>
                             Venipede
@@ -5581,8 +5581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="Whirlipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="View Whirlipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" alt="Whirlipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">544</span>
                             Whirlipede
@@ -5591,8 +5591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="Scolipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="View Scolipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" alt="Scolipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">545</span>
                             Scolipede
@@ -5601,8 +5601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="Cottonee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="View Cottonee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" alt="Cottonee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">546</span>
                             Cottonee
@@ -5611,8 +5611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="Whimsicott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="View Whimsicott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" alt="Whimsicott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">547</span>
                             Whimsicott
@@ -5621,8 +5621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="Petilil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="View Petilil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" alt="Petilil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">548</span>
                             Petilil
@@ -5631,8 +5631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="Lilligant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="View Lilligant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" alt="Lilligant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">549</span>
                             Lilligant
@@ -5641,8 +5641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="Basculin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="View Basculin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" alt="Basculin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">550</span>
                             Basculin
@@ -5651,8 +5651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="Sandile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="View Sandile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" alt="Sandile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">551</span>
                             Sandile
@@ -5661,8 +5661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="Krokorok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="View Krokorok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" alt="Krokorok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">552</span>
                             Krokorok
@@ -5671,8 +5671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="Krookodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="View Krookodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" alt="Krookodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">553</span>
                             Krookodile
@@ -5681,8 +5681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="Darumaka">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="View Darumaka on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" alt="Darumaka" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">554</span>
                             Darumaka
@@ -5691,8 +5691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="Darmanitan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="View Darmanitan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" alt="Darmanitan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">555</span>
                             Darmanitan
@@ -5701,8 +5701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="Maractus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="View Maractus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" alt="Maractus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">556</span>
                             Maractus
@@ -5711,8 +5711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="Dwebble">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="View Dwebble on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" alt="Dwebble" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">557</span>
                             Dwebble
@@ -5721,8 +5721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="Crustle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="View Crustle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" alt="Crustle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">558</span>
                             Crustle
@@ -5731,8 +5731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="Scraggy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="View Scraggy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" alt="Scraggy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">559</span>
                             Scraggy
@@ -5741,8 +5741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="Scrafty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="View Scrafty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" alt="Scrafty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">560</span>
                             Scrafty
@@ -5751,8 +5751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="Sigilyph">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="View Sigilyph on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" alt="Sigilyph" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">561</span>
                             Sigilyph
@@ -5761,8 +5761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="Yamask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="View Yamask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" alt="Yamask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">562</span>
                             Yamask
@@ -5771,8 +5771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="Cofagrigus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="View Cofagrigus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" alt="Cofagrigus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">563</span>
                             Cofagrigus
@@ -5781,8 +5781,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tirtouga/" title="Tirtouga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/564.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tirtouga/" title="View Tirtouga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/564.png" alt="Tirtouga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">564</span>
                             Tirtouga
@@ -5791,8 +5791,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carracosta/" title="Carracosta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/565.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carracosta/" title="View Carracosta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/565.png" alt="Carracosta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">565</span>
                             Carracosta
@@ -5801,8 +5801,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/archen/" title="Archen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/566.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/archen/" title="View Archen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/566.png" alt="Archen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">566</span>
                             Archen
@@ -5811,8 +5811,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/archeops/" title="Archeops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/567.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/archeops/" title="View Archeops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/567.png" alt="Archeops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">567</span>
                             Archeops
@@ -5821,8 +5821,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="Trubbish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="View Trubbish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" alt="Trubbish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">568</span>
                             Trubbish
@@ -5831,8 +5831,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="Garbodor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="View Garbodor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" alt="Garbodor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">569</span>
                             Garbodor
@@ -5841,8 +5841,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="Zorua">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="View Zorua on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" alt="Zorua" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">570</span>
                             Zorua
@@ -5858,8 +5858,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="Zoroark">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="View Zoroark on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" alt="Zoroark" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">571</span>
                             Zoroark
@@ -5868,8 +5868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="Minccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="View Minccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" alt="Minccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">572</span>
                             Minccino
@@ -5878,8 +5878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="Cinccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="View Cinccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" alt="Cinccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">573</span>
                             Cinccino
@@ -5888,8 +5888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="Gothita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="View Gothita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" alt="Gothita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">574</span>
                             Gothita
@@ -5898,8 +5898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="Gothorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="View Gothorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" alt="Gothorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">575</span>
                             Gothorita
@@ -5908,8 +5908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="Gothitelle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="View Gothitelle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" alt="Gothitelle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">576</span>
                             Gothitelle
@@ -5918,8 +5918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="Solosis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="View Solosis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" alt="Solosis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">577</span>
                             Solosis
@@ -5928,8 +5928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="Duosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="View Duosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" alt="Duosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">578</span>
                             Duosion
@@ -5938,8 +5938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="Reuniclus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="View Reuniclus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" alt="Reuniclus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">579</span>
                             Reuniclus
@@ -5948,8 +5948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ducklett/" title="Ducklett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/580.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ducklett/" title="View Ducklett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/580.png" alt="Ducklett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">580</span>
                             Ducklett
@@ -5958,8 +5958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swanna/" title="Swanna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/581.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swanna/" title="View Swanna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/581.png" alt="Swanna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">581</span>
                             Swanna
@@ -5968,8 +5968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="Vanillite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="View Vanillite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" alt="Vanillite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">582</span>
                             Vanillite
@@ -5978,8 +5978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="Vanillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="View Vanillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" alt="Vanillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">583</span>
                             Vanillish
@@ -5988,8 +5988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="Vanilluxe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="View Vanilluxe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" alt="Vanilluxe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">584</span>
                             Vanilluxe
@@ -5998,8 +5998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deerling/" title="Deerling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/585.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deerling/" title="View Deerling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/585.png" alt="Deerling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">585</span>
                             Deerling
@@ -6008,8 +6008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sawsbuck/" title="Sawsbuck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/586.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sawsbuck/" title="View Sawsbuck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/586.png" alt="Sawsbuck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">586</span>
                             Sawsbuck
@@ -6018,8 +6018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="Emolga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="View Emolga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" alt="Emolga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">587</span>
                             Emolga
@@ -6028,8 +6028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="Karrablast">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="View Karrablast on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" alt="Karrablast" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">588</span>
                             Karrablast
@@ -6038,8 +6038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="Escavalier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="View Escavalier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" alt="Escavalier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">589</span>
                             Escavalier
@@ -6048,8 +6048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="Foongus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="View Foongus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" alt="Foongus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">590</span>
                             Foongus
@@ -6058,8 +6058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="Amoonguss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="View Amoonguss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" alt="Amoonguss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">591</span>
                             Amoonguss
@@ -6068,8 +6068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="Frillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="View Frillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" alt="Frillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">592</span>
                             Frillish
@@ -6078,8 +6078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="Jellicent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="View Jellicent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" alt="Jellicent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">593</span>
                             Jellicent
@@ -6088,8 +6088,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alomomola/" title="Alomomola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/594.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alomomola/" title="View Alomomola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/594.png" alt="Alomomola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">594</span>
                             Alomomola
@@ -6098,8 +6098,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="Joltik">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="View Joltik on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" alt="Joltik" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">595</span>
                             Joltik
@@ -6108,8 +6108,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="Galvantula">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="View Galvantula on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" alt="Galvantula" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">596</span>
                             Galvantula
@@ -6118,8 +6118,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="Ferroseed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="View Ferroseed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" alt="Ferroseed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">597</span>
                             Ferroseed
@@ -6128,8 +6128,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="Ferrothorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="View Ferrothorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" alt="Ferrothorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">598</span>
                             Ferrothorn
@@ -6138,8 +6138,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="Klink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="View Klink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" alt="Klink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">599</span>
                             Klink
@@ -6148,8 +6148,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="Klang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="View Klang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" alt="Klang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">600</span>
                             Klang
@@ -6165,8 +6165,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="Klinklang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="View Klinklang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" alt="Klinklang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">601</span>
                             Klinklang
@@ -6175,8 +6175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tynamo/" title="Tynamo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/602.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tynamo/" title="View Tynamo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/602.png" alt="Tynamo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">602</span>
                             Tynamo
@@ -6185,8 +6185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eelektrik/" title="Eelektrik">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/603.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eelektrik/" title="View Eelektrik on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/603.png" alt="Eelektrik" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">603</span>
                             Eelektrik
@@ -6195,8 +6195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eelektross/" title="Eelektross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/604.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eelektross/" title="View Eelektross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/604.png" alt="Eelektross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">604</span>
                             Eelektross
@@ -6205,8 +6205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="Elgyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="View Elgyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" alt="Elgyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">605</span>
                             Elgyem
@@ -6215,8 +6215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="Beheeyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="View Beheeyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" alt="Beheeyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">606</span>
                             Beheeyem
@@ -6225,8 +6225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="Litwick">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="View Litwick on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" alt="Litwick" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">607</span>
                             Litwick
@@ -6235,8 +6235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="Lampent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="View Lampent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" alt="Lampent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">608</span>
                             Lampent
@@ -6245,8 +6245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="Chandelure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="View Chandelure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" alt="Chandelure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">609</span>
                             Chandelure
@@ -6255,8 +6255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="Axew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="View Axew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" alt="Axew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">610</span>
                             Axew
@@ -6265,8 +6265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="Fraxure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="View Fraxure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" alt="Fraxure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">611</span>
                             Fraxure
@@ -6275,8 +6275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="Haxorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="View Haxorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" alt="Haxorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">612</span>
                             Haxorus
@@ -6285,8 +6285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="Cubchoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="View Cubchoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" alt="Cubchoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">613</span>
                             Cubchoo
@@ -6295,8 +6295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="Beartic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="View Beartic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" alt="Beartic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">614</span>
                             Beartic
@@ -6305,8 +6305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cryogonal/" title="Cryogonal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/615.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cryogonal/" title="View Cryogonal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/615.png" alt="Cryogonal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">615</span>
                             Cryogonal
@@ -6315,8 +6315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="Shelmet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="View Shelmet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" alt="Shelmet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">616</span>
                             Shelmet
@@ -6325,8 +6325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="Accelgor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="View Accelgor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" alt="Accelgor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">617</span>
                             Accelgor
@@ -6335,8 +6335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="Stunfisk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="View Stunfisk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" alt="Stunfisk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">618</span>
                             Stunfisk
@@ -6345,8 +6345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="Mienfoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="View Mienfoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" alt="Mienfoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">619</span>
                             Mienfoo
@@ -6355,8 +6355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="Mienshao">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="View Mienshao on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" alt="Mienshao" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">620</span>
                             Mienshao
@@ -6365,8 +6365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="Druddigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="View Druddigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" alt="Druddigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">621</span>
                             Druddigon
@@ -6375,8 +6375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="Golett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="View Golett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" alt="Golett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">622</span>
                             Golett
@@ -6385,8 +6385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="Golurk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="View Golurk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" alt="Golurk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">623</span>
                             Golurk
@@ -6395,8 +6395,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="Pawniard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="View Pawniard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" alt="Pawniard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">624</span>
                             Pawniard
@@ -6405,8 +6405,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="Bisharp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="View Bisharp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" alt="Bisharp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">625</span>
                             Bisharp
@@ -6415,8 +6415,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="Bouffalant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="View Bouffalant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" alt="Bouffalant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">626</span>
                             Bouffalant
@@ -6425,8 +6425,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="Rufflet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="View Rufflet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" alt="Rufflet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">627</span>
                             Rufflet
@@ -6435,8 +6435,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="Braviary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="View Braviary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" alt="Braviary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">628</span>
                             Braviary
@@ -6445,8 +6445,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="Vullaby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="View Vullaby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" alt="Vullaby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">629</span>
                             Vullaby
@@ -6455,8 +6455,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="Mandibuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="View Mandibuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" alt="Mandibuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">630</span>
                             Mandibuzz
@@ -6472,8 +6472,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="Heatmor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="View Heatmor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" alt="Heatmor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">631</span>
                             Heatmor
@@ -6482,8 +6482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="Durant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="View Durant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" alt="Durant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">632</span>
                             Durant
@@ -6492,8 +6492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="Deino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="View Deino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" alt="Deino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">633</span>
                             Deino
@@ -6502,8 +6502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="Zweilous">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="View Zweilous on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" alt="Zweilous" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">634</span>
                             Zweilous
@@ -6512,8 +6512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="Hydreigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="View Hydreigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" alt="Hydreigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">635</span>
                             Hydreigon
@@ -6522,8 +6522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="Larvesta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="View Larvesta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" alt="Larvesta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">636</span>
                             Larvesta
@@ -6532,8 +6532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="Volcarona">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="View Volcarona on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" alt="Volcarona" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">637</span>
                             Volcarona
@@ -6542,8 +6542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cobalion/" title="Cobalion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/638.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cobalion/" title="View Cobalion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/638.png" alt="Cobalion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">638</span>
                             Cobalion
@@ -6552,8 +6552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/terrakion/" title="Terrakion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/639.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/terrakion/" title="View Terrakion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/639.png" alt="Terrakion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">639</span>
                             Terrakion
@@ -6562,8 +6562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/virizion/" title="Virizion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/640.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/virizion/" title="View Virizion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/640.png" alt="Virizion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">640</span>
                             Virizion
@@ -6572,8 +6572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tornadus/" title="Tornadus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/641.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tornadus/" title="View Tornadus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/641.png" alt="Tornadus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">641</span>
                             Tornadus
@@ -6582,8 +6582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/thundurus/" title="Thundurus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/642.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/thundurus/" title="View Thundurus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/642.png" alt="Thundurus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">642</span>
                             Thundurus
@@ -6592,8 +6592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/reshiram/" title="Reshiram">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/643.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/reshiram/" title="View Reshiram on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/643.png" alt="Reshiram" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">643</span>
                             Reshiram
@@ -6602,8 +6602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zekrom/" title="Zekrom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/644.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zekrom/" title="View Zekrom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/644.png" alt="Zekrom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">644</span>
                             Zekrom
@@ -6612,8 +6612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/landorus/" title="Landorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/645.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/landorus/" title="View Landorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/645.png" alt="Landorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">645</span>
                             Landorus
@@ -6622,8 +6622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyurem/" title="Kyurem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/646.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyurem/" title="View Kyurem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/646.png" alt="Kyurem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">646</span>
                             Kyurem
@@ -6632,8 +6632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/keldeo/" title="Keldeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/647.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/keldeo/" title="View Keldeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/647.png" alt="Keldeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">647</span>
                             Keldeo
@@ -6642,8 +6642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meloetta/" title="Meloetta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/648.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meloetta/" title="View Meloetta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/648.png" alt="Meloetta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">648</span>
                             Meloetta
@@ -6652,8 +6652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/genesect/" title="Genesect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/649.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/genesect/" title="View Genesect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/649.png" alt="Genesect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">649</span>
                             Genesect
@@ -6667,8 +6667,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/diamond-pearl-platinum.html
+++ b/docs/diamond-pearl-platinum.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Bulbasaur
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Ivysaur
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Venusaur
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Charmander
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Charmeleon
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Charizard
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Squirtle
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Wartortle
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Blastoise
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Caterpie
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Metapod
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Butterfree
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="Weedle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="View Weedle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" alt="Weedle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Weedle
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="Kakuna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="View Kakuna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" alt="Kakuna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Kakuna
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="Beedrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="View Beedrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" alt="Beedrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Beedrill
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="Pidgey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="View Pidgey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" alt="Pidgey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Pidgey
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="Pidgeotto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="View Pidgeotto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" alt="Pidgeotto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Pidgeotto
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="Pidgeot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="View Pidgeot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" alt="Pidgeot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Pidgeot
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="Rattata">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="View Rattata on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" alt="Rattata" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Rattata
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="Raticate">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="View Raticate on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" alt="Raticate" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Raticate
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="Spearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="View Spearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" alt="Spearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Spearow
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="Fearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="View Fearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" alt="Fearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fearow
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="Ekans">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="View Ekans on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" alt="Ekans" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Ekans
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="Arbok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="View Arbok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" alt="Arbok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Arbok
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Pikachu
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Raichu
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Sandshrew
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Sandslash
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="Nidoran♀">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="View Nidoran♀ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" alt="Nidoran♀" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nidoran♀
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="Nidorina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="View Nidorina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" alt="Nidorina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Nidorina
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="Nidoqueen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="View Nidoqueen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" alt="Nidoqueen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Nidoqueen
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="Nidoran♂">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="View Nidoran♂ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" alt="Nidoran♂" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Nidoran♂
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="Nidorino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="View Nidorino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" alt="Nidorino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Nidorino
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="Nidoking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="View Nidoking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" alt="Nidoking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Nidoking
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Clefairy
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Clefable
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Vulpix
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ninetales
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Jigglypuff
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Wigglytuff
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="Zubat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="View Zubat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" alt="Zubat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Zubat
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="Golbat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="View Golbat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" alt="Golbat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Golbat
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Oddish
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Gloom
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Vileplume
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="Paras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="View Paras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" alt="Paras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Paras
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="Parasect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="View Parasect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" alt="Parasect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Parasect
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="Venonat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="View Venonat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" alt="Venonat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Venonat
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="Venomoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="View Venomoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" alt="Venomoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Venomoth
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Diglett
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Dugtrio
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Meowth
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Persian
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Psyduck
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Golduck
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="Mankey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="View Mankey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" alt="Mankey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Mankey
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="Primeape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="View Primeape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" alt="Primeape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Primeape
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Growlithe
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Arcanine
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Poliwag
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Poliwhirl
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Poliwrath
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Abra
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Kadabra
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Alakazam
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Machop
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Machoke
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Machamp
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="Bellsprout">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="View Bellsprout on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" alt="Bellsprout" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Bellsprout
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="Weepinbell">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="View Weepinbell on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" alt="Weepinbell" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Weepinbell
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="Victreebel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="View Victreebel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" alt="Victreebel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Victreebel
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Tentacool
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Tentacruel
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="Geodude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="View Geodude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" alt="Geodude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Geodude
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="Graveler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="View Graveler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" alt="Graveler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Graveler
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="Golem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="View Golem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" alt="Golem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Golem
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Ponyta
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Rapidash
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Slowpoke
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Slowbro
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Magnemite
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Magneton
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="Farfetch’d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="View Farfetch’d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch’d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Farfetch’d
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="Doduo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="View Doduo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" alt="Doduo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Doduo
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="Dodrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="View Dodrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" alt="Dodrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Dodrio
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="Seel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="View Seel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" alt="Seel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Seel
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="Dewgong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="View Dewgong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" alt="Dewgong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Dewgong
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="Grimer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="View Grimer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" alt="Grimer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Grimer
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="Muk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="View Muk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" alt="Muk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Muk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Shellder
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Cloyster
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Gastly
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Haunter
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Gengar
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Onix
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="Drowzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="View Drowzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" alt="Drowzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Drowzee
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="Hypno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="View Hypno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" alt="Hypno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Hypno
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="Voltorb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="View Voltorb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" alt="Voltorb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Voltorb
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="Electrode">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="View Electrode on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" alt="Electrode" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Electrode
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Exeggcute
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Exeggutor
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Cubone
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Marowak
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Hitmonlee
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Hitmonchan
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Lickitung
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Koffing
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Weezing
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Rhyhorn
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Rhydon
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Chansey
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Tangela
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Kangaskhan
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Horsea
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Seadra
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Goldeen
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Seaking
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Staryu
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Starmie
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Mr. Mime
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Scyther
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="Jynx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="View Jynx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" alt="Jynx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Jynx
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="Electabuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="View Electabuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" alt="Electabuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Electabuzz
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="Magmar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="View Magmar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" alt="Magmar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Magmar
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Pinsir
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Tauros
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Magikarp
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Gyarados
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Lapras
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Ditto
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Eevee
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Vaporeon
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Jolteon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Flareon
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Porygon
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="Omanyte">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="View Omanyte on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" alt="Omanyte" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Omanyte
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="Omastar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="View Omastar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" alt="Omastar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Omastar
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="Kabuto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="View Kabuto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" alt="Kabuto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Kabuto
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="Kabutops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="View Kabutops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" alt="Kabutops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Kabutops
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="Aerodactyl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="View Aerodactyl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" alt="Aerodactyl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Aerodactyl
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Snorlax
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="Articuno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="View Articuno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" alt="Articuno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Articuno
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="Zapdos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="View Zapdos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" alt="Zapdos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Zapdos
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="Moltres">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="View Moltres on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" alt="Moltres" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Moltres
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="Dratini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="View Dratini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" alt="Dratini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Dratini
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="Dragonair">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="View Dragonair on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" alt="Dragonair" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Dragonair
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="Dragonite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="View Dragonite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" alt="Dragonite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Dragonite
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="Mewtwo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="View Mewtwo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" alt="Mewtwo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Mewtwo
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="Mew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="View Mew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" alt="Mew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Mew
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="Chikorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="View Chikorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" alt="Chikorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Chikorita
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="Bayleef">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="View Bayleef on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" alt="Bayleef" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Bayleef
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="Meganium">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="View Meganium on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" alt="Meganium" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Meganium
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="Cyndaquil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="View Cyndaquil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" alt="Cyndaquil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Cyndaquil
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="Quilava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="View Quilava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" alt="Quilava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Quilava
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="Typhlosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="View Typhlosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" alt="Typhlosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Typhlosion
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="Totodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="View Totodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" alt="Totodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Totodile
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="Croconaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="View Croconaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" alt="Croconaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Croconaw
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="Feraligatr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="View Feraligatr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" alt="Feraligatr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Feraligatr
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="Sentret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="View Sentret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" alt="Sentret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Sentret
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="Furret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="View Furret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" alt="Furret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Furret
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="Hoothoot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="View Hoothoot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" alt="Hoothoot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Hoothoot
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="Noctowl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="View Noctowl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" alt="Noctowl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Noctowl
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="Ledyba">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="View Ledyba on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" alt="Ledyba" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Ledyba
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="Ledian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="View Ledian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" alt="Ledian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Ledian
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="Spinarak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="View Spinarak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" alt="Spinarak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Spinarak
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="Ariados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="View Ariados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" alt="Ariados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Ariados
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="Crobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="View Crobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" alt="Crobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Crobat
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Chinchou
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Lanturn
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Pichu
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="Cleffa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="View Cleffa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" alt="Cleffa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Cleffa
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="Igglybuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="View Igglybuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" alt="Igglybuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Igglybuff
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="Togepi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="View Togepi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" alt="Togepi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Togepi
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="Togetic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="View Togetic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" alt="Togetic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Togetic
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="Natu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="View Natu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" alt="Natu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Natu
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="Xatu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="View Xatu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" alt="Xatu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Xatu
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="Mareep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="View Mareep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" alt="Mareep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Mareep
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="Flaaffy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="View Flaaffy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" alt="Flaaffy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Flaaffy
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="Ampharos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="View Ampharos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" alt="Ampharos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Ampharos
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="Bellossom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="View Bellossom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" alt="Bellossom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Bellossom
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="Marill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="View Marill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" alt="Marill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Marill
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="Azumarill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="View Azumarill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" alt="Azumarill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Azumarill
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="Sudowoodo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="View Sudowoodo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" alt="Sudowoodo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Sudowoodo
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="Politoed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="View Politoed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" alt="Politoed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Politoed
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="Hoppip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="View Hoppip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" alt="Hoppip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Hoppip
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="Skiploom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="View Skiploom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" alt="Skiploom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Skiploom
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="Jumpluff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="View Jumpluff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" alt="Jumpluff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Jumpluff
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="Aipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="View Aipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" alt="Aipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Aipom
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="Sunkern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="View Sunkern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" alt="Sunkern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Sunkern
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="Sunflora">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="View Sunflora on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" alt="Sunflora" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Sunflora
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="Yanma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="View Yanma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" alt="Yanma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Yanma
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Wooper
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Quagsire
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="Espeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="View Espeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" alt="Espeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Espeon
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="Umbreon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="View Umbreon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" alt="Umbreon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Umbreon
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="Murkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="View Murkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" alt="Murkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Murkrow
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="Slowking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="View Slowking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" alt="Slowking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Slowking
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="Misdreavus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="View Misdreavus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" alt="Misdreavus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Misdreavus
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="Unown">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="View Unown on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" alt="Unown" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Unown
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="Wobbuffet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="View Wobbuffet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" alt="Wobbuffet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Wobbuffet
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="Girafarig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="View Girafarig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" alt="Girafarig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Girafarig
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="Pineco">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="View Pineco on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" alt="Pineco" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Pineco
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="Forretress">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="View Forretress on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" alt="Forretress" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Forretress
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="Dunsparce">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="View Dunsparce on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" alt="Dunsparce" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Dunsparce
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="Gligar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="View Gligar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" alt="Gligar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Gligar
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="Steelix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="View Steelix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" alt="Steelix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Steelix
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="Snubbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="View Snubbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" alt="Snubbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Snubbull
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="Granbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="View Granbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" alt="Granbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Granbull
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="Qwilfish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="View Qwilfish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" alt="Qwilfish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Qwilfish
@@ -2184,8 +2184,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="Scizor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="View Scizor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" alt="Scizor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">212</span>
                             Scizor
@@ -2194,8 +2194,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="Shuckle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="View Shuckle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" alt="Shuckle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">213</span>
                             Shuckle
@@ -2204,8 +2204,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="Heracross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="View Heracross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" alt="Heracross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">214</span>
                             Heracross
@@ -2214,8 +2214,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="Sneasel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="View Sneasel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" alt="Sneasel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">215</span>
                             Sneasel
@@ -2224,8 +2224,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="Teddiursa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="View Teddiursa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" alt="Teddiursa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">216</span>
                             Teddiursa
@@ -2234,8 +2234,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="Ursaring">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="View Ursaring on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" alt="Ursaring" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">217</span>
                             Ursaring
@@ -2244,8 +2244,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="Slugma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="View Slugma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" alt="Slugma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">218</span>
                             Slugma
@@ -2254,8 +2254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="Magcargo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="View Magcargo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" alt="Magcargo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">219</span>
                             Magcargo
@@ -2264,8 +2264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="Swinub">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="View Swinub on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" alt="Swinub" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">220</span>
                             Swinub
@@ -2274,8 +2274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="Piloswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="View Piloswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" alt="Piloswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">221</span>
                             Piloswine
@@ -2284,8 +2284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="Corsola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="View Corsola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" alt="Corsola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">222</span>
                             Corsola
@@ -2294,8 +2294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">223</span>
                             Remoraid
@@ -2304,8 +2304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">224</span>
                             Octillery
@@ -2314,8 +2314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="Delibird">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="View Delibird on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" alt="Delibird" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">225</span>
                             Delibird
@@ -2324,8 +2324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">226</span>
                             Mantine
@@ -2334,8 +2334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="Skarmory">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="View Skarmory on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" alt="Skarmory" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">227</span>
                             Skarmory
@@ -2344,8 +2344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="Houndour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="View Houndour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" alt="Houndour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">228</span>
                             Houndour
@@ -2354,8 +2354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="Houndoom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="View Houndoom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" alt="Houndoom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">229</span>
                             Houndoom
@@ -2364,8 +2364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="Kingdra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="View Kingdra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" alt="Kingdra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">230</span>
                             Kingdra
@@ -2374,8 +2374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="Phanpy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="View Phanpy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" alt="Phanpy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">231</span>
                             Phanpy
@@ -2384,8 +2384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="Donphan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="View Donphan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" alt="Donphan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">232</span>
                             Donphan
@@ -2394,8 +2394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="Porygon2">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="View Porygon2 on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" alt="Porygon2" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">233</span>
                             Porygon2
@@ -2404,8 +2404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="Stantler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="View Stantler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" alt="Stantler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">234</span>
                             Stantler
@@ -2414,8 +2414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="Smeargle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="View Smeargle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" alt="Smeargle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">235</span>
                             Smeargle
@@ -2424,8 +2424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="Tyrogue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="View Tyrogue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" alt="Tyrogue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">236</span>
                             Tyrogue
@@ -2434,8 +2434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="Hitmontop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="View Hitmontop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" alt="Hitmontop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">237</span>
                             Hitmontop
@@ -2444,8 +2444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="Smoochum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="View Smoochum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" alt="Smoochum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">238</span>
                             Smoochum
@@ -2454,8 +2454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="Elekid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="View Elekid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" alt="Elekid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">239</span>
                             Elekid
@@ -2464,8 +2464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="Magby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="View Magby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" alt="Magby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">240</span>
                             Magby
@@ -2481,8 +2481,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="Miltank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="View Miltank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" alt="Miltank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">241</span>
                             Miltank
@@ -2491,8 +2491,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="Blissey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="View Blissey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" alt="Blissey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">242</span>
                             Blissey
@@ -2501,8 +2501,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="Raikou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="View Raikou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" alt="Raikou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">243</span>
                             Raikou
@@ -2511,8 +2511,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="Entei">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="View Entei on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" alt="Entei" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">244</span>
                             Entei
@@ -2521,8 +2521,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="Suicune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="View Suicune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" alt="Suicune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">245</span>
                             Suicune
@@ -2531,8 +2531,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="Larvitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="View Larvitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" alt="Larvitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">246</span>
                             Larvitar
@@ -2541,8 +2541,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="Pupitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="View Pupitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" alt="Pupitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">247</span>
                             Pupitar
@@ -2551,8 +2551,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="Tyranitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="View Tyranitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" alt="Tyranitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">248</span>
                             Tyranitar
@@ -2561,8 +2561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="Lugia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="View Lugia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" alt="Lugia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">249</span>
                             Lugia
@@ -2571,8 +2571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="Ho-Oh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="View Ho-Oh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" alt="Ho-Oh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">250</span>
                             Ho-Oh
@@ -2581,8 +2581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="Celebi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="View Celebi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" alt="Celebi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">251</span>
                             Celebi
@@ -2591,8 +2591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="Treecko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="View Treecko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" alt="Treecko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">252</span>
                             Treecko
@@ -2601,8 +2601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="Grovyle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="View Grovyle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" alt="Grovyle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">253</span>
                             Grovyle
@@ -2611,8 +2611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="Sceptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="View Sceptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" alt="Sceptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">254</span>
                             Sceptile
@@ -2621,8 +2621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="Torchic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="View Torchic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" alt="Torchic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">255</span>
                             Torchic
@@ -2631,8 +2631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="Combusken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="View Combusken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" alt="Combusken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">256</span>
                             Combusken
@@ -2641,8 +2641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="Blaziken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="View Blaziken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" alt="Blaziken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">257</span>
                             Blaziken
@@ -2651,8 +2651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="Mudkip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="View Mudkip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" alt="Mudkip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">258</span>
                             Mudkip
@@ -2661,8 +2661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="Marshtomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="View Marshtomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" alt="Marshtomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">259</span>
                             Marshtomp
@@ -2671,8 +2671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="Swampert">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="View Swampert on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" alt="Swampert" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">260</span>
                             Swampert
@@ -2681,8 +2681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="Poochyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="View Poochyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" alt="Poochyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">261</span>
                             Poochyena
@@ -2691,8 +2691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="Mightyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="View Mightyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" alt="Mightyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">262</span>
                             Mightyena
@@ -2701,8 +2701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="Zigzagoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="View Zigzagoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" alt="Zigzagoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">263</span>
                             Zigzagoon
@@ -2711,8 +2711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="Linoone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="View Linoone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" alt="Linoone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">264</span>
                             Linoone
@@ -2721,8 +2721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="Wurmple">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="View Wurmple on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" alt="Wurmple" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">265</span>
                             Wurmple
@@ -2731,8 +2731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="Silcoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="View Silcoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" alt="Silcoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">266</span>
                             Silcoon
@@ -2741,8 +2741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="Beautifly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="View Beautifly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" alt="Beautifly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">267</span>
                             Beautifly
@@ -2751,8 +2751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="Cascoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="View Cascoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" alt="Cascoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">268</span>
                             Cascoon
@@ -2761,8 +2761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="Dustox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="View Dustox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" alt="Dustox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">269</span>
                             Dustox
@@ -2771,8 +2771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="Lotad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="View Lotad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" alt="Lotad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">270</span>
                             Lotad
@@ -2788,8 +2788,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="Lombre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="View Lombre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" alt="Lombre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">271</span>
                             Lombre
@@ -2798,8 +2798,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="Ludicolo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="View Ludicolo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" alt="Ludicolo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">272</span>
                             Ludicolo
@@ -2808,8 +2808,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="Seedot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="View Seedot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" alt="Seedot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">273</span>
                             Seedot
@@ -2818,8 +2818,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="Nuzleaf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="View Nuzleaf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" alt="Nuzleaf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">274</span>
                             Nuzleaf
@@ -2828,8 +2828,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="Shiftry">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="View Shiftry on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" alt="Shiftry" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">275</span>
                             Shiftry
@@ -2838,8 +2838,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="Taillow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="View Taillow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" alt="Taillow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">276</span>
                             Taillow
@@ -2848,8 +2848,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="Swellow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="View Swellow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" alt="Swellow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">277</span>
                             Swellow
@@ -2858,8 +2858,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="Wingull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="View Wingull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" alt="Wingull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">278</span>
                             Wingull
@@ -2868,8 +2868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="Pelipper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="View Pelipper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" alt="Pelipper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">279</span>
                             Pelipper
@@ -2878,8 +2878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="Ralts">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="View Ralts on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" alt="Ralts" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">280</span>
                             Ralts
@@ -2888,8 +2888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="Kirlia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="View Kirlia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" alt="Kirlia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">281</span>
                             Kirlia
@@ -2898,8 +2898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="Gardevoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="View Gardevoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" alt="Gardevoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">282</span>
                             Gardevoir
@@ -2908,8 +2908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="Surskit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="View Surskit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" alt="Surskit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">283</span>
                             Surskit
@@ -2918,8 +2918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="Masquerain">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="View Masquerain on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" alt="Masquerain" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">284</span>
                             Masquerain
@@ -2928,8 +2928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="Shroomish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="View Shroomish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" alt="Shroomish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">285</span>
                             Shroomish
@@ -2938,8 +2938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="Breloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="View Breloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" alt="Breloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">286</span>
                             Breloom
@@ -2948,8 +2948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="Slakoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="View Slakoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" alt="Slakoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">287</span>
                             Slakoth
@@ -2958,8 +2958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="Vigoroth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="View Vigoroth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" alt="Vigoroth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">288</span>
                             Vigoroth
@@ -2968,8 +2968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="Slaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="View Slaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" alt="Slaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">289</span>
                             Slaking
@@ -2978,8 +2978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="Nincada">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="View Nincada on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" alt="Nincada" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">290</span>
                             Nincada
@@ -2988,8 +2988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="Ninjask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="View Ninjask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" alt="Ninjask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">291</span>
                             Ninjask
@@ -2998,8 +2998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="Shedinja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="View Shedinja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" alt="Shedinja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">292</span>
                             Shedinja
@@ -3008,8 +3008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="Whismur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="View Whismur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" alt="Whismur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">293</span>
                             Whismur
@@ -3018,8 +3018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="Loudred">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="View Loudred on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" alt="Loudred" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">294</span>
                             Loudred
@@ -3028,8 +3028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="Exploud">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="View Exploud on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" alt="Exploud" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">295</span>
                             Exploud
@@ -3038,8 +3038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="Makuhita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="View Makuhita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" alt="Makuhita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">296</span>
                             Makuhita
@@ -3048,8 +3048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="Hariyama">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="View Hariyama on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" alt="Hariyama" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">297</span>
                             Hariyama
@@ -3058,8 +3058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="Azurill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="View Azurill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" alt="Azurill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">298</span>
                             Azurill
@@ -3068,8 +3068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="Nosepass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="View Nosepass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" alt="Nosepass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">299</span>
                             Nosepass
@@ -3078,8 +3078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="Skitty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="View Skitty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" alt="Skitty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">300</span>
                             Skitty
@@ -3095,8 +3095,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="Delcatty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="View Delcatty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" alt="Delcatty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">301</span>
                             Delcatty
@@ -3105,8 +3105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="Sableye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="View Sableye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" alt="Sableye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">302</span>
                             Sableye
@@ -3115,8 +3115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="Mawile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="View Mawile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" alt="Mawile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">303</span>
                             Mawile
@@ -3125,8 +3125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="Aron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="View Aron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" alt="Aron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">304</span>
                             Aron
@@ -3135,8 +3135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="Lairon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="View Lairon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" alt="Lairon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">305</span>
                             Lairon
@@ -3145,8 +3145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="Aggron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="View Aggron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" alt="Aggron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">306</span>
                             Aggron
@@ -3155,8 +3155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="Meditite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="View Meditite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" alt="Meditite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">307</span>
                             Meditite
@@ -3165,8 +3165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="Medicham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="View Medicham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" alt="Medicham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">308</span>
                             Medicham
@@ -3175,8 +3175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="Electrike">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="View Electrike on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" alt="Electrike" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">309</span>
                             Electrike
@@ -3185,8 +3185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="Manectric">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="View Manectric on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" alt="Manectric" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">310</span>
                             Manectric
@@ -3195,8 +3195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="Plusle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="View Plusle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" alt="Plusle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">311</span>
                             Plusle
@@ -3205,8 +3205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="Minun">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="View Minun on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" alt="Minun" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">312</span>
                             Minun
@@ -3215,8 +3215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="Volbeat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="View Volbeat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" alt="Volbeat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">313</span>
                             Volbeat
@@ -3225,8 +3225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="Illumise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="View Illumise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" alt="Illumise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">314</span>
                             Illumise
@@ -3235,8 +3235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="Roselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="View Roselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" alt="Roselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">315</span>
                             Roselia
@@ -3245,8 +3245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="Gulpin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="View Gulpin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" alt="Gulpin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">316</span>
                             Gulpin
@@ -3255,8 +3255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="Swalot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="View Swalot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" alt="Swalot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">317</span>
                             Swalot
@@ -3265,8 +3265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="Carvanha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="View Carvanha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" alt="Carvanha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">318</span>
                             Carvanha
@@ -3275,8 +3275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="Sharpedo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="View Sharpedo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" alt="Sharpedo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">319</span>
                             Sharpedo
@@ -3285,8 +3285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="Wailmer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="View Wailmer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" alt="Wailmer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">320</span>
                             Wailmer
@@ -3295,8 +3295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="Wailord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="View Wailord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" alt="Wailord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">321</span>
                             Wailord
@@ -3305,8 +3305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="Numel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="View Numel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" alt="Numel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">322</span>
                             Numel
@@ -3315,8 +3315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="Camerupt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="View Camerupt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" alt="Camerupt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">323</span>
                             Camerupt
@@ -3325,8 +3325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="Torkoal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="View Torkoal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" alt="Torkoal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">324</span>
                             Torkoal
@@ -3335,8 +3335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="Spoink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="View Spoink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" alt="Spoink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">325</span>
                             Spoink
@@ -3345,8 +3345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="Grumpig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="View Grumpig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" alt="Grumpig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">326</span>
                             Grumpig
@@ -3355,8 +3355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="Spinda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="View Spinda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" alt="Spinda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">327</span>
                             Spinda
@@ -3365,8 +3365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="Trapinch">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="View Trapinch on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" alt="Trapinch" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">328</span>
                             Trapinch
@@ -3375,8 +3375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="Vibrava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="View Vibrava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" alt="Vibrava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">329</span>
                             Vibrava
@@ -3385,8 +3385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="Flygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="View Flygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" alt="Flygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">330</span>
                             Flygon
@@ -3402,8 +3402,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="Cacnea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="View Cacnea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" alt="Cacnea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">331</span>
                             Cacnea
@@ -3412,8 +3412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="Cacturne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="View Cacturne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" alt="Cacturne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">332</span>
                             Cacturne
@@ -3422,8 +3422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="Swablu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="View Swablu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" alt="Swablu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">333</span>
                             Swablu
@@ -3432,8 +3432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="Altaria">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="View Altaria on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" alt="Altaria" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">334</span>
                             Altaria
@@ -3442,8 +3442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="Zangoose">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="View Zangoose on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" alt="Zangoose" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">335</span>
                             Zangoose
@@ -3452,8 +3452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="Seviper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="View Seviper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" alt="Seviper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">336</span>
                             Seviper
@@ -3462,8 +3462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="Lunatone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="View Lunatone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" alt="Lunatone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">337</span>
                             Lunatone
@@ -3472,8 +3472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="Solrock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="View Solrock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" alt="Solrock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">338</span>
                             Solrock
@@ -3482,8 +3482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="Barboach">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="View Barboach on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" alt="Barboach" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">339</span>
                             Barboach
@@ -3492,8 +3492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="Whiscash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="View Whiscash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" alt="Whiscash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">340</span>
                             Whiscash
@@ -3502,8 +3502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="Corphish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="View Corphish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" alt="Corphish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">341</span>
                             Corphish
@@ -3512,8 +3512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="Crawdaunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="View Crawdaunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" alt="Crawdaunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">342</span>
                             Crawdaunt
@@ -3522,8 +3522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="Baltoy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="View Baltoy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" alt="Baltoy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">343</span>
                             Baltoy
@@ -3532,8 +3532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="Claydol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="View Claydol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" alt="Claydol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">344</span>
                             Claydol
@@ -3542,8 +3542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="Lileep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="View Lileep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" alt="Lileep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">345</span>
                             Lileep
@@ -3552,8 +3552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="Cradily">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="View Cradily on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" alt="Cradily" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">346</span>
                             Cradily
@@ -3562,8 +3562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="Anorith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="View Anorith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" alt="Anorith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">347</span>
                             Anorith
@@ -3572,8 +3572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="Armaldo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="View Armaldo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" alt="Armaldo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">348</span>
                             Armaldo
@@ -3582,8 +3582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="Feebas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="View Feebas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" alt="Feebas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">349</span>
                             Feebas
@@ -3592,8 +3592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="Milotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="View Milotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" alt="Milotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">350</span>
                             Milotic
@@ -3602,8 +3602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="Castform">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="View Castform on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" alt="Castform" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">351</span>
                             Castform
@@ -3612,8 +3612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="Kecleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="View Kecleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" alt="Kecleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">352</span>
                             Kecleon
@@ -3622,8 +3622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="Shuppet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="View Shuppet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" alt="Shuppet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">353</span>
                             Shuppet
@@ -3632,8 +3632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="Banette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="View Banette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" alt="Banette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">354</span>
                             Banette
@@ -3642,8 +3642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="Duskull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="View Duskull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" alt="Duskull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">355</span>
                             Duskull
@@ -3652,8 +3652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="Dusclops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="View Dusclops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" alt="Dusclops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">356</span>
                             Dusclops
@@ -3662,8 +3662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="Tropius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="View Tropius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" alt="Tropius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">357</span>
                             Tropius
@@ -3672,8 +3672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="Chimecho">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="View Chimecho on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" alt="Chimecho" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">358</span>
                             Chimecho
@@ -3682,8 +3682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="Absol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="View Absol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" alt="Absol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">359</span>
                             Absol
@@ -3692,8 +3692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="Wynaut">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="View Wynaut on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" alt="Wynaut" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">360</span>
                             Wynaut
@@ -3709,8 +3709,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="Snorunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="View Snorunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" alt="Snorunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">361</span>
                             Snorunt
@@ -3719,8 +3719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="Glalie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="View Glalie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" alt="Glalie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">362</span>
                             Glalie
@@ -3729,8 +3729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="Spheal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="View Spheal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" alt="Spheal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">363</span>
                             Spheal
@@ -3739,8 +3739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="Sealeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="View Sealeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" alt="Sealeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">364</span>
                             Sealeo
@@ -3749,8 +3749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="Walrein">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="View Walrein on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" alt="Walrein" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">365</span>
                             Walrein
@@ -3759,8 +3759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="Clamperl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="View Clamperl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" alt="Clamperl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">366</span>
                             Clamperl
@@ -3769,8 +3769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="Huntail">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="View Huntail on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" alt="Huntail" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">367</span>
                             Huntail
@@ -3779,8 +3779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="Gorebyss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="View Gorebyss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" alt="Gorebyss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">368</span>
                             Gorebyss
@@ -3789,8 +3789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="Relicanth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="View Relicanth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" alt="Relicanth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">369</span>
                             Relicanth
@@ -3799,8 +3799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="Luvdisc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="View Luvdisc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" alt="Luvdisc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">370</span>
                             Luvdisc
@@ -3809,8 +3809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="Bagon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="View Bagon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" alt="Bagon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">371</span>
                             Bagon
@@ -3819,8 +3819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="Shelgon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="View Shelgon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" alt="Shelgon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">372</span>
                             Shelgon
@@ -3829,8 +3829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="Salamence">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="View Salamence on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" alt="Salamence" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">373</span>
                             Salamence
@@ -3839,8 +3839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="Beldum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="View Beldum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" alt="Beldum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">374</span>
                             Beldum
@@ -3849,8 +3849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="Metang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="View Metang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" alt="Metang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">375</span>
                             Metang
@@ -3859,8 +3859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="Metagross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="View Metagross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" alt="Metagross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">376</span>
                             Metagross
@@ -3869,8 +3869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="Regirock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="View Regirock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" alt="Regirock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">377</span>
                             Regirock
@@ -3879,8 +3879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="Regice">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="View Regice on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" alt="Regice" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">378</span>
                             Regice
@@ -3889,8 +3889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="Registeel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="View Registeel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" alt="Registeel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">379</span>
                             Registeel
@@ -3899,8 +3899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="Latias">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="View Latias on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" alt="Latias" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">380</span>
                             Latias
@@ -3909,8 +3909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="Latios">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="View Latios on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" alt="Latios" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">381</span>
                             Latios
@@ -3919,8 +3919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="Kyogre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="View Kyogre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" alt="Kyogre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">382</span>
                             Kyogre
@@ -3929,8 +3929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="Groudon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="View Groudon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" alt="Groudon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">383</span>
                             Groudon
@@ -3939,8 +3939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="Rayquaza">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="View Rayquaza on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" alt="Rayquaza" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">384</span>
                             Rayquaza
@@ -3949,8 +3949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="Jirachi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="View Jirachi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" alt="Jirachi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">385</span>
                             Jirachi
@@ -3959,8 +3959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="Deoxys">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="View Deoxys on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" alt="Deoxys" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">386</span>
                             Deoxys
@@ -3969,8 +3969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="Turtwig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="View Turtwig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" alt="Turtwig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">387</span>
                             Turtwig
@@ -3979,8 +3979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="Grotle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="View Grotle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" alt="Grotle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">388</span>
                             Grotle
@@ -3989,8 +3989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="Torterra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="View Torterra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" alt="Torterra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">389</span>
                             Torterra
@@ -3999,8 +3999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="Chimchar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="View Chimchar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" alt="Chimchar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">390</span>
                             Chimchar
@@ -4016,8 +4016,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="Monferno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="View Monferno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" alt="Monferno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">391</span>
                             Monferno
@@ -4026,8 +4026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="Infernape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="View Infernape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" alt="Infernape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">392</span>
                             Infernape
@@ -4036,8 +4036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="Piplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="View Piplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" alt="Piplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">393</span>
                             Piplup
@@ -4046,8 +4046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="Prinplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="View Prinplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" alt="Prinplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">394</span>
                             Prinplup
@@ -4056,8 +4056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="Empoleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="View Empoleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" alt="Empoleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">395</span>
                             Empoleon
@@ -4066,8 +4066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="Starly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="View Starly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" alt="Starly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">396</span>
                             Starly
@@ -4076,8 +4076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="Staravia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="View Staravia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" alt="Staravia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">397</span>
                             Staravia
@@ -4086,8 +4086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="Staraptor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="View Staraptor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" alt="Staraptor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">398</span>
                             Staraptor
@@ -4096,8 +4096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="Bidoof">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="View Bidoof on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" alt="Bidoof" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">399</span>
                             Bidoof
@@ -4106,8 +4106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="Bibarel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="View Bibarel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" alt="Bibarel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">400</span>
                             Bibarel
@@ -4116,8 +4116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="Kricketot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="View Kricketot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" alt="Kricketot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">401</span>
                             Kricketot
@@ -4126,8 +4126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="Kricketune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="View Kricketune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" alt="Kricketune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">402</span>
                             Kricketune
@@ -4136,8 +4136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="Shinx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="View Shinx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" alt="Shinx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">403</span>
                             Shinx
@@ -4146,8 +4146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="Luxio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="View Luxio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" alt="Luxio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">404</span>
                             Luxio
@@ -4156,8 +4156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="Luxray">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="View Luxray on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" alt="Luxray" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">405</span>
                             Luxray
@@ -4166,8 +4166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="Budew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="View Budew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" alt="Budew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">406</span>
                             Budew
@@ -4176,8 +4176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="Roserade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="View Roserade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" alt="Roserade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">407</span>
                             Roserade
@@ -4186,8 +4186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="Cranidos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="View Cranidos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" alt="Cranidos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">408</span>
                             Cranidos
@@ -4196,8 +4196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="Rampardos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="View Rampardos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" alt="Rampardos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">409</span>
                             Rampardos
@@ -4206,8 +4206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="Shieldon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="View Shieldon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" alt="Shieldon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">410</span>
                             Shieldon
@@ -4216,8 +4216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="Bastiodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="View Bastiodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" alt="Bastiodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">411</span>
                             Bastiodon
@@ -4226,8 +4226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="Burmy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="View Burmy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" alt="Burmy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">412</span>
                             Burmy
@@ -4236,8 +4236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="Wormadam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="View Wormadam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" alt="Wormadam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">413</span>
                             Wormadam
@@ -4246,8 +4246,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="Mothim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="View Mothim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" alt="Mothim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">414</span>
                             Mothim
@@ -4256,8 +4256,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="Combee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="View Combee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" alt="Combee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">415</span>
                             Combee
@@ -4266,8 +4266,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="Vespiquen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="View Vespiquen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" alt="Vespiquen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">416</span>
                             Vespiquen
@@ -4276,8 +4276,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="Pachirisu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="View Pachirisu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" alt="Pachirisu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">417</span>
                             Pachirisu
@@ -4286,8 +4286,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="Buizel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="View Buizel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" alt="Buizel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">418</span>
                             Buizel
@@ -4296,8 +4296,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="Floatzel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="View Floatzel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" alt="Floatzel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">419</span>
                             Floatzel
@@ -4306,8 +4306,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="Cherubi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="View Cherubi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" alt="Cherubi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">420</span>
                             Cherubi
@@ -4323,8 +4323,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="Cherrim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="View Cherrim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" alt="Cherrim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">421</span>
                             Cherrim
@@ -4333,8 +4333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="Shellos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="View Shellos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" alt="Shellos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">422</span>
                             Shellos
@@ -4343,8 +4343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="Gastrodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="View Gastrodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" alt="Gastrodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">423</span>
                             Gastrodon
@@ -4353,8 +4353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="Ambipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="View Ambipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" alt="Ambipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">424</span>
                             Ambipom
@@ -4363,8 +4363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="Drifloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="View Drifloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" alt="Drifloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">425</span>
                             Drifloon
@@ -4373,8 +4373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="Drifblim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="View Drifblim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" alt="Drifblim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">426</span>
                             Drifblim
@@ -4383,8 +4383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="Buneary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="View Buneary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" alt="Buneary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">427</span>
                             Buneary
@@ -4393,8 +4393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="Lopunny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="View Lopunny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" alt="Lopunny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">428</span>
                             Lopunny
@@ -4403,8 +4403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="Mismagius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="View Mismagius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" alt="Mismagius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">429</span>
                             Mismagius
@@ -4413,8 +4413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="Honchkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="View Honchkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" alt="Honchkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">430</span>
                             Honchkrow
@@ -4423,8 +4423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="Glameow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="View Glameow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" alt="Glameow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">431</span>
                             Glameow
@@ -4433,8 +4433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="Purugly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="View Purugly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" alt="Purugly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">432</span>
                             Purugly
@@ -4443,8 +4443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="Chingling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="View Chingling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" alt="Chingling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">433</span>
                             Chingling
@@ -4453,8 +4453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="Stunky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="View Stunky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" alt="Stunky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">434</span>
                             Stunky
@@ -4463,8 +4463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="Skuntank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="View Skuntank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" alt="Skuntank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">435</span>
                             Skuntank
@@ -4473,8 +4473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="Bronzor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="View Bronzor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" alt="Bronzor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">436</span>
                             Bronzor
@@ -4483,8 +4483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="Bronzong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="View Bronzong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" alt="Bronzong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">437</span>
                             Bronzong
@@ -4493,8 +4493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="Bonsly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="View Bonsly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" alt="Bonsly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">438</span>
                             Bonsly
@@ -4503,8 +4503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="Mime Jr.">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="View Mime Jr. on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" alt="Mime Jr." loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">439</span>
                             Mime Jr.
@@ -4513,8 +4513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="Happiny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="View Happiny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" alt="Happiny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">440</span>
                             Happiny
@@ -4523,8 +4523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="Chatot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="View Chatot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" alt="Chatot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">441</span>
                             Chatot
@@ -4533,8 +4533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="Spiritomb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="View Spiritomb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" alt="Spiritomb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">442</span>
                             Spiritomb
@@ -4543,8 +4543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="Gible">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="View Gible on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" alt="Gible" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">443</span>
                             Gible
@@ -4553,8 +4553,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="Gabite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="View Gabite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" alt="Gabite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">444</span>
                             Gabite
@@ -4563,8 +4563,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="Garchomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="View Garchomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" alt="Garchomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">445</span>
                             Garchomp
@@ -4573,8 +4573,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="Munchlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="View Munchlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" alt="Munchlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">446</span>
                             Munchlax
@@ -4583,8 +4583,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="Riolu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="View Riolu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" alt="Riolu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">447</span>
                             Riolu
@@ -4593,8 +4593,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="Lucario">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="View Lucario on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" alt="Lucario" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">448</span>
                             Lucario
@@ -4603,8 +4603,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="Hippopotas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="View Hippopotas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" alt="Hippopotas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">449</span>
                             Hippopotas
@@ -4613,8 +4613,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="Hippowdon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="View Hippowdon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" alt="Hippowdon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">450</span>
                             Hippowdon
@@ -4630,8 +4630,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="Skorupi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="View Skorupi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" alt="Skorupi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">451</span>
                             Skorupi
@@ -4640,8 +4640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="Drapion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="View Drapion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" alt="Drapion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">452</span>
                             Drapion
@@ -4650,8 +4650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="Croagunk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="View Croagunk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" alt="Croagunk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">453</span>
                             Croagunk
@@ -4660,8 +4660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="Toxicroak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="View Toxicroak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" alt="Toxicroak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">454</span>
                             Toxicroak
@@ -4670,8 +4670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="Carnivine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="View Carnivine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" alt="Carnivine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">455</span>
                             Carnivine
@@ -4680,8 +4680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="Finneon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="View Finneon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" alt="Finneon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">456</span>
                             Finneon
@@ -4690,8 +4690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="Lumineon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="View Lumineon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" alt="Lumineon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">457</span>
                             Lumineon
@@ -4700,8 +4700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="Mantyke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="View Mantyke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" alt="Mantyke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">458</span>
                             Mantyke
@@ -4710,8 +4710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="Snover">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="View Snover on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" alt="Snover" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">459</span>
                             Snover
@@ -4720,8 +4720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="Abomasnow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="View Abomasnow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" alt="Abomasnow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">460</span>
                             Abomasnow
@@ -4730,8 +4730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="Weavile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="View Weavile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" alt="Weavile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">461</span>
                             Weavile
@@ -4740,8 +4740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="Magnezone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="View Magnezone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" alt="Magnezone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">462</span>
                             Magnezone
@@ -4750,8 +4750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="Lickilicky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="View Lickilicky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" alt="Lickilicky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">463</span>
                             Lickilicky
@@ -4760,8 +4760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="Rhyperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="View Rhyperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" alt="Rhyperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">464</span>
                             Rhyperior
@@ -4770,8 +4770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="Tangrowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="View Tangrowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" alt="Tangrowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">465</span>
                             Tangrowth
@@ -4780,8 +4780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="Electivire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="View Electivire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" alt="Electivire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">466</span>
                             Electivire
@@ -4790,8 +4790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="Magmortar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="View Magmortar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" alt="Magmortar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">467</span>
                             Magmortar
@@ -4800,8 +4800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="Togekiss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="View Togekiss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" alt="Togekiss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">468</span>
                             Togekiss
@@ -4810,8 +4810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="Yanmega">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="View Yanmega on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" alt="Yanmega" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">469</span>
                             Yanmega
@@ -4820,8 +4820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="Leafeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="View Leafeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" alt="Leafeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">470</span>
                             Leafeon
@@ -4830,8 +4830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="Glaceon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="View Glaceon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" alt="Glaceon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">471</span>
                             Glaceon
@@ -4840,8 +4840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="Gliscor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="View Gliscor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" alt="Gliscor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">472</span>
                             Gliscor
@@ -4850,8 +4850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="Mamoswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="View Mamoswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" alt="Mamoswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">473</span>
                             Mamoswine
@@ -4860,8 +4860,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="Porygon-Z">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="View Porygon-Z on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" alt="Porygon-Z" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">474</span>
                             Porygon-Z
@@ -4870,8 +4870,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="Gallade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="View Gallade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" alt="Gallade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">475</span>
                             Gallade
@@ -4880,8 +4880,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="Probopass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="View Probopass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" alt="Probopass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">476</span>
                             Probopass
@@ -4890,8 +4890,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="Dusknoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="View Dusknoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" alt="Dusknoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">477</span>
                             Dusknoir
@@ -4900,8 +4900,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="Froslass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="View Froslass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" alt="Froslass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">478</span>
                             Froslass
@@ -4910,8 +4910,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="Rotom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="View Rotom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" alt="Rotom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">479</span>
                             Rotom
@@ -4920,8 +4920,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="Uxie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="View Uxie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" alt="Uxie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">480</span>
                             Uxie
@@ -4937,8 +4937,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="Mesprit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="View Mesprit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" alt="Mesprit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">481</span>
                             Mesprit
@@ -4947,8 +4947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="Azelf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="View Azelf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" alt="Azelf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">482</span>
                             Azelf
@@ -4957,8 +4957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="Dialga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="View Dialga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" alt="Dialga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">483</span>
                             Dialga
@@ -4967,8 +4967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="Palkia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="View Palkia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" alt="Palkia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">484</span>
                             Palkia
@@ -4977,8 +4977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="Heatran">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="View Heatran on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" alt="Heatran" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">485</span>
                             Heatran
@@ -4987,8 +4987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="Regigigas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="View Regigigas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" alt="Regigigas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">486</span>
                             Regigigas
@@ -4997,8 +4997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="Giratina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="View Giratina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" alt="Giratina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">487</span>
                             Giratina
@@ -5007,8 +5007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="Cresselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="View Cresselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" alt="Cresselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">488</span>
                             Cresselia
@@ -5017,8 +5017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="Phione">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="View Phione on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" alt="Phione" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">489</span>
                             Phione
@@ -5027,8 +5027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="Manaphy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="View Manaphy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" alt="Manaphy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">490</span>
                             Manaphy
@@ -5042,8 +5042,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/firered-leafgreen.html
+++ b/docs/firered-leafgreen.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Bulbasaur
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Ivysaur
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Venusaur
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Charmander
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Charmeleon
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Charizard
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Squirtle
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Wartortle
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Blastoise
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Caterpie
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Metapod
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Butterfree
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="Weedle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="View Weedle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" alt="Weedle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Weedle
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="Kakuna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="View Kakuna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" alt="Kakuna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Kakuna
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="Beedrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="View Beedrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" alt="Beedrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Beedrill
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="Pidgey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="View Pidgey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" alt="Pidgey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Pidgey
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="Pidgeotto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="View Pidgeotto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" alt="Pidgeotto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Pidgeotto
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="Pidgeot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="View Pidgeot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" alt="Pidgeot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Pidgeot
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="Rattata">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="View Rattata on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" alt="Rattata" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Rattata
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="Raticate">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="View Raticate on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" alt="Raticate" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Raticate
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="Spearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="View Spearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" alt="Spearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Spearow
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="Fearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="View Fearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" alt="Fearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fearow
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="Ekans">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="View Ekans on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" alt="Ekans" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Ekans
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="Arbok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="View Arbok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" alt="Arbok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Arbok
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Pikachu
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Raichu
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Sandshrew
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Sandslash
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="Nidoran♀">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="View Nidoran♀ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" alt="Nidoran♀" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nidoran♀
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="Nidorina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="View Nidorina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" alt="Nidorina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Nidorina
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="Nidoqueen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="View Nidoqueen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" alt="Nidoqueen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Nidoqueen
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="Nidoran♂">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="View Nidoran♂ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" alt="Nidoran♂" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Nidoran♂
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="Nidorino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="View Nidorino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" alt="Nidorino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Nidorino
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="Nidoking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="View Nidoking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" alt="Nidoking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Nidoking
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Clefairy
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Clefable
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Vulpix
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ninetales
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Jigglypuff
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Wigglytuff
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="Zubat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="View Zubat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" alt="Zubat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Zubat
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="Golbat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="View Golbat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" alt="Golbat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Golbat
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Oddish
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Gloom
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Vileplume
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="Paras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="View Paras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" alt="Paras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Paras
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="Parasect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="View Parasect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" alt="Parasect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Parasect
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="Venonat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="View Venonat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" alt="Venonat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Venonat
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="Venomoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="View Venomoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" alt="Venomoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Venomoth
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Diglett
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Dugtrio
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Meowth
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Persian
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Psyduck
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Golduck
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="Mankey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="View Mankey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" alt="Mankey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Mankey
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="Primeape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="View Primeape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" alt="Primeape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Primeape
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Growlithe
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Arcanine
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Poliwag
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Poliwhirl
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Poliwrath
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Abra
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Kadabra
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Alakazam
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Machop
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Machoke
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Machamp
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="Bellsprout">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="View Bellsprout on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" alt="Bellsprout" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Bellsprout
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="Weepinbell">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="View Weepinbell on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" alt="Weepinbell" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Weepinbell
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="Victreebel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="View Victreebel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" alt="Victreebel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Victreebel
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Tentacool
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Tentacruel
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="Geodude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="View Geodude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" alt="Geodude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Geodude
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="Graveler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="View Graveler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" alt="Graveler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Graveler
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="Golem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="View Golem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" alt="Golem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Golem
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Ponyta
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Rapidash
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Slowpoke
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Slowbro
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Magnemite
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Magneton
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="Farfetch’d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="View Farfetch’d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch’d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Farfetch’d
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="Doduo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="View Doduo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" alt="Doduo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Doduo
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="Dodrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="View Dodrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" alt="Dodrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Dodrio
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="Seel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="View Seel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" alt="Seel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Seel
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="Dewgong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="View Dewgong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" alt="Dewgong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Dewgong
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="Grimer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="View Grimer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" alt="Grimer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Grimer
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="Muk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="View Muk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" alt="Muk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Muk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Shellder
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Cloyster
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Gastly
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Haunter
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Gengar
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Onix
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="Drowzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="View Drowzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" alt="Drowzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Drowzee
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="Hypno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="View Hypno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" alt="Hypno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Hypno
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="Voltorb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="View Voltorb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" alt="Voltorb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Voltorb
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="Electrode">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="View Electrode on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" alt="Electrode" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Electrode
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Exeggcute
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Exeggutor
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Cubone
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Marowak
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Hitmonlee
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Hitmonchan
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Lickitung
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Koffing
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Weezing
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Rhyhorn
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Rhydon
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Chansey
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Tangela
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Kangaskhan
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Horsea
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Seadra
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Goldeen
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Seaking
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Staryu
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Starmie
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Mr. Mime
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Scyther
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="Jynx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="View Jynx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" alt="Jynx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Jynx
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="Electabuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="View Electabuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" alt="Electabuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Electabuzz
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="Magmar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="View Magmar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" alt="Magmar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Magmar
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Pinsir
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Tauros
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Magikarp
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Gyarados
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Lapras
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Ditto
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Eevee
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Vaporeon
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Jolteon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Flareon
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Porygon
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="Omanyte">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="View Omanyte on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" alt="Omanyte" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Omanyte
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="Omastar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="View Omastar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" alt="Omastar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Omastar
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="Kabuto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="View Kabuto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" alt="Kabuto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Kabuto
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="Kabutops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="View Kabutops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" alt="Kabutops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Kabutops
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="Aerodactyl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="View Aerodactyl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" alt="Aerodactyl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Aerodactyl
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Snorlax
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="Articuno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="View Articuno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" alt="Articuno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Articuno
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="Zapdos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="View Zapdos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" alt="Zapdos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Zapdos
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="Moltres">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="View Moltres on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" alt="Moltres" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Moltres
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="Dratini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="View Dratini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" alt="Dratini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Dratini
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="Dragonair">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="View Dragonair on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" alt="Dragonair" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Dragonair
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="Dragonite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="View Dragonite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" alt="Dragonite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Dragonite
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="Mewtwo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="View Mewtwo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" alt="Mewtwo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Mewtwo
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="Mew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="View Mew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" alt="Mew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Mew
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="Chikorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="View Chikorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" alt="Chikorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Chikorita
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="Bayleef">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="View Bayleef on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" alt="Bayleef" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Bayleef
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="Meganium">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="View Meganium on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" alt="Meganium" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Meganium
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="Cyndaquil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="View Cyndaquil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" alt="Cyndaquil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Cyndaquil
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="Quilava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="View Quilava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" alt="Quilava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Quilava
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="Typhlosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="View Typhlosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" alt="Typhlosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Typhlosion
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="Totodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="View Totodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" alt="Totodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Totodile
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="Croconaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="View Croconaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" alt="Croconaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Croconaw
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="Feraligatr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="View Feraligatr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" alt="Feraligatr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Feraligatr
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="Sentret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="View Sentret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" alt="Sentret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Sentret
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="Furret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="View Furret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" alt="Furret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Furret
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="Hoothoot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="View Hoothoot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" alt="Hoothoot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Hoothoot
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="Noctowl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="View Noctowl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" alt="Noctowl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Noctowl
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="Ledyba">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="View Ledyba on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" alt="Ledyba" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Ledyba
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="Ledian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="View Ledian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" alt="Ledian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Ledian
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="Spinarak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="View Spinarak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" alt="Spinarak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Spinarak
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="Ariados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="View Ariados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" alt="Ariados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Ariados
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="Crobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="View Crobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" alt="Crobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Crobat
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Chinchou
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Lanturn
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Pichu
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="Cleffa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="View Cleffa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" alt="Cleffa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Cleffa
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="Igglybuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="View Igglybuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" alt="Igglybuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Igglybuff
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="Togepi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="View Togepi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" alt="Togepi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Togepi
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="Togetic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="View Togetic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" alt="Togetic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Togetic
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="Natu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="View Natu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" alt="Natu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Natu
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="Xatu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="View Xatu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" alt="Xatu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Xatu
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="Mareep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="View Mareep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" alt="Mareep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Mareep
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="Flaaffy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="View Flaaffy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" alt="Flaaffy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Flaaffy
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="Ampharos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="View Ampharos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" alt="Ampharos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Ampharos
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="Bellossom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="View Bellossom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" alt="Bellossom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Bellossom
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="Marill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="View Marill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" alt="Marill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Marill
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="Azumarill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="View Azumarill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" alt="Azumarill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Azumarill
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="Sudowoodo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="View Sudowoodo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" alt="Sudowoodo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Sudowoodo
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="Politoed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="View Politoed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" alt="Politoed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Politoed
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="Hoppip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="View Hoppip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" alt="Hoppip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Hoppip
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="Skiploom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="View Skiploom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" alt="Skiploom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Skiploom
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="Jumpluff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="View Jumpluff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" alt="Jumpluff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Jumpluff
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="Aipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="View Aipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" alt="Aipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Aipom
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="Sunkern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="View Sunkern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" alt="Sunkern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Sunkern
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="Sunflora">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="View Sunflora on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" alt="Sunflora" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Sunflora
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="Yanma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="View Yanma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" alt="Yanma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Yanma
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Wooper
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Quagsire
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="Espeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="View Espeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" alt="Espeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Espeon
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="Umbreon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="View Umbreon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" alt="Umbreon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Umbreon
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="Murkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="View Murkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" alt="Murkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Murkrow
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="Slowking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="View Slowking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" alt="Slowking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Slowking
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="Misdreavus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="View Misdreavus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" alt="Misdreavus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Misdreavus
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="Unown">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="View Unown on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" alt="Unown" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Unown
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="Wobbuffet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="View Wobbuffet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" alt="Wobbuffet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Wobbuffet
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="Girafarig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="View Girafarig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" alt="Girafarig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Girafarig
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="Pineco">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="View Pineco on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" alt="Pineco" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Pineco
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="Forretress">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="View Forretress on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" alt="Forretress" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Forretress
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="Dunsparce">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="View Dunsparce on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" alt="Dunsparce" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Dunsparce
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="Gligar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="View Gligar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" alt="Gligar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Gligar
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="Steelix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="View Steelix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" alt="Steelix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Steelix
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="Snubbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="View Snubbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" alt="Snubbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Snubbull
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="Granbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="View Granbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" alt="Granbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Granbull
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="Qwilfish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="View Qwilfish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" alt="Qwilfish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Qwilfish
@@ -2184,8 +2184,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="Scizor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="View Scizor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" alt="Scizor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">212</span>
                             Scizor
@@ -2194,8 +2194,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="Shuckle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="View Shuckle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" alt="Shuckle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">213</span>
                             Shuckle
@@ -2204,8 +2204,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="Heracross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="View Heracross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" alt="Heracross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">214</span>
                             Heracross
@@ -2214,8 +2214,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="Sneasel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="View Sneasel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" alt="Sneasel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">215</span>
                             Sneasel
@@ -2224,8 +2224,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="Teddiursa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="View Teddiursa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" alt="Teddiursa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">216</span>
                             Teddiursa
@@ -2234,8 +2234,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="Ursaring">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="View Ursaring on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" alt="Ursaring" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">217</span>
                             Ursaring
@@ -2244,8 +2244,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="Slugma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="View Slugma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" alt="Slugma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">218</span>
                             Slugma
@@ -2254,8 +2254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="Magcargo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="View Magcargo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" alt="Magcargo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">219</span>
                             Magcargo
@@ -2264,8 +2264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="Swinub">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="View Swinub on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" alt="Swinub" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">220</span>
                             Swinub
@@ -2274,8 +2274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="Piloswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="View Piloswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" alt="Piloswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">221</span>
                             Piloswine
@@ -2284,8 +2284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="Corsola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="View Corsola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" alt="Corsola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">222</span>
                             Corsola
@@ -2294,8 +2294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">223</span>
                             Remoraid
@@ -2304,8 +2304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">224</span>
                             Octillery
@@ -2314,8 +2314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="Delibird">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="View Delibird on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" alt="Delibird" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">225</span>
                             Delibird
@@ -2324,8 +2324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">226</span>
                             Mantine
@@ -2334,8 +2334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="Skarmory">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="View Skarmory on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" alt="Skarmory" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">227</span>
                             Skarmory
@@ -2344,8 +2344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="Houndour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="View Houndour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" alt="Houndour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">228</span>
                             Houndour
@@ -2354,8 +2354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="Houndoom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="View Houndoom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" alt="Houndoom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">229</span>
                             Houndoom
@@ -2364,8 +2364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="Kingdra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="View Kingdra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" alt="Kingdra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">230</span>
                             Kingdra
@@ -2374,8 +2374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="Phanpy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="View Phanpy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" alt="Phanpy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">231</span>
                             Phanpy
@@ -2384,8 +2384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="Donphan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="View Donphan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" alt="Donphan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">232</span>
                             Donphan
@@ -2394,8 +2394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="Porygon2">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="View Porygon2 on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" alt="Porygon2" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">233</span>
                             Porygon2
@@ -2404,8 +2404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="Stantler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="View Stantler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" alt="Stantler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">234</span>
                             Stantler
@@ -2414,8 +2414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="Smeargle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="View Smeargle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" alt="Smeargle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">235</span>
                             Smeargle
@@ -2424,8 +2424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="Tyrogue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="View Tyrogue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" alt="Tyrogue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">236</span>
                             Tyrogue
@@ -2434,8 +2434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="Hitmontop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="View Hitmontop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" alt="Hitmontop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">237</span>
                             Hitmontop
@@ -2444,8 +2444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="Smoochum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="View Smoochum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" alt="Smoochum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">238</span>
                             Smoochum
@@ -2454,8 +2454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="Elekid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="View Elekid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" alt="Elekid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">239</span>
                             Elekid
@@ -2464,8 +2464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="Magby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="View Magby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" alt="Magby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">240</span>
                             Magby
@@ -2481,8 +2481,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="Miltank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="View Miltank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" alt="Miltank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">241</span>
                             Miltank
@@ -2491,8 +2491,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="Blissey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="View Blissey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" alt="Blissey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">242</span>
                             Blissey
@@ -2501,8 +2501,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="Raikou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="View Raikou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" alt="Raikou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">243</span>
                             Raikou
@@ -2511,8 +2511,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="Entei">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="View Entei on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" alt="Entei" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">244</span>
                             Entei
@@ -2521,8 +2521,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="Suicune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="View Suicune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" alt="Suicune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">245</span>
                             Suicune
@@ -2531,8 +2531,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="Larvitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="View Larvitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" alt="Larvitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">246</span>
                             Larvitar
@@ -2541,8 +2541,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="Pupitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="View Pupitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" alt="Pupitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">247</span>
                             Pupitar
@@ -2551,8 +2551,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="Tyranitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="View Tyranitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" alt="Tyranitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">248</span>
                             Tyranitar
@@ -2561,8 +2561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="Lugia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="View Lugia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" alt="Lugia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">249</span>
                             Lugia
@@ -2571,8 +2571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="Ho-Oh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="View Ho-Oh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" alt="Ho-Oh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">250</span>
                             Ho-Oh
@@ -2581,8 +2581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="Celebi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="View Celebi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" alt="Celebi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">251</span>
                             Celebi
@@ -2591,8 +2591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="Treecko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="View Treecko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" alt="Treecko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">252</span>
                             Treecko
@@ -2601,8 +2601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="Grovyle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="View Grovyle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" alt="Grovyle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">253</span>
                             Grovyle
@@ -2611,8 +2611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="Sceptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="View Sceptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" alt="Sceptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">254</span>
                             Sceptile
@@ -2621,8 +2621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="Torchic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="View Torchic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" alt="Torchic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">255</span>
                             Torchic
@@ -2631,8 +2631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="Combusken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="View Combusken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" alt="Combusken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">256</span>
                             Combusken
@@ -2641,8 +2641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="Blaziken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="View Blaziken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" alt="Blaziken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">257</span>
                             Blaziken
@@ -2651,8 +2651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="Mudkip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="View Mudkip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" alt="Mudkip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">258</span>
                             Mudkip
@@ -2661,8 +2661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="Marshtomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="View Marshtomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" alt="Marshtomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">259</span>
                             Marshtomp
@@ -2671,8 +2671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="Swampert">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="View Swampert on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" alt="Swampert" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">260</span>
                             Swampert
@@ -2681,8 +2681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="Poochyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="View Poochyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" alt="Poochyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">261</span>
                             Poochyena
@@ -2691,8 +2691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="Mightyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="View Mightyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" alt="Mightyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">262</span>
                             Mightyena
@@ -2701,8 +2701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="Zigzagoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="View Zigzagoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" alt="Zigzagoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">263</span>
                             Zigzagoon
@@ -2711,8 +2711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="Linoone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="View Linoone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" alt="Linoone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">264</span>
                             Linoone
@@ -2721,8 +2721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="Wurmple">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="View Wurmple on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" alt="Wurmple" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">265</span>
                             Wurmple
@@ -2731,8 +2731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="Silcoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="View Silcoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" alt="Silcoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">266</span>
                             Silcoon
@@ -2741,8 +2741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="Beautifly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="View Beautifly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" alt="Beautifly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">267</span>
                             Beautifly
@@ -2751,8 +2751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="Cascoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="View Cascoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" alt="Cascoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">268</span>
                             Cascoon
@@ -2761,8 +2761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="Dustox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="View Dustox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" alt="Dustox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">269</span>
                             Dustox
@@ -2771,8 +2771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="Lotad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="View Lotad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" alt="Lotad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">270</span>
                             Lotad
@@ -2788,8 +2788,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="Lombre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="View Lombre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" alt="Lombre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">271</span>
                             Lombre
@@ -2798,8 +2798,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="Ludicolo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="View Ludicolo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" alt="Ludicolo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">272</span>
                             Ludicolo
@@ -2808,8 +2808,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="Seedot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="View Seedot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" alt="Seedot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">273</span>
                             Seedot
@@ -2818,8 +2818,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="Nuzleaf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="View Nuzleaf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" alt="Nuzleaf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">274</span>
                             Nuzleaf
@@ -2828,8 +2828,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="Shiftry">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="View Shiftry on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" alt="Shiftry" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">275</span>
                             Shiftry
@@ -2838,8 +2838,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="Taillow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="View Taillow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" alt="Taillow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">276</span>
                             Taillow
@@ -2848,8 +2848,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="Swellow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="View Swellow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" alt="Swellow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">277</span>
                             Swellow
@@ -2858,8 +2858,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="Wingull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="View Wingull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" alt="Wingull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">278</span>
                             Wingull
@@ -2868,8 +2868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="Pelipper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="View Pelipper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" alt="Pelipper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">279</span>
                             Pelipper
@@ -2878,8 +2878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="Ralts">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="View Ralts on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" alt="Ralts" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">280</span>
                             Ralts
@@ -2888,8 +2888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="Kirlia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="View Kirlia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" alt="Kirlia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">281</span>
                             Kirlia
@@ -2898,8 +2898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="Gardevoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="View Gardevoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" alt="Gardevoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">282</span>
                             Gardevoir
@@ -2908,8 +2908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="Surskit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="View Surskit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" alt="Surskit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">283</span>
                             Surskit
@@ -2918,8 +2918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="Masquerain">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="View Masquerain on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" alt="Masquerain" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">284</span>
                             Masquerain
@@ -2928,8 +2928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="Shroomish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="View Shroomish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" alt="Shroomish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">285</span>
                             Shroomish
@@ -2938,8 +2938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="Breloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="View Breloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" alt="Breloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">286</span>
                             Breloom
@@ -2948,8 +2948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="Slakoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="View Slakoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" alt="Slakoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">287</span>
                             Slakoth
@@ -2958,8 +2958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="Vigoroth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="View Vigoroth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" alt="Vigoroth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">288</span>
                             Vigoroth
@@ -2968,8 +2968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="Slaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="View Slaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" alt="Slaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">289</span>
                             Slaking
@@ -2978,8 +2978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="Nincada">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="View Nincada on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" alt="Nincada" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">290</span>
                             Nincada
@@ -2988,8 +2988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="Ninjask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="View Ninjask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" alt="Ninjask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">291</span>
                             Ninjask
@@ -2998,8 +2998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="Shedinja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="View Shedinja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" alt="Shedinja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">292</span>
                             Shedinja
@@ -3008,8 +3008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="Whismur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="View Whismur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" alt="Whismur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">293</span>
                             Whismur
@@ -3018,8 +3018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="Loudred">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="View Loudred on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" alt="Loudred" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">294</span>
                             Loudred
@@ -3028,8 +3028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="Exploud">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="View Exploud on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" alt="Exploud" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">295</span>
                             Exploud
@@ -3038,8 +3038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="Makuhita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="View Makuhita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" alt="Makuhita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">296</span>
                             Makuhita
@@ -3048,8 +3048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="Hariyama">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="View Hariyama on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" alt="Hariyama" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">297</span>
                             Hariyama
@@ -3058,8 +3058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="Azurill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="View Azurill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" alt="Azurill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">298</span>
                             Azurill
@@ -3068,8 +3068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="Nosepass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="View Nosepass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" alt="Nosepass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">299</span>
                             Nosepass
@@ -3078,8 +3078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="Skitty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="View Skitty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" alt="Skitty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">300</span>
                             Skitty
@@ -3095,8 +3095,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="Delcatty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="View Delcatty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" alt="Delcatty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">301</span>
                             Delcatty
@@ -3105,8 +3105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="Sableye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="View Sableye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" alt="Sableye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">302</span>
                             Sableye
@@ -3115,8 +3115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="Mawile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="View Mawile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" alt="Mawile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">303</span>
                             Mawile
@@ -3125,8 +3125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="Aron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="View Aron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" alt="Aron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">304</span>
                             Aron
@@ -3135,8 +3135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="Lairon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="View Lairon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" alt="Lairon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">305</span>
                             Lairon
@@ -3145,8 +3145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="Aggron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="View Aggron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" alt="Aggron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">306</span>
                             Aggron
@@ -3155,8 +3155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="Meditite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="View Meditite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" alt="Meditite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">307</span>
                             Meditite
@@ -3165,8 +3165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="Medicham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="View Medicham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" alt="Medicham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">308</span>
                             Medicham
@@ -3175,8 +3175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="Electrike">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="View Electrike on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" alt="Electrike" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">309</span>
                             Electrike
@@ -3185,8 +3185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="Manectric">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="View Manectric on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" alt="Manectric" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">310</span>
                             Manectric
@@ -3195,8 +3195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="Plusle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="View Plusle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" alt="Plusle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">311</span>
                             Plusle
@@ -3205,8 +3205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="Minun">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="View Minun on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" alt="Minun" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">312</span>
                             Minun
@@ -3215,8 +3215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="Volbeat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="View Volbeat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" alt="Volbeat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">313</span>
                             Volbeat
@@ -3225,8 +3225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="Illumise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="View Illumise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" alt="Illumise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">314</span>
                             Illumise
@@ -3235,8 +3235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="Roselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="View Roselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" alt="Roselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">315</span>
                             Roselia
@@ -3245,8 +3245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="Gulpin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="View Gulpin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" alt="Gulpin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">316</span>
                             Gulpin
@@ -3255,8 +3255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="Swalot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="View Swalot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" alt="Swalot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">317</span>
                             Swalot
@@ -3265,8 +3265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="Carvanha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="View Carvanha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" alt="Carvanha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">318</span>
                             Carvanha
@@ -3275,8 +3275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="Sharpedo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="View Sharpedo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" alt="Sharpedo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">319</span>
                             Sharpedo
@@ -3285,8 +3285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="Wailmer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="View Wailmer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" alt="Wailmer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">320</span>
                             Wailmer
@@ -3295,8 +3295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="Wailord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="View Wailord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" alt="Wailord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">321</span>
                             Wailord
@@ -3305,8 +3305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="Numel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="View Numel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" alt="Numel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">322</span>
                             Numel
@@ -3315,8 +3315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="Camerupt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="View Camerupt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" alt="Camerupt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">323</span>
                             Camerupt
@@ -3325,8 +3325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="Torkoal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="View Torkoal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" alt="Torkoal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">324</span>
                             Torkoal
@@ -3335,8 +3335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="Spoink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="View Spoink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" alt="Spoink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">325</span>
                             Spoink
@@ -3345,8 +3345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="Grumpig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="View Grumpig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" alt="Grumpig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">326</span>
                             Grumpig
@@ -3355,8 +3355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="Spinda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="View Spinda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" alt="Spinda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">327</span>
                             Spinda
@@ -3365,8 +3365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="Trapinch">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="View Trapinch on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" alt="Trapinch" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">328</span>
                             Trapinch
@@ -3375,8 +3375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="Vibrava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="View Vibrava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" alt="Vibrava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">329</span>
                             Vibrava
@@ -3385,8 +3385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="Flygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="View Flygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" alt="Flygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">330</span>
                             Flygon
@@ -3402,8 +3402,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="Cacnea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="View Cacnea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" alt="Cacnea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">331</span>
                             Cacnea
@@ -3412,8 +3412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="Cacturne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="View Cacturne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" alt="Cacturne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">332</span>
                             Cacturne
@@ -3422,8 +3422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="Swablu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="View Swablu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" alt="Swablu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">333</span>
                             Swablu
@@ -3432,8 +3432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="Altaria">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="View Altaria on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" alt="Altaria" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">334</span>
                             Altaria
@@ -3442,8 +3442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="Zangoose">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="View Zangoose on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" alt="Zangoose" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">335</span>
                             Zangoose
@@ -3452,8 +3452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="Seviper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="View Seviper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" alt="Seviper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">336</span>
                             Seviper
@@ -3462,8 +3462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="Lunatone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="View Lunatone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" alt="Lunatone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">337</span>
                             Lunatone
@@ -3472,8 +3472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="Solrock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="View Solrock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" alt="Solrock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">338</span>
                             Solrock
@@ -3482,8 +3482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="Barboach">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="View Barboach on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" alt="Barboach" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">339</span>
                             Barboach
@@ -3492,8 +3492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="Whiscash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="View Whiscash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" alt="Whiscash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">340</span>
                             Whiscash
@@ -3502,8 +3502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="Corphish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="View Corphish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" alt="Corphish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">341</span>
                             Corphish
@@ -3512,8 +3512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="Crawdaunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="View Crawdaunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" alt="Crawdaunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">342</span>
                             Crawdaunt
@@ -3522,8 +3522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="Baltoy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="View Baltoy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" alt="Baltoy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">343</span>
                             Baltoy
@@ -3532,8 +3532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="Claydol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="View Claydol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" alt="Claydol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">344</span>
                             Claydol
@@ -3542,8 +3542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="Lileep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="View Lileep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" alt="Lileep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">345</span>
                             Lileep
@@ -3552,8 +3552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="Cradily">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="View Cradily on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" alt="Cradily" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">346</span>
                             Cradily
@@ -3562,8 +3562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="Anorith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="View Anorith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" alt="Anorith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">347</span>
                             Anorith
@@ -3572,8 +3572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="Armaldo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="View Armaldo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" alt="Armaldo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">348</span>
                             Armaldo
@@ -3582,8 +3582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="Feebas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="View Feebas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" alt="Feebas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">349</span>
                             Feebas
@@ -3592,8 +3592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="Milotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="View Milotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" alt="Milotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">350</span>
                             Milotic
@@ -3602,8 +3602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="Castform">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="View Castform on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" alt="Castform" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">351</span>
                             Castform
@@ -3612,8 +3612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="Kecleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="View Kecleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" alt="Kecleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">352</span>
                             Kecleon
@@ -3622,8 +3622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="Shuppet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="View Shuppet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" alt="Shuppet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">353</span>
                             Shuppet
@@ -3632,8 +3632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="Banette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="View Banette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" alt="Banette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">354</span>
                             Banette
@@ -3642,8 +3642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="Duskull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="View Duskull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" alt="Duskull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">355</span>
                             Duskull
@@ -3652,8 +3652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="Dusclops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="View Dusclops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" alt="Dusclops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">356</span>
                             Dusclops
@@ -3662,8 +3662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="Tropius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="View Tropius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" alt="Tropius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">357</span>
                             Tropius
@@ -3672,8 +3672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="Chimecho">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="View Chimecho on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" alt="Chimecho" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">358</span>
                             Chimecho
@@ -3682,8 +3682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="Absol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="View Absol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" alt="Absol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">359</span>
                             Absol
@@ -3692,8 +3692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="Wynaut">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="View Wynaut on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" alt="Wynaut" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">360</span>
                             Wynaut
@@ -3709,8 +3709,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="Snorunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="View Snorunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" alt="Snorunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">361</span>
                             Snorunt
@@ -3719,8 +3719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="Glalie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="View Glalie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" alt="Glalie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">362</span>
                             Glalie
@@ -3729,8 +3729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="Spheal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="View Spheal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" alt="Spheal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">363</span>
                             Spheal
@@ -3739,8 +3739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="Sealeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="View Sealeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" alt="Sealeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">364</span>
                             Sealeo
@@ -3749,8 +3749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="Walrein">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="View Walrein on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" alt="Walrein" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">365</span>
                             Walrein
@@ -3759,8 +3759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="Clamperl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="View Clamperl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" alt="Clamperl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">366</span>
                             Clamperl
@@ -3769,8 +3769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="Huntail">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="View Huntail on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" alt="Huntail" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">367</span>
                             Huntail
@@ -3779,8 +3779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="Gorebyss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="View Gorebyss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" alt="Gorebyss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">368</span>
                             Gorebyss
@@ -3789,8 +3789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="Relicanth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="View Relicanth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" alt="Relicanth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">369</span>
                             Relicanth
@@ -3799,8 +3799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="Luvdisc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="View Luvdisc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" alt="Luvdisc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">370</span>
                             Luvdisc
@@ -3809,8 +3809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="Bagon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="View Bagon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" alt="Bagon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">371</span>
                             Bagon
@@ -3819,8 +3819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="Shelgon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="View Shelgon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" alt="Shelgon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">372</span>
                             Shelgon
@@ -3829,8 +3829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="Salamence">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="View Salamence on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" alt="Salamence" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">373</span>
                             Salamence
@@ -3839,8 +3839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="Beldum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="View Beldum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" alt="Beldum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">374</span>
                             Beldum
@@ -3849,8 +3849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="Metang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="View Metang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" alt="Metang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">375</span>
                             Metang
@@ -3859,8 +3859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="Metagross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="View Metagross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" alt="Metagross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">376</span>
                             Metagross
@@ -3869,8 +3869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="Regirock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="View Regirock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" alt="Regirock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">377</span>
                             Regirock
@@ -3879,8 +3879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="Regice">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="View Regice on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" alt="Regice" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">378</span>
                             Regice
@@ -3889,8 +3889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="Registeel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="View Registeel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" alt="Registeel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">379</span>
                             Registeel
@@ -3899,8 +3899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="Latias">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="View Latias on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" alt="Latias" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">380</span>
                             Latias
@@ -3909,8 +3909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="Latios">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="View Latios on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" alt="Latios" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">381</span>
                             Latios
@@ -3919,8 +3919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="Kyogre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="View Kyogre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" alt="Kyogre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">382</span>
                             Kyogre
@@ -3929,8 +3929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="Groudon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="View Groudon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" alt="Groudon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">383</span>
                             Groudon
@@ -3939,8 +3939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="Rayquaza">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="View Rayquaza on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" alt="Rayquaza" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">384</span>
                             Rayquaza
@@ -3949,8 +3949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="Jirachi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="View Jirachi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" alt="Jirachi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">385</span>
                             Jirachi
@@ -3959,8 +3959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="Deoxys">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="View Deoxys on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" alt="Deoxys" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">386</span>
                             Deoxys
@@ -3974,8 +3974,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/gold-silver-crystal.html
+++ b/docs/gold-silver-crystal.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Bulbasaur
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Ivysaur
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Venusaur
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Charmander
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Charmeleon
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Charizard
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Squirtle
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Wartortle
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Blastoise
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Caterpie
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Metapod
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Butterfree
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="Weedle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="View Weedle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" alt="Weedle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Weedle
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="Kakuna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="View Kakuna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" alt="Kakuna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Kakuna
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="Beedrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="View Beedrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" alt="Beedrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Beedrill
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="Pidgey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="View Pidgey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" alt="Pidgey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Pidgey
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="Pidgeotto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="View Pidgeotto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" alt="Pidgeotto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Pidgeotto
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="Pidgeot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="View Pidgeot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" alt="Pidgeot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Pidgeot
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="Rattata">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="View Rattata on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" alt="Rattata" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Rattata
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="Raticate">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="View Raticate on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" alt="Raticate" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Raticate
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="Spearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="View Spearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" alt="Spearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Spearow
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="Fearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="View Fearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" alt="Fearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fearow
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="Ekans">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="View Ekans on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" alt="Ekans" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Ekans
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="Arbok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="View Arbok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" alt="Arbok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Arbok
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Pikachu
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Raichu
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Sandshrew
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Sandslash
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="Nidoran♀">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="View Nidoran♀ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" alt="Nidoran♀" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nidoran♀
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="Nidorina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="View Nidorina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" alt="Nidorina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Nidorina
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="Nidoqueen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="View Nidoqueen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" alt="Nidoqueen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Nidoqueen
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="Nidoran♂">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="View Nidoran♂ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" alt="Nidoran♂" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Nidoran♂
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="Nidorino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="View Nidorino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" alt="Nidorino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Nidorino
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="Nidoking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="View Nidoking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" alt="Nidoking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Nidoking
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Clefairy
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Clefable
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Vulpix
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ninetales
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Jigglypuff
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Wigglytuff
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="Zubat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="View Zubat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" alt="Zubat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Zubat
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="Golbat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="View Golbat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" alt="Golbat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Golbat
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Oddish
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Gloom
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Vileplume
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="Paras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="View Paras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" alt="Paras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Paras
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="Parasect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="View Parasect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" alt="Parasect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Parasect
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="Venonat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="View Venonat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" alt="Venonat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Venonat
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="Venomoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="View Venomoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" alt="Venomoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Venomoth
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Diglett
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Dugtrio
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Meowth
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Persian
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Psyduck
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Golduck
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="Mankey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="View Mankey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" alt="Mankey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Mankey
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="Primeape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="View Primeape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" alt="Primeape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Primeape
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Growlithe
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Arcanine
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Poliwag
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Poliwhirl
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Poliwrath
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Abra
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Kadabra
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Alakazam
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Machop
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Machoke
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Machamp
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="Bellsprout">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="View Bellsprout on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" alt="Bellsprout" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Bellsprout
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="Weepinbell">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="View Weepinbell on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" alt="Weepinbell" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Weepinbell
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="Victreebel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="View Victreebel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" alt="Victreebel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Victreebel
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Tentacool
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Tentacruel
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="Geodude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="View Geodude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" alt="Geodude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Geodude
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="Graveler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="View Graveler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" alt="Graveler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Graveler
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="Golem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="View Golem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" alt="Golem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Golem
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Ponyta
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Rapidash
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Slowpoke
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Slowbro
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Magnemite
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Magneton
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="Farfetch’d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="View Farfetch’d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch’d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Farfetch’d
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="Doduo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="View Doduo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" alt="Doduo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Doduo
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="Dodrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="View Dodrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" alt="Dodrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Dodrio
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="Seel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="View Seel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" alt="Seel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Seel
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="Dewgong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="View Dewgong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" alt="Dewgong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Dewgong
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="Grimer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="View Grimer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" alt="Grimer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Grimer
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="Muk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="View Muk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" alt="Muk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Muk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Shellder
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Cloyster
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Gastly
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Haunter
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Gengar
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Onix
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="Drowzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="View Drowzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" alt="Drowzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Drowzee
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="Hypno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="View Hypno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" alt="Hypno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Hypno
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="Voltorb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="View Voltorb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" alt="Voltorb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Voltorb
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="Electrode">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="View Electrode on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" alt="Electrode" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Electrode
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Exeggcute
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Exeggutor
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Cubone
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Marowak
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Hitmonlee
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Hitmonchan
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Lickitung
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Koffing
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Weezing
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Rhyhorn
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Rhydon
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Chansey
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Tangela
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Kangaskhan
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Horsea
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Seadra
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Goldeen
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Seaking
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Staryu
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Starmie
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Mr. Mime
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Scyther
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="Jynx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="View Jynx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" alt="Jynx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Jynx
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="Electabuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="View Electabuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" alt="Electabuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Electabuzz
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="Magmar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="View Magmar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" alt="Magmar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Magmar
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Pinsir
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Tauros
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Magikarp
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Gyarados
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Lapras
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Ditto
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Eevee
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Vaporeon
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Jolteon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Flareon
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Porygon
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="Omanyte">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="View Omanyte on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" alt="Omanyte" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Omanyte
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="Omastar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="View Omastar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" alt="Omastar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Omastar
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="Kabuto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="View Kabuto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" alt="Kabuto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Kabuto
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="Kabutops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="View Kabutops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" alt="Kabutops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Kabutops
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="Aerodactyl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="View Aerodactyl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" alt="Aerodactyl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Aerodactyl
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Snorlax
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="Articuno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="View Articuno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" alt="Articuno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Articuno
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="Zapdos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="View Zapdos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" alt="Zapdos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Zapdos
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="Moltres">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="View Moltres on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" alt="Moltres" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Moltres
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="Dratini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="View Dratini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" alt="Dratini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Dratini
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="Dragonair">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="View Dragonair on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" alt="Dragonair" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Dragonair
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="Dragonite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="View Dragonite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" alt="Dragonite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Dragonite
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="Mewtwo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="View Mewtwo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" alt="Mewtwo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Mewtwo
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="Mew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="View Mew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" alt="Mew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Mew
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="Chikorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="View Chikorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" alt="Chikorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Chikorita
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="Bayleef">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="View Bayleef on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" alt="Bayleef" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Bayleef
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="Meganium">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="View Meganium on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" alt="Meganium" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Meganium
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="Cyndaquil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="View Cyndaquil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" alt="Cyndaquil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Cyndaquil
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="Quilava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="View Quilava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" alt="Quilava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Quilava
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="Typhlosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="View Typhlosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" alt="Typhlosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Typhlosion
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="Totodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="View Totodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" alt="Totodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Totodile
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="Croconaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="View Croconaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" alt="Croconaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Croconaw
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="Feraligatr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="View Feraligatr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" alt="Feraligatr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Feraligatr
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="Sentret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="View Sentret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" alt="Sentret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Sentret
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="Furret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="View Furret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" alt="Furret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Furret
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="Hoothoot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="View Hoothoot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" alt="Hoothoot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Hoothoot
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="Noctowl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="View Noctowl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" alt="Noctowl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Noctowl
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="Ledyba">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="View Ledyba on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" alt="Ledyba" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Ledyba
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="Ledian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="View Ledian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" alt="Ledian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Ledian
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="Spinarak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="View Spinarak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" alt="Spinarak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Spinarak
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="Ariados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="View Ariados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" alt="Ariados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Ariados
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="Crobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="View Crobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" alt="Crobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Crobat
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Chinchou
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Lanturn
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Pichu
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="Cleffa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="View Cleffa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" alt="Cleffa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Cleffa
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="Igglybuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="View Igglybuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" alt="Igglybuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Igglybuff
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="Togepi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="View Togepi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" alt="Togepi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Togepi
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="Togetic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="View Togetic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" alt="Togetic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Togetic
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="Natu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="View Natu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" alt="Natu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Natu
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="Xatu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="View Xatu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" alt="Xatu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Xatu
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="Mareep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="View Mareep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" alt="Mareep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Mareep
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="Flaaffy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="View Flaaffy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" alt="Flaaffy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Flaaffy
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="Ampharos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="View Ampharos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" alt="Ampharos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Ampharos
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="Bellossom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="View Bellossom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" alt="Bellossom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Bellossom
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="Marill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="View Marill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" alt="Marill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Marill
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="Azumarill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="View Azumarill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" alt="Azumarill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Azumarill
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="Sudowoodo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="View Sudowoodo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" alt="Sudowoodo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Sudowoodo
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="Politoed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="View Politoed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" alt="Politoed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Politoed
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="Hoppip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="View Hoppip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" alt="Hoppip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Hoppip
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="Skiploom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="View Skiploom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" alt="Skiploom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Skiploom
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="Jumpluff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="View Jumpluff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" alt="Jumpluff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Jumpluff
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="Aipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="View Aipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" alt="Aipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Aipom
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="Sunkern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="View Sunkern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" alt="Sunkern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Sunkern
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="Sunflora">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="View Sunflora on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" alt="Sunflora" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Sunflora
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="Yanma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="View Yanma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" alt="Yanma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Yanma
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Wooper
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Quagsire
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="Espeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="View Espeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" alt="Espeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Espeon
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="Umbreon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="View Umbreon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" alt="Umbreon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Umbreon
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="Murkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="View Murkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" alt="Murkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Murkrow
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="Slowking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="View Slowking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" alt="Slowking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Slowking
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="Misdreavus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="View Misdreavus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" alt="Misdreavus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Misdreavus
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="Unown">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="View Unown on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" alt="Unown" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Unown
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="Wobbuffet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="View Wobbuffet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" alt="Wobbuffet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Wobbuffet
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="Girafarig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="View Girafarig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" alt="Girafarig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Girafarig
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="Pineco">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="View Pineco on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" alt="Pineco" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Pineco
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="Forretress">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="View Forretress on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" alt="Forretress" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Forretress
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="Dunsparce">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="View Dunsparce on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" alt="Dunsparce" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Dunsparce
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="Gligar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="View Gligar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" alt="Gligar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Gligar
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="Steelix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="View Steelix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" alt="Steelix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Steelix
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="Snubbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="View Snubbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" alt="Snubbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Snubbull
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="Granbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="View Granbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" alt="Granbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Granbull
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="Qwilfish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="View Qwilfish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" alt="Qwilfish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Qwilfish
@@ -2184,8 +2184,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="Scizor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="View Scizor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" alt="Scizor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">212</span>
                             Scizor
@@ -2194,8 +2194,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="Shuckle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="View Shuckle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" alt="Shuckle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">213</span>
                             Shuckle
@@ -2204,8 +2204,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="Heracross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="View Heracross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" alt="Heracross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">214</span>
                             Heracross
@@ -2214,8 +2214,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="Sneasel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="View Sneasel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" alt="Sneasel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">215</span>
                             Sneasel
@@ -2224,8 +2224,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="Teddiursa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="View Teddiursa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" alt="Teddiursa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">216</span>
                             Teddiursa
@@ -2234,8 +2234,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="Ursaring">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="View Ursaring on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" alt="Ursaring" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">217</span>
                             Ursaring
@@ -2244,8 +2244,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="Slugma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="View Slugma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" alt="Slugma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">218</span>
                             Slugma
@@ -2254,8 +2254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="Magcargo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="View Magcargo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" alt="Magcargo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">219</span>
                             Magcargo
@@ -2264,8 +2264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="Swinub">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="View Swinub on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" alt="Swinub" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">220</span>
                             Swinub
@@ -2274,8 +2274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="Piloswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="View Piloswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" alt="Piloswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">221</span>
                             Piloswine
@@ -2284,8 +2284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="Corsola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="View Corsola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" alt="Corsola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">222</span>
                             Corsola
@@ -2294,8 +2294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">223</span>
                             Remoraid
@@ -2304,8 +2304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">224</span>
                             Octillery
@@ -2314,8 +2314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="Delibird">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="View Delibird on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" alt="Delibird" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">225</span>
                             Delibird
@@ -2324,8 +2324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">226</span>
                             Mantine
@@ -2334,8 +2334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="Skarmory">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="View Skarmory on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" alt="Skarmory" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">227</span>
                             Skarmory
@@ -2344,8 +2344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="Houndour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="View Houndour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" alt="Houndour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">228</span>
                             Houndour
@@ -2354,8 +2354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="Houndoom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="View Houndoom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" alt="Houndoom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">229</span>
                             Houndoom
@@ -2364,8 +2364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="Kingdra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="View Kingdra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" alt="Kingdra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">230</span>
                             Kingdra
@@ -2374,8 +2374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="Phanpy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="View Phanpy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" alt="Phanpy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">231</span>
                             Phanpy
@@ -2384,8 +2384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="Donphan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="View Donphan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" alt="Donphan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">232</span>
                             Donphan
@@ -2394,8 +2394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="Porygon2">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="View Porygon2 on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" alt="Porygon2" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">233</span>
                             Porygon2
@@ -2404,8 +2404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="Stantler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="View Stantler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" alt="Stantler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">234</span>
                             Stantler
@@ -2414,8 +2414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="Smeargle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="View Smeargle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" alt="Smeargle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">235</span>
                             Smeargle
@@ -2424,8 +2424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="Tyrogue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="View Tyrogue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" alt="Tyrogue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">236</span>
                             Tyrogue
@@ -2434,8 +2434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="Hitmontop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="View Hitmontop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" alt="Hitmontop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">237</span>
                             Hitmontop
@@ -2444,8 +2444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="Smoochum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="View Smoochum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" alt="Smoochum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">238</span>
                             Smoochum
@@ -2454,8 +2454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="Elekid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="View Elekid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" alt="Elekid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">239</span>
                             Elekid
@@ -2464,8 +2464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="Magby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="View Magby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" alt="Magby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">240</span>
                             Magby
@@ -2481,8 +2481,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="Miltank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="View Miltank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" alt="Miltank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">241</span>
                             Miltank
@@ -2491,8 +2491,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="Blissey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="View Blissey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" alt="Blissey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">242</span>
                             Blissey
@@ -2501,8 +2501,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="Raikou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="View Raikou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" alt="Raikou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">243</span>
                             Raikou
@@ -2511,8 +2511,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="Entei">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="View Entei on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" alt="Entei" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">244</span>
                             Entei
@@ -2521,8 +2521,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="Suicune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="View Suicune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" alt="Suicune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">245</span>
                             Suicune
@@ -2531,8 +2531,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="Larvitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="View Larvitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" alt="Larvitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">246</span>
                             Larvitar
@@ -2541,8 +2541,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="Pupitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="View Pupitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" alt="Pupitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">247</span>
                             Pupitar
@@ -2551,8 +2551,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="Tyranitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="View Tyranitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" alt="Tyranitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">248</span>
                             Tyranitar
@@ -2561,8 +2561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="Lugia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="View Lugia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" alt="Lugia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">249</span>
                             Lugia
@@ -2571,8 +2571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="Ho-Oh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="View Ho-Oh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" alt="Ho-Oh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">250</span>
                             Ho-Oh
@@ -2581,8 +2581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="Celebi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="View Celebi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" alt="Celebi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">251</span>
                             Celebi
@@ -2596,8 +2596,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/heartgold-soulsilver.html
+++ b/docs/heartgold-soulsilver.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Bulbasaur
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Ivysaur
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Venusaur
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Charmander
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Charmeleon
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Charizard
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Squirtle
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Wartortle
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Blastoise
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Caterpie
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Metapod
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Butterfree
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="Weedle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="View Weedle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" alt="Weedle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Weedle
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="Kakuna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="View Kakuna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" alt="Kakuna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Kakuna
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="Beedrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="View Beedrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" alt="Beedrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Beedrill
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="Pidgey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="View Pidgey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" alt="Pidgey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Pidgey
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="Pidgeotto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="View Pidgeotto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" alt="Pidgeotto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Pidgeotto
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="Pidgeot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="View Pidgeot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" alt="Pidgeot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Pidgeot
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="Rattata">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="View Rattata on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" alt="Rattata" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Rattata
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="Raticate">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="View Raticate on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" alt="Raticate" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Raticate
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="Spearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="View Spearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" alt="Spearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Spearow
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="Fearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="View Fearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" alt="Fearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fearow
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="Ekans">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="View Ekans on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" alt="Ekans" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Ekans
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="Arbok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="View Arbok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" alt="Arbok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Arbok
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Pikachu
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Raichu
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Sandshrew
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Sandslash
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="Nidoran♀">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="View Nidoran♀ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" alt="Nidoran♀" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nidoran♀
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="Nidorina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="View Nidorina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" alt="Nidorina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Nidorina
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="Nidoqueen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="View Nidoqueen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" alt="Nidoqueen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Nidoqueen
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="Nidoran♂">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="View Nidoran♂ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" alt="Nidoran♂" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Nidoran♂
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="Nidorino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="View Nidorino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" alt="Nidorino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Nidorino
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="Nidoking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="View Nidoking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" alt="Nidoking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Nidoking
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Clefairy
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Clefable
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Vulpix
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ninetales
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Jigglypuff
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Wigglytuff
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="Zubat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="View Zubat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" alt="Zubat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Zubat
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="Golbat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="View Golbat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" alt="Golbat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Golbat
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Oddish
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Gloom
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Vileplume
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="Paras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="View Paras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" alt="Paras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Paras
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="Parasect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="View Parasect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" alt="Parasect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Parasect
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="Venonat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="View Venonat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" alt="Venonat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Venonat
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="Venomoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="View Venomoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" alt="Venomoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Venomoth
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Diglett
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Dugtrio
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Meowth
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Persian
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Psyduck
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Golduck
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="Mankey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="View Mankey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" alt="Mankey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Mankey
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="Primeape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="View Primeape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" alt="Primeape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Primeape
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Growlithe
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Arcanine
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Poliwag
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Poliwhirl
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Poliwrath
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Abra
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Kadabra
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Alakazam
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Machop
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Machoke
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Machamp
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="Bellsprout">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="View Bellsprout on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" alt="Bellsprout" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Bellsprout
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="Weepinbell">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="View Weepinbell on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" alt="Weepinbell" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Weepinbell
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="Victreebel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="View Victreebel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" alt="Victreebel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Victreebel
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Tentacool
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Tentacruel
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="Geodude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="View Geodude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" alt="Geodude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Geodude
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="Graveler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="View Graveler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" alt="Graveler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Graveler
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="Golem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="View Golem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" alt="Golem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Golem
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Ponyta
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Rapidash
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Slowpoke
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Slowbro
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Magnemite
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Magneton
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="Farfetch’d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="View Farfetch’d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch’d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Farfetch’d
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="Doduo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="View Doduo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" alt="Doduo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Doduo
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="Dodrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="View Dodrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" alt="Dodrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Dodrio
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="Seel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="View Seel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" alt="Seel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Seel
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="Dewgong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="View Dewgong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" alt="Dewgong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Dewgong
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="Grimer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="View Grimer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" alt="Grimer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Grimer
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="Muk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="View Muk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" alt="Muk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Muk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Shellder
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Cloyster
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Gastly
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Haunter
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Gengar
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Onix
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="Drowzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="View Drowzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" alt="Drowzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Drowzee
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="Hypno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="View Hypno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" alt="Hypno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Hypno
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="Voltorb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="View Voltorb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" alt="Voltorb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Voltorb
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="Electrode">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="View Electrode on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" alt="Electrode" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Electrode
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Exeggcute
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Exeggutor
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Cubone
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Marowak
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Hitmonlee
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Hitmonchan
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Lickitung
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Koffing
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Weezing
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Rhyhorn
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Rhydon
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Chansey
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Tangela
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Kangaskhan
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Horsea
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Seadra
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Goldeen
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Seaking
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Staryu
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Starmie
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Mr. Mime
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Scyther
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="Jynx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="View Jynx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" alt="Jynx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Jynx
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="Electabuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="View Electabuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" alt="Electabuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Electabuzz
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="Magmar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="View Magmar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" alt="Magmar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Magmar
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Pinsir
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Tauros
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Magikarp
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Gyarados
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Lapras
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Ditto
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Eevee
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Vaporeon
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Jolteon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Flareon
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Porygon
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="Omanyte">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="View Omanyte on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" alt="Omanyte" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Omanyte
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="Omastar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="View Omastar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" alt="Omastar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Omastar
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="Kabuto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="View Kabuto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" alt="Kabuto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Kabuto
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="Kabutops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="View Kabutops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" alt="Kabutops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Kabutops
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="Aerodactyl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="View Aerodactyl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" alt="Aerodactyl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Aerodactyl
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Snorlax
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="Articuno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="View Articuno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" alt="Articuno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Articuno
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="Zapdos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="View Zapdos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" alt="Zapdos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Zapdos
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="Moltres">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="View Moltres on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" alt="Moltres" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Moltres
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="Dratini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="View Dratini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" alt="Dratini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Dratini
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="Dragonair">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="View Dragonair on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" alt="Dragonair" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Dragonair
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="Dragonite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="View Dragonite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" alt="Dragonite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Dragonite
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="Mewtwo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="View Mewtwo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" alt="Mewtwo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Mewtwo
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="Mew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="View Mew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" alt="Mew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Mew
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="Chikorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="View Chikorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" alt="Chikorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Chikorita
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="Bayleef">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="View Bayleef on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" alt="Bayleef" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Bayleef
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="Meganium">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="View Meganium on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" alt="Meganium" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Meganium
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="Cyndaquil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="View Cyndaquil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" alt="Cyndaquil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Cyndaquil
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="Quilava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="View Quilava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" alt="Quilava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Quilava
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="Typhlosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="View Typhlosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" alt="Typhlosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Typhlosion
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="Totodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="View Totodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" alt="Totodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Totodile
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="Croconaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="View Croconaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" alt="Croconaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Croconaw
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="Feraligatr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="View Feraligatr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" alt="Feraligatr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Feraligatr
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="Sentret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="View Sentret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" alt="Sentret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Sentret
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="Furret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="View Furret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" alt="Furret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Furret
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="Hoothoot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="View Hoothoot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" alt="Hoothoot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Hoothoot
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="Noctowl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="View Noctowl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" alt="Noctowl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Noctowl
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="Ledyba">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="View Ledyba on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" alt="Ledyba" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Ledyba
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="Ledian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="View Ledian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" alt="Ledian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Ledian
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="Spinarak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="View Spinarak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" alt="Spinarak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Spinarak
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="Ariados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="View Ariados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" alt="Ariados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Ariados
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="Crobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="View Crobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" alt="Crobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Crobat
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Chinchou
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Lanturn
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Pichu
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="Cleffa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="View Cleffa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" alt="Cleffa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Cleffa
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="Igglybuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="View Igglybuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" alt="Igglybuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Igglybuff
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="Togepi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="View Togepi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" alt="Togepi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Togepi
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="Togetic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="View Togetic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" alt="Togetic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Togetic
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="Natu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="View Natu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" alt="Natu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Natu
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="Xatu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="View Xatu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" alt="Xatu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Xatu
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="Mareep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="View Mareep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" alt="Mareep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Mareep
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="Flaaffy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="View Flaaffy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" alt="Flaaffy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Flaaffy
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="Ampharos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="View Ampharos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" alt="Ampharos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Ampharos
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="Bellossom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="View Bellossom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" alt="Bellossom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Bellossom
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="Marill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="View Marill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" alt="Marill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Marill
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="Azumarill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="View Azumarill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" alt="Azumarill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Azumarill
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="Sudowoodo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="View Sudowoodo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" alt="Sudowoodo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Sudowoodo
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="Politoed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="View Politoed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" alt="Politoed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Politoed
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="Hoppip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="View Hoppip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" alt="Hoppip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Hoppip
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="Skiploom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="View Skiploom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" alt="Skiploom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Skiploom
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="Jumpluff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="View Jumpluff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" alt="Jumpluff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Jumpluff
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="Aipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="View Aipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" alt="Aipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Aipom
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="Sunkern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="View Sunkern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" alt="Sunkern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Sunkern
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="Sunflora">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="View Sunflora on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" alt="Sunflora" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Sunflora
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="Yanma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="View Yanma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" alt="Yanma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Yanma
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Wooper
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Quagsire
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="Espeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="View Espeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" alt="Espeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Espeon
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="Umbreon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="View Umbreon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" alt="Umbreon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Umbreon
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="Murkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="View Murkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" alt="Murkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Murkrow
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="Slowking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="View Slowking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" alt="Slowking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Slowking
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="Misdreavus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="View Misdreavus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" alt="Misdreavus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Misdreavus
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="Unown">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="View Unown on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" alt="Unown" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Unown
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="Wobbuffet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="View Wobbuffet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" alt="Wobbuffet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Wobbuffet
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="Girafarig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="View Girafarig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" alt="Girafarig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Girafarig
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="Pineco">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="View Pineco on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" alt="Pineco" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Pineco
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="Forretress">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="View Forretress on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" alt="Forretress" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Forretress
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="Dunsparce">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="View Dunsparce on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" alt="Dunsparce" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Dunsparce
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="Gligar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="View Gligar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" alt="Gligar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Gligar
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="Steelix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="View Steelix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" alt="Steelix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Steelix
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="Snubbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="View Snubbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" alt="Snubbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Snubbull
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="Granbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="View Granbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" alt="Granbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Granbull
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="Qwilfish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="View Qwilfish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" alt="Qwilfish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Qwilfish
@@ -2184,8 +2184,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="Scizor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="View Scizor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" alt="Scizor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">212</span>
                             Scizor
@@ -2194,8 +2194,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="Shuckle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="View Shuckle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" alt="Shuckle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">213</span>
                             Shuckle
@@ -2204,8 +2204,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="Heracross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="View Heracross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" alt="Heracross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">214</span>
                             Heracross
@@ -2214,8 +2214,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="Sneasel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="View Sneasel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" alt="Sneasel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">215</span>
                             Sneasel
@@ -2224,8 +2224,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="Teddiursa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="View Teddiursa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" alt="Teddiursa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">216</span>
                             Teddiursa
@@ -2234,8 +2234,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="Ursaring">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="View Ursaring on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" alt="Ursaring" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">217</span>
                             Ursaring
@@ -2244,8 +2244,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="Slugma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="View Slugma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" alt="Slugma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">218</span>
                             Slugma
@@ -2254,8 +2254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="Magcargo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="View Magcargo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" alt="Magcargo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">219</span>
                             Magcargo
@@ -2264,8 +2264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="Swinub">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="View Swinub on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" alt="Swinub" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">220</span>
                             Swinub
@@ -2274,8 +2274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="Piloswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="View Piloswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" alt="Piloswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">221</span>
                             Piloswine
@@ -2284,8 +2284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="Corsola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="View Corsola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" alt="Corsola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">222</span>
                             Corsola
@@ -2294,8 +2294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">223</span>
                             Remoraid
@@ -2304,8 +2304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">224</span>
                             Octillery
@@ -2314,8 +2314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="Delibird">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="View Delibird on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" alt="Delibird" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">225</span>
                             Delibird
@@ -2324,8 +2324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">226</span>
                             Mantine
@@ -2334,8 +2334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="Skarmory">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="View Skarmory on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" alt="Skarmory" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">227</span>
                             Skarmory
@@ -2344,8 +2344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="Houndour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="View Houndour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" alt="Houndour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">228</span>
                             Houndour
@@ -2354,8 +2354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="Houndoom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="View Houndoom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" alt="Houndoom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">229</span>
                             Houndoom
@@ -2364,8 +2364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="Kingdra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="View Kingdra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" alt="Kingdra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">230</span>
                             Kingdra
@@ -2374,8 +2374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="Phanpy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="View Phanpy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" alt="Phanpy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">231</span>
                             Phanpy
@@ -2384,8 +2384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="Donphan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="View Donphan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" alt="Donphan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">232</span>
                             Donphan
@@ -2394,8 +2394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="Porygon2">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="View Porygon2 on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" alt="Porygon2" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">233</span>
                             Porygon2
@@ -2404,8 +2404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="Stantler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="View Stantler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" alt="Stantler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">234</span>
                             Stantler
@@ -2414,8 +2414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="Smeargle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="View Smeargle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" alt="Smeargle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">235</span>
                             Smeargle
@@ -2424,8 +2424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="Tyrogue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="View Tyrogue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" alt="Tyrogue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">236</span>
                             Tyrogue
@@ -2434,8 +2434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="Hitmontop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="View Hitmontop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" alt="Hitmontop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">237</span>
                             Hitmontop
@@ -2444,8 +2444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="Smoochum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="View Smoochum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" alt="Smoochum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">238</span>
                             Smoochum
@@ -2454,8 +2454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="Elekid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="View Elekid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" alt="Elekid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">239</span>
                             Elekid
@@ -2464,8 +2464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="Magby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="View Magby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" alt="Magby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">240</span>
                             Magby
@@ -2481,8 +2481,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="Miltank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="View Miltank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" alt="Miltank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">241</span>
                             Miltank
@@ -2491,8 +2491,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="Blissey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="View Blissey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" alt="Blissey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">242</span>
                             Blissey
@@ -2501,8 +2501,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="Raikou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="View Raikou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" alt="Raikou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">243</span>
                             Raikou
@@ -2511,8 +2511,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="Entei">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="View Entei on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" alt="Entei" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">244</span>
                             Entei
@@ -2521,8 +2521,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="Suicune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="View Suicune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" alt="Suicune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">245</span>
                             Suicune
@@ -2531,8 +2531,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="Larvitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="View Larvitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" alt="Larvitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">246</span>
                             Larvitar
@@ -2541,8 +2541,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="Pupitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="View Pupitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" alt="Pupitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">247</span>
                             Pupitar
@@ -2551,8 +2551,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="Tyranitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="View Tyranitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" alt="Tyranitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">248</span>
                             Tyranitar
@@ -2561,8 +2561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="Lugia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="View Lugia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" alt="Lugia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">249</span>
                             Lugia
@@ -2571,8 +2571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="Ho-Oh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="View Ho-Oh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" alt="Ho-Oh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">250</span>
                             Ho-Oh
@@ -2581,8 +2581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="Celebi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="View Celebi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" alt="Celebi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">251</span>
                             Celebi
@@ -2591,8 +2591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="Treecko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="View Treecko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" alt="Treecko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">252</span>
                             Treecko
@@ -2601,8 +2601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="Grovyle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="View Grovyle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" alt="Grovyle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">253</span>
                             Grovyle
@@ -2611,8 +2611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="Sceptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="View Sceptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" alt="Sceptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">254</span>
                             Sceptile
@@ -2621,8 +2621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="Torchic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="View Torchic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" alt="Torchic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">255</span>
                             Torchic
@@ -2631,8 +2631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="Combusken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="View Combusken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" alt="Combusken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">256</span>
                             Combusken
@@ -2641,8 +2641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="Blaziken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="View Blaziken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" alt="Blaziken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">257</span>
                             Blaziken
@@ -2651,8 +2651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="Mudkip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="View Mudkip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" alt="Mudkip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">258</span>
                             Mudkip
@@ -2661,8 +2661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="Marshtomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="View Marshtomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" alt="Marshtomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">259</span>
                             Marshtomp
@@ -2671,8 +2671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="Swampert">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="View Swampert on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" alt="Swampert" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">260</span>
                             Swampert
@@ -2681,8 +2681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="Poochyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="View Poochyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" alt="Poochyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">261</span>
                             Poochyena
@@ -2691,8 +2691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="Mightyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="View Mightyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" alt="Mightyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">262</span>
                             Mightyena
@@ -2701,8 +2701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="Zigzagoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="View Zigzagoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" alt="Zigzagoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">263</span>
                             Zigzagoon
@@ -2711,8 +2711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="Linoone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="View Linoone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" alt="Linoone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">264</span>
                             Linoone
@@ -2721,8 +2721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="Wurmple">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="View Wurmple on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" alt="Wurmple" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">265</span>
                             Wurmple
@@ -2731,8 +2731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="Silcoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="View Silcoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" alt="Silcoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">266</span>
                             Silcoon
@@ -2741,8 +2741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="Beautifly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="View Beautifly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" alt="Beautifly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">267</span>
                             Beautifly
@@ -2751,8 +2751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="Cascoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="View Cascoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" alt="Cascoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">268</span>
                             Cascoon
@@ -2761,8 +2761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="Dustox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="View Dustox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" alt="Dustox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">269</span>
                             Dustox
@@ -2771,8 +2771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="Lotad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="View Lotad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" alt="Lotad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">270</span>
                             Lotad
@@ -2788,8 +2788,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="Lombre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="View Lombre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" alt="Lombre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">271</span>
                             Lombre
@@ -2798,8 +2798,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="Ludicolo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="View Ludicolo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" alt="Ludicolo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">272</span>
                             Ludicolo
@@ -2808,8 +2808,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="Seedot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="View Seedot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" alt="Seedot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">273</span>
                             Seedot
@@ -2818,8 +2818,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="Nuzleaf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="View Nuzleaf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" alt="Nuzleaf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">274</span>
                             Nuzleaf
@@ -2828,8 +2828,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="Shiftry">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="View Shiftry on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" alt="Shiftry" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">275</span>
                             Shiftry
@@ -2838,8 +2838,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="Taillow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="View Taillow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" alt="Taillow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">276</span>
                             Taillow
@@ -2848,8 +2848,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="Swellow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="View Swellow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" alt="Swellow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">277</span>
                             Swellow
@@ -2858,8 +2858,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="Wingull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="View Wingull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" alt="Wingull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">278</span>
                             Wingull
@@ -2868,8 +2868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="Pelipper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="View Pelipper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" alt="Pelipper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">279</span>
                             Pelipper
@@ -2878,8 +2878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="Ralts">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="View Ralts on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" alt="Ralts" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">280</span>
                             Ralts
@@ -2888,8 +2888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="Kirlia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="View Kirlia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" alt="Kirlia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">281</span>
                             Kirlia
@@ -2898,8 +2898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="Gardevoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="View Gardevoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" alt="Gardevoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">282</span>
                             Gardevoir
@@ -2908,8 +2908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="Surskit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="View Surskit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" alt="Surskit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">283</span>
                             Surskit
@@ -2918,8 +2918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="Masquerain">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="View Masquerain on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" alt="Masquerain" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">284</span>
                             Masquerain
@@ -2928,8 +2928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="Shroomish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="View Shroomish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" alt="Shroomish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">285</span>
                             Shroomish
@@ -2938,8 +2938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="Breloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="View Breloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" alt="Breloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">286</span>
                             Breloom
@@ -2948,8 +2948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="Slakoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="View Slakoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" alt="Slakoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">287</span>
                             Slakoth
@@ -2958,8 +2958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="Vigoroth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="View Vigoroth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" alt="Vigoroth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">288</span>
                             Vigoroth
@@ -2968,8 +2968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="Slaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="View Slaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" alt="Slaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">289</span>
                             Slaking
@@ -2978,8 +2978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="Nincada">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="View Nincada on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" alt="Nincada" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">290</span>
                             Nincada
@@ -2988,8 +2988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="Ninjask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="View Ninjask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" alt="Ninjask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">291</span>
                             Ninjask
@@ -2998,8 +2998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="Shedinja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="View Shedinja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" alt="Shedinja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">292</span>
                             Shedinja
@@ -3008,8 +3008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="Whismur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="View Whismur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" alt="Whismur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">293</span>
                             Whismur
@@ -3018,8 +3018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="Loudred">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="View Loudred on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" alt="Loudred" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">294</span>
                             Loudred
@@ -3028,8 +3028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="Exploud">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="View Exploud on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" alt="Exploud" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">295</span>
                             Exploud
@@ -3038,8 +3038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="Makuhita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="View Makuhita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" alt="Makuhita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">296</span>
                             Makuhita
@@ -3048,8 +3048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="Hariyama">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="View Hariyama on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" alt="Hariyama" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">297</span>
                             Hariyama
@@ -3058,8 +3058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="Azurill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="View Azurill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" alt="Azurill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">298</span>
                             Azurill
@@ -3068,8 +3068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="Nosepass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="View Nosepass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" alt="Nosepass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">299</span>
                             Nosepass
@@ -3078,8 +3078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="Skitty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="View Skitty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" alt="Skitty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">300</span>
                             Skitty
@@ -3095,8 +3095,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="Delcatty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="View Delcatty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" alt="Delcatty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">301</span>
                             Delcatty
@@ -3105,8 +3105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="Sableye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="View Sableye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" alt="Sableye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">302</span>
                             Sableye
@@ -3115,8 +3115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="Mawile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="View Mawile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" alt="Mawile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">303</span>
                             Mawile
@@ -3125,8 +3125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="Aron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="View Aron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" alt="Aron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">304</span>
                             Aron
@@ -3135,8 +3135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="Lairon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="View Lairon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" alt="Lairon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">305</span>
                             Lairon
@@ -3145,8 +3145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="Aggron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="View Aggron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" alt="Aggron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">306</span>
                             Aggron
@@ -3155,8 +3155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="Meditite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="View Meditite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" alt="Meditite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">307</span>
                             Meditite
@@ -3165,8 +3165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="Medicham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="View Medicham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" alt="Medicham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">308</span>
                             Medicham
@@ -3175,8 +3175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="Electrike">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="View Electrike on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" alt="Electrike" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">309</span>
                             Electrike
@@ -3185,8 +3185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="Manectric">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="View Manectric on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" alt="Manectric" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">310</span>
                             Manectric
@@ -3195,8 +3195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="Plusle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="View Plusle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" alt="Plusle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">311</span>
                             Plusle
@@ -3205,8 +3205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="Minun">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="View Minun on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" alt="Minun" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">312</span>
                             Minun
@@ -3215,8 +3215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="Volbeat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="View Volbeat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" alt="Volbeat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">313</span>
                             Volbeat
@@ -3225,8 +3225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="Illumise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="View Illumise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" alt="Illumise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">314</span>
                             Illumise
@@ -3235,8 +3235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="Roselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="View Roselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" alt="Roselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">315</span>
                             Roselia
@@ -3245,8 +3245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="Gulpin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="View Gulpin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" alt="Gulpin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">316</span>
                             Gulpin
@@ -3255,8 +3255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="Swalot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="View Swalot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" alt="Swalot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">317</span>
                             Swalot
@@ -3265,8 +3265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="Carvanha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="View Carvanha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" alt="Carvanha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">318</span>
                             Carvanha
@@ -3275,8 +3275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="Sharpedo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="View Sharpedo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" alt="Sharpedo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">319</span>
                             Sharpedo
@@ -3285,8 +3285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="Wailmer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="View Wailmer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" alt="Wailmer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">320</span>
                             Wailmer
@@ -3295,8 +3295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="Wailord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="View Wailord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" alt="Wailord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">321</span>
                             Wailord
@@ -3305,8 +3305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="Numel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="View Numel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" alt="Numel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">322</span>
                             Numel
@@ -3315,8 +3315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="Camerupt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="View Camerupt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" alt="Camerupt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">323</span>
                             Camerupt
@@ -3325,8 +3325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="Torkoal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="View Torkoal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" alt="Torkoal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">324</span>
                             Torkoal
@@ -3335,8 +3335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="Spoink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="View Spoink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" alt="Spoink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">325</span>
                             Spoink
@@ -3345,8 +3345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="Grumpig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="View Grumpig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" alt="Grumpig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">326</span>
                             Grumpig
@@ -3355,8 +3355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="Spinda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="View Spinda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" alt="Spinda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">327</span>
                             Spinda
@@ -3365,8 +3365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="Trapinch">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="View Trapinch on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" alt="Trapinch" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">328</span>
                             Trapinch
@@ -3375,8 +3375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="Vibrava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="View Vibrava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" alt="Vibrava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">329</span>
                             Vibrava
@@ -3385,8 +3385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="Flygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="View Flygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" alt="Flygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">330</span>
                             Flygon
@@ -3402,8 +3402,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="Cacnea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="View Cacnea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" alt="Cacnea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">331</span>
                             Cacnea
@@ -3412,8 +3412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="Cacturne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="View Cacturne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" alt="Cacturne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">332</span>
                             Cacturne
@@ -3422,8 +3422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="Swablu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="View Swablu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" alt="Swablu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">333</span>
                             Swablu
@@ -3432,8 +3432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="Altaria">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="View Altaria on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" alt="Altaria" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">334</span>
                             Altaria
@@ -3442,8 +3442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="Zangoose">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="View Zangoose on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" alt="Zangoose" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">335</span>
                             Zangoose
@@ -3452,8 +3452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="Seviper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="View Seviper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" alt="Seviper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">336</span>
                             Seviper
@@ -3462,8 +3462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="Lunatone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="View Lunatone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" alt="Lunatone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">337</span>
                             Lunatone
@@ -3472,8 +3472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="Solrock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="View Solrock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" alt="Solrock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">338</span>
                             Solrock
@@ -3482,8 +3482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="Barboach">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="View Barboach on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" alt="Barboach" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">339</span>
                             Barboach
@@ -3492,8 +3492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="Whiscash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="View Whiscash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" alt="Whiscash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">340</span>
                             Whiscash
@@ -3502,8 +3502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="Corphish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="View Corphish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" alt="Corphish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">341</span>
                             Corphish
@@ -3512,8 +3512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="Crawdaunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="View Crawdaunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" alt="Crawdaunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">342</span>
                             Crawdaunt
@@ -3522,8 +3522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="Baltoy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="View Baltoy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" alt="Baltoy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">343</span>
                             Baltoy
@@ -3532,8 +3532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="Claydol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="View Claydol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" alt="Claydol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">344</span>
                             Claydol
@@ -3542,8 +3542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="Lileep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="View Lileep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" alt="Lileep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">345</span>
                             Lileep
@@ -3552,8 +3552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="Cradily">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="View Cradily on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" alt="Cradily" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">346</span>
                             Cradily
@@ -3562,8 +3562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="Anorith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="View Anorith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" alt="Anorith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">347</span>
                             Anorith
@@ -3572,8 +3572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="Armaldo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="View Armaldo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" alt="Armaldo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">348</span>
                             Armaldo
@@ -3582,8 +3582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="Feebas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="View Feebas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" alt="Feebas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">349</span>
                             Feebas
@@ -3592,8 +3592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="Milotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="View Milotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" alt="Milotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">350</span>
                             Milotic
@@ -3602,8 +3602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="Castform">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="View Castform on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" alt="Castform" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">351</span>
                             Castform
@@ -3612,8 +3612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="Kecleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="View Kecleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" alt="Kecleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">352</span>
                             Kecleon
@@ -3622,8 +3622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="Shuppet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="View Shuppet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" alt="Shuppet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">353</span>
                             Shuppet
@@ -3632,8 +3632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="Banette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="View Banette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" alt="Banette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">354</span>
                             Banette
@@ -3642,8 +3642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="Duskull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="View Duskull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" alt="Duskull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">355</span>
                             Duskull
@@ -3652,8 +3652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="Dusclops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="View Dusclops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" alt="Dusclops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">356</span>
                             Dusclops
@@ -3662,8 +3662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="Tropius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="View Tropius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" alt="Tropius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">357</span>
                             Tropius
@@ -3672,8 +3672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="Chimecho">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="View Chimecho on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" alt="Chimecho" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">358</span>
                             Chimecho
@@ -3682,8 +3682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="Absol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="View Absol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" alt="Absol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">359</span>
                             Absol
@@ -3692,8 +3692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="Wynaut">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="View Wynaut on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" alt="Wynaut" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">360</span>
                             Wynaut
@@ -3709,8 +3709,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="Snorunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="View Snorunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" alt="Snorunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">361</span>
                             Snorunt
@@ -3719,8 +3719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="Glalie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="View Glalie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" alt="Glalie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">362</span>
                             Glalie
@@ -3729,8 +3729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="Spheal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="View Spheal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" alt="Spheal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">363</span>
                             Spheal
@@ -3739,8 +3739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="Sealeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="View Sealeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" alt="Sealeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">364</span>
                             Sealeo
@@ -3749,8 +3749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="Walrein">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="View Walrein on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" alt="Walrein" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">365</span>
                             Walrein
@@ -3759,8 +3759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="Clamperl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="View Clamperl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" alt="Clamperl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">366</span>
                             Clamperl
@@ -3769,8 +3769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="Huntail">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="View Huntail on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" alt="Huntail" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">367</span>
                             Huntail
@@ -3779,8 +3779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="Gorebyss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="View Gorebyss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" alt="Gorebyss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">368</span>
                             Gorebyss
@@ -3789,8 +3789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="Relicanth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="View Relicanth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" alt="Relicanth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">369</span>
                             Relicanth
@@ -3799,8 +3799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="Luvdisc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="View Luvdisc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" alt="Luvdisc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">370</span>
                             Luvdisc
@@ -3809,8 +3809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="Bagon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="View Bagon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" alt="Bagon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">371</span>
                             Bagon
@@ -3819,8 +3819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="Shelgon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="View Shelgon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" alt="Shelgon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">372</span>
                             Shelgon
@@ -3829,8 +3829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="Salamence">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="View Salamence on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" alt="Salamence" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">373</span>
                             Salamence
@@ -3839,8 +3839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="Beldum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="View Beldum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" alt="Beldum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">374</span>
                             Beldum
@@ -3849,8 +3849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="Metang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="View Metang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" alt="Metang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">375</span>
                             Metang
@@ -3859,8 +3859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="Metagross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="View Metagross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" alt="Metagross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">376</span>
                             Metagross
@@ -3869,8 +3869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="Regirock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="View Regirock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" alt="Regirock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">377</span>
                             Regirock
@@ -3879,8 +3879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="Regice">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="View Regice on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" alt="Regice" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">378</span>
                             Regice
@@ -3889,8 +3889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="Registeel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="View Registeel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" alt="Registeel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">379</span>
                             Registeel
@@ -3899,8 +3899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="Latias">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="View Latias on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" alt="Latias" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">380</span>
                             Latias
@@ -3909,8 +3909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="Latios">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="View Latios on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" alt="Latios" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">381</span>
                             Latios
@@ -3919,8 +3919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="Kyogre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="View Kyogre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" alt="Kyogre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">382</span>
                             Kyogre
@@ -3929,8 +3929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="Groudon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="View Groudon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" alt="Groudon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">383</span>
                             Groudon
@@ -3939,8 +3939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="Rayquaza">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="View Rayquaza on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" alt="Rayquaza" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">384</span>
                             Rayquaza
@@ -3949,8 +3949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="Jirachi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="View Jirachi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" alt="Jirachi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">385</span>
                             Jirachi
@@ -3959,8 +3959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="Deoxys">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="View Deoxys on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" alt="Deoxys" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">386</span>
                             Deoxys
@@ -3969,8 +3969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="Turtwig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="View Turtwig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" alt="Turtwig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">387</span>
                             Turtwig
@@ -3979,8 +3979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="Grotle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="View Grotle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" alt="Grotle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">388</span>
                             Grotle
@@ -3989,8 +3989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="Torterra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="View Torterra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" alt="Torterra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">389</span>
                             Torterra
@@ -3999,8 +3999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="Chimchar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="View Chimchar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" alt="Chimchar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">390</span>
                             Chimchar
@@ -4016,8 +4016,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="Monferno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="View Monferno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" alt="Monferno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">391</span>
                             Monferno
@@ -4026,8 +4026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="Infernape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="View Infernape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" alt="Infernape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">392</span>
                             Infernape
@@ -4036,8 +4036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="Piplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="View Piplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" alt="Piplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">393</span>
                             Piplup
@@ -4046,8 +4046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="Prinplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="View Prinplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" alt="Prinplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">394</span>
                             Prinplup
@@ -4056,8 +4056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="Empoleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="View Empoleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" alt="Empoleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">395</span>
                             Empoleon
@@ -4066,8 +4066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="Starly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="View Starly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" alt="Starly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">396</span>
                             Starly
@@ -4076,8 +4076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="Staravia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="View Staravia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" alt="Staravia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">397</span>
                             Staravia
@@ -4086,8 +4086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="Staraptor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="View Staraptor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" alt="Staraptor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">398</span>
                             Staraptor
@@ -4096,8 +4096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="Bidoof">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="View Bidoof on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" alt="Bidoof" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">399</span>
                             Bidoof
@@ -4106,8 +4106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="Bibarel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="View Bibarel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" alt="Bibarel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">400</span>
                             Bibarel
@@ -4116,8 +4116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="Kricketot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="View Kricketot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" alt="Kricketot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">401</span>
                             Kricketot
@@ -4126,8 +4126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="Kricketune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="View Kricketune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" alt="Kricketune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">402</span>
                             Kricketune
@@ -4136,8 +4136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="Shinx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="View Shinx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" alt="Shinx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">403</span>
                             Shinx
@@ -4146,8 +4146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="Luxio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="View Luxio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" alt="Luxio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">404</span>
                             Luxio
@@ -4156,8 +4156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="Luxray">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="View Luxray on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" alt="Luxray" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">405</span>
                             Luxray
@@ -4166,8 +4166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="Budew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="View Budew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" alt="Budew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">406</span>
                             Budew
@@ -4176,8 +4176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="Roserade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="View Roserade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" alt="Roserade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">407</span>
                             Roserade
@@ -4186,8 +4186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="Cranidos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="View Cranidos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" alt="Cranidos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">408</span>
                             Cranidos
@@ -4196,8 +4196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="Rampardos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="View Rampardos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" alt="Rampardos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">409</span>
                             Rampardos
@@ -4206,8 +4206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="Shieldon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="View Shieldon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" alt="Shieldon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">410</span>
                             Shieldon
@@ -4216,8 +4216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="Bastiodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="View Bastiodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" alt="Bastiodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">411</span>
                             Bastiodon
@@ -4226,8 +4226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="Burmy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="View Burmy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" alt="Burmy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">412</span>
                             Burmy
@@ -4236,8 +4236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="Wormadam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="View Wormadam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" alt="Wormadam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">413</span>
                             Wormadam
@@ -4246,8 +4246,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="Mothim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="View Mothim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" alt="Mothim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">414</span>
                             Mothim
@@ -4256,8 +4256,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="Combee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="View Combee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" alt="Combee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">415</span>
                             Combee
@@ -4266,8 +4266,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="Vespiquen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="View Vespiquen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" alt="Vespiquen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">416</span>
                             Vespiquen
@@ -4276,8 +4276,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="Pachirisu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="View Pachirisu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" alt="Pachirisu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">417</span>
                             Pachirisu
@@ -4286,8 +4286,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="Buizel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="View Buizel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" alt="Buizel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">418</span>
                             Buizel
@@ -4296,8 +4296,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="Floatzel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="View Floatzel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" alt="Floatzel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">419</span>
                             Floatzel
@@ -4306,8 +4306,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="Cherubi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="View Cherubi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" alt="Cherubi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">420</span>
                             Cherubi
@@ -4323,8 +4323,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="Cherrim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="View Cherrim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" alt="Cherrim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">421</span>
                             Cherrim
@@ -4333,8 +4333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="Shellos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="View Shellos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" alt="Shellos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">422</span>
                             Shellos
@@ -4343,8 +4343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="Gastrodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="View Gastrodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" alt="Gastrodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">423</span>
                             Gastrodon
@@ -4353,8 +4353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="Ambipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="View Ambipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" alt="Ambipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">424</span>
                             Ambipom
@@ -4363,8 +4363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="Drifloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="View Drifloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" alt="Drifloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">425</span>
                             Drifloon
@@ -4373,8 +4373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="Drifblim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="View Drifblim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" alt="Drifblim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">426</span>
                             Drifblim
@@ -4383,8 +4383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="Buneary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="View Buneary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" alt="Buneary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">427</span>
                             Buneary
@@ -4393,8 +4393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="Lopunny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="View Lopunny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" alt="Lopunny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">428</span>
                             Lopunny
@@ -4403,8 +4403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="Mismagius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="View Mismagius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" alt="Mismagius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">429</span>
                             Mismagius
@@ -4413,8 +4413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="Honchkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="View Honchkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" alt="Honchkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">430</span>
                             Honchkrow
@@ -4423,8 +4423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="Glameow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="View Glameow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" alt="Glameow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">431</span>
                             Glameow
@@ -4433,8 +4433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="Purugly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="View Purugly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" alt="Purugly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">432</span>
                             Purugly
@@ -4443,8 +4443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="Chingling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="View Chingling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" alt="Chingling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">433</span>
                             Chingling
@@ -4453,8 +4453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="Stunky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="View Stunky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" alt="Stunky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">434</span>
                             Stunky
@@ -4463,8 +4463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="Skuntank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="View Skuntank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" alt="Skuntank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">435</span>
                             Skuntank
@@ -4473,8 +4473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="Bronzor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="View Bronzor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" alt="Bronzor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">436</span>
                             Bronzor
@@ -4483,8 +4483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="Bronzong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="View Bronzong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" alt="Bronzong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">437</span>
                             Bronzong
@@ -4493,8 +4493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="Bonsly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="View Bonsly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" alt="Bonsly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">438</span>
                             Bonsly
@@ -4503,8 +4503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="Mime Jr.">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="View Mime Jr. on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" alt="Mime Jr." loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">439</span>
                             Mime Jr.
@@ -4513,8 +4513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="Happiny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="View Happiny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" alt="Happiny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">440</span>
                             Happiny
@@ -4523,8 +4523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="Chatot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="View Chatot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" alt="Chatot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">441</span>
                             Chatot
@@ -4533,8 +4533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="Spiritomb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="View Spiritomb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" alt="Spiritomb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">442</span>
                             Spiritomb
@@ -4543,8 +4543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="Gible">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="View Gible on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" alt="Gible" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">443</span>
                             Gible
@@ -4553,8 +4553,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="Gabite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="View Gabite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" alt="Gabite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">444</span>
                             Gabite
@@ -4563,8 +4563,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="Garchomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="View Garchomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" alt="Garchomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">445</span>
                             Garchomp
@@ -4573,8 +4573,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="Munchlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="View Munchlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" alt="Munchlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">446</span>
                             Munchlax
@@ -4583,8 +4583,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="Riolu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="View Riolu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" alt="Riolu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">447</span>
                             Riolu
@@ -4593,8 +4593,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="Lucario">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="View Lucario on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" alt="Lucario" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">448</span>
                             Lucario
@@ -4603,8 +4603,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="Hippopotas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="View Hippopotas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" alt="Hippopotas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">449</span>
                             Hippopotas
@@ -4613,8 +4613,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="Hippowdon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="View Hippowdon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" alt="Hippowdon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">450</span>
                             Hippowdon
@@ -4630,8 +4630,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="Skorupi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="View Skorupi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" alt="Skorupi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">451</span>
                             Skorupi
@@ -4640,8 +4640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="Drapion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="View Drapion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" alt="Drapion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">452</span>
                             Drapion
@@ -4650,8 +4650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="Croagunk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="View Croagunk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" alt="Croagunk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">453</span>
                             Croagunk
@@ -4660,8 +4660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="Toxicroak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="View Toxicroak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" alt="Toxicroak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">454</span>
                             Toxicroak
@@ -4670,8 +4670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="Carnivine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="View Carnivine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" alt="Carnivine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">455</span>
                             Carnivine
@@ -4680,8 +4680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="Finneon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="View Finneon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" alt="Finneon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">456</span>
                             Finneon
@@ -4690,8 +4690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="Lumineon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="View Lumineon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" alt="Lumineon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">457</span>
                             Lumineon
@@ -4700,8 +4700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="Mantyke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="View Mantyke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" alt="Mantyke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">458</span>
                             Mantyke
@@ -4710,8 +4710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="Snover">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="View Snover on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" alt="Snover" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">459</span>
                             Snover
@@ -4720,8 +4720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="Abomasnow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="View Abomasnow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" alt="Abomasnow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">460</span>
                             Abomasnow
@@ -4730,8 +4730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="Weavile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="View Weavile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" alt="Weavile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">461</span>
                             Weavile
@@ -4740,8 +4740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="Magnezone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="View Magnezone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" alt="Magnezone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">462</span>
                             Magnezone
@@ -4750,8 +4750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="Lickilicky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="View Lickilicky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" alt="Lickilicky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">463</span>
                             Lickilicky
@@ -4760,8 +4760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="Rhyperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="View Rhyperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" alt="Rhyperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">464</span>
                             Rhyperior
@@ -4770,8 +4770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="Tangrowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="View Tangrowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" alt="Tangrowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">465</span>
                             Tangrowth
@@ -4780,8 +4780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="Electivire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="View Electivire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" alt="Electivire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">466</span>
                             Electivire
@@ -4790,8 +4790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="Magmortar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="View Magmortar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" alt="Magmortar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">467</span>
                             Magmortar
@@ -4800,8 +4800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="Togekiss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="View Togekiss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" alt="Togekiss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">468</span>
                             Togekiss
@@ -4810,8 +4810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="Yanmega">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="View Yanmega on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" alt="Yanmega" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">469</span>
                             Yanmega
@@ -4820,8 +4820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="Leafeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="View Leafeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" alt="Leafeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">470</span>
                             Leafeon
@@ -4830,8 +4830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="Glaceon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="View Glaceon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" alt="Glaceon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">471</span>
                             Glaceon
@@ -4840,8 +4840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="Gliscor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="View Gliscor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" alt="Gliscor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">472</span>
                             Gliscor
@@ -4850,8 +4850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="Mamoswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="View Mamoswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" alt="Mamoswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">473</span>
                             Mamoswine
@@ -4860,8 +4860,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="Porygon-Z">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="View Porygon-Z on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" alt="Porygon-Z" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">474</span>
                             Porygon-Z
@@ -4870,8 +4870,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="Gallade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="View Gallade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" alt="Gallade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">475</span>
                             Gallade
@@ -4880,8 +4880,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="Probopass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="View Probopass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" alt="Probopass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">476</span>
                             Probopass
@@ -4890,8 +4890,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="Dusknoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="View Dusknoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" alt="Dusknoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">477</span>
                             Dusknoir
@@ -4900,8 +4900,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="Froslass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="View Froslass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" alt="Froslass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">478</span>
                             Froslass
@@ -4910,8 +4910,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="Rotom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="View Rotom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" alt="Rotom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">479</span>
                             Rotom
@@ -4920,8 +4920,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="Uxie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="View Uxie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" alt="Uxie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">480</span>
                             Uxie
@@ -4937,8 +4937,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="Mesprit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="View Mesprit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" alt="Mesprit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">481</span>
                             Mesprit
@@ -4947,8 +4947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="Azelf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="View Azelf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" alt="Azelf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">482</span>
                             Azelf
@@ -4957,8 +4957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="Dialga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="View Dialga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" alt="Dialga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">483</span>
                             Dialga
@@ -4967,8 +4967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="Palkia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="View Palkia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" alt="Palkia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">484</span>
                             Palkia
@@ -4977,8 +4977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="Heatran">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="View Heatran on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" alt="Heatran" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">485</span>
                             Heatran
@@ -4987,8 +4987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="Regigigas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="View Regigigas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" alt="Regigigas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">486</span>
                             Regigigas
@@ -4997,8 +4997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="Giratina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="View Giratina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" alt="Giratina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">487</span>
                             Giratina
@@ -5007,8 +5007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="Cresselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="View Cresselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" alt="Cresselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">488</span>
                             Cresselia
@@ -5017,8 +5017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="Phione">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="View Phione on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" alt="Phione" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">489</span>
                             Phione
@@ -5027,8 +5027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="Manaphy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="View Manaphy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" alt="Manaphy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">490</span>
                             Manaphy
@@ -5042,8 +5042,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/index.html
+++ b/docs/index.html
@@ -154,8 +154,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/omega-ruby-alpha-sapphire.html
+++ b/docs/omega-ruby-alpha-sapphire.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Bulbasaur
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Ivysaur
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Venusaur
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Charmander
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Charmeleon
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Charizard
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Squirtle
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Wartortle
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Blastoise
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Caterpie
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Metapod
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Butterfree
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="Weedle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="View Weedle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" alt="Weedle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Weedle
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="Kakuna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="View Kakuna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" alt="Kakuna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Kakuna
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="Beedrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="View Beedrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" alt="Beedrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Beedrill
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="Pidgey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="View Pidgey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" alt="Pidgey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Pidgey
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="Pidgeotto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="View Pidgeotto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" alt="Pidgeotto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Pidgeotto
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="Pidgeot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="View Pidgeot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" alt="Pidgeot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Pidgeot
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="Rattata">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="View Rattata on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" alt="Rattata" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Rattata
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="Raticate">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="View Raticate on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" alt="Raticate" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Raticate
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="Spearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="View Spearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" alt="Spearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Spearow
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="Fearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="View Fearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" alt="Fearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fearow
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="Ekans">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="View Ekans on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" alt="Ekans" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Ekans
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="Arbok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="View Arbok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" alt="Arbok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Arbok
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Pikachu
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Raichu
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Sandshrew
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Sandslash
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="Nidoran♀">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="View Nidoran♀ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" alt="Nidoran♀" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nidoran♀
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="Nidorina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="View Nidorina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" alt="Nidorina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Nidorina
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="Nidoqueen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="View Nidoqueen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" alt="Nidoqueen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Nidoqueen
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="Nidoran♂">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="View Nidoran♂ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" alt="Nidoran♂" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Nidoran♂
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="Nidorino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="View Nidorino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" alt="Nidorino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Nidorino
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="Nidoking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="View Nidoking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" alt="Nidoking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Nidoking
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Clefairy
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Clefable
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Vulpix
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ninetales
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Jigglypuff
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Wigglytuff
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="Zubat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="View Zubat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" alt="Zubat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Zubat
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="Golbat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="View Golbat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" alt="Golbat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Golbat
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Oddish
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Gloom
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Vileplume
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="Paras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="View Paras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" alt="Paras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Paras
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="Parasect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="View Parasect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" alt="Parasect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Parasect
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="Venonat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="View Venonat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" alt="Venonat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Venonat
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="Venomoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="View Venomoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" alt="Venomoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Venomoth
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Diglett
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Dugtrio
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Meowth
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Persian
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Psyduck
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Golduck
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="Mankey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="View Mankey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" alt="Mankey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Mankey
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="Primeape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="View Primeape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" alt="Primeape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Primeape
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Growlithe
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Arcanine
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Poliwag
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Poliwhirl
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Poliwrath
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Abra
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Kadabra
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Alakazam
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Machop
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Machoke
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Machamp
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="Bellsprout">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="View Bellsprout on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" alt="Bellsprout" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Bellsprout
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="Weepinbell">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="View Weepinbell on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" alt="Weepinbell" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Weepinbell
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="Victreebel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="View Victreebel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" alt="Victreebel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Victreebel
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Tentacool
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Tentacruel
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="Geodude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="View Geodude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" alt="Geodude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Geodude
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="Graveler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="View Graveler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" alt="Graveler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Graveler
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="Golem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="View Golem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" alt="Golem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Golem
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Ponyta
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Rapidash
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Slowpoke
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Slowbro
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Magnemite
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Magneton
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="Farfetch’d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="View Farfetch’d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch’d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Farfetch’d
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="Doduo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="View Doduo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" alt="Doduo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Doduo
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="Dodrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="View Dodrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" alt="Dodrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Dodrio
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="Seel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="View Seel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" alt="Seel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Seel
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="Dewgong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="View Dewgong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" alt="Dewgong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Dewgong
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="Grimer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="View Grimer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" alt="Grimer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Grimer
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="Muk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="View Muk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" alt="Muk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Muk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Shellder
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Cloyster
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Gastly
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Haunter
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Gengar
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Onix
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="Drowzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="View Drowzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" alt="Drowzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Drowzee
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="Hypno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="View Hypno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" alt="Hypno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Hypno
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="Voltorb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="View Voltorb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" alt="Voltorb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Voltorb
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="Electrode">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="View Electrode on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" alt="Electrode" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Electrode
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Exeggcute
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Exeggutor
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Cubone
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Marowak
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Hitmonlee
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Hitmonchan
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Lickitung
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Koffing
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Weezing
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Rhyhorn
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Rhydon
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Chansey
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Tangela
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Kangaskhan
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Horsea
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Seadra
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Goldeen
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Seaking
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Staryu
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Starmie
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Mr. Mime
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Scyther
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="Jynx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="View Jynx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" alt="Jynx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Jynx
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="Electabuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="View Electabuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" alt="Electabuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Electabuzz
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="Magmar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="View Magmar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" alt="Magmar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Magmar
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Pinsir
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Tauros
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Magikarp
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Gyarados
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Lapras
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Ditto
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Eevee
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Vaporeon
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Jolteon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Flareon
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Porygon
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="Omanyte">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="View Omanyte on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" alt="Omanyte" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Omanyte
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="Omastar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="View Omastar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" alt="Omastar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Omastar
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="Kabuto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="View Kabuto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" alt="Kabuto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Kabuto
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="Kabutops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="View Kabutops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" alt="Kabutops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Kabutops
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="Aerodactyl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="View Aerodactyl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" alt="Aerodactyl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Aerodactyl
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Snorlax
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="Articuno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="View Articuno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" alt="Articuno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Articuno
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="Zapdos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="View Zapdos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" alt="Zapdos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Zapdos
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="Moltres">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="View Moltres on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" alt="Moltres" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Moltres
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="Dratini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="View Dratini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" alt="Dratini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Dratini
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="Dragonair">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="View Dragonair on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" alt="Dragonair" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Dragonair
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="Dragonite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="View Dragonite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" alt="Dragonite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Dragonite
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="Mewtwo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="View Mewtwo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" alt="Mewtwo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Mewtwo
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="Mew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="View Mew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" alt="Mew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Mew
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="Chikorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="View Chikorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" alt="Chikorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Chikorita
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="Bayleef">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="View Bayleef on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" alt="Bayleef" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Bayleef
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="Meganium">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="View Meganium on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" alt="Meganium" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Meganium
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="Cyndaquil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="View Cyndaquil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" alt="Cyndaquil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Cyndaquil
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="Quilava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="View Quilava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" alt="Quilava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Quilava
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="Typhlosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="View Typhlosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" alt="Typhlosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Typhlosion
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="Totodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="View Totodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" alt="Totodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Totodile
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="Croconaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="View Croconaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" alt="Croconaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Croconaw
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="Feraligatr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="View Feraligatr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" alt="Feraligatr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Feraligatr
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="Sentret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="View Sentret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" alt="Sentret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Sentret
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="Furret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="View Furret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" alt="Furret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Furret
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="Hoothoot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="View Hoothoot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" alt="Hoothoot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Hoothoot
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="Noctowl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="View Noctowl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" alt="Noctowl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Noctowl
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="Ledyba">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="View Ledyba on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" alt="Ledyba" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Ledyba
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="Ledian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="View Ledian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" alt="Ledian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Ledian
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="Spinarak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="View Spinarak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" alt="Spinarak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Spinarak
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="Ariados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="View Ariados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" alt="Ariados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Ariados
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="Crobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="View Crobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" alt="Crobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Crobat
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Chinchou
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Lanturn
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Pichu
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="Cleffa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="View Cleffa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" alt="Cleffa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Cleffa
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="Igglybuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="View Igglybuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" alt="Igglybuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Igglybuff
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="Togepi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="View Togepi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" alt="Togepi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Togepi
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="Togetic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="View Togetic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" alt="Togetic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Togetic
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="Natu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="View Natu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" alt="Natu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Natu
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="Xatu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="View Xatu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" alt="Xatu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Xatu
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="Mareep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="View Mareep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" alt="Mareep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Mareep
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="Flaaffy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="View Flaaffy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" alt="Flaaffy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Flaaffy
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="Ampharos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="View Ampharos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" alt="Ampharos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Ampharos
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="Bellossom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="View Bellossom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" alt="Bellossom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Bellossom
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="Marill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="View Marill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" alt="Marill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Marill
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="Azumarill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="View Azumarill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" alt="Azumarill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Azumarill
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="Sudowoodo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="View Sudowoodo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" alt="Sudowoodo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Sudowoodo
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="Politoed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="View Politoed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" alt="Politoed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Politoed
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="Hoppip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="View Hoppip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" alt="Hoppip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Hoppip
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="Skiploom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="View Skiploom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" alt="Skiploom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Skiploom
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="Jumpluff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="View Jumpluff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" alt="Jumpluff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Jumpluff
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="Aipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="View Aipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" alt="Aipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Aipom
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="Sunkern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="View Sunkern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" alt="Sunkern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Sunkern
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="Sunflora">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="View Sunflora on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" alt="Sunflora" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Sunflora
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="Yanma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="View Yanma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" alt="Yanma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Yanma
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Wooper
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Quagsire
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="Espeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="View Espeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" alt="Espeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Espeon
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="Umbreon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="View Umbreon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" alt="Umbreon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Umbreon
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="Murkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="View Murkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" alt="Murkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Murkrow
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="Slowking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="View Slowking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" alt="Slowking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Slowking
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="Misdreavus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="View Misdreavus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" alt="Misdreavus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Misdreavus
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="Unown">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="View Unown on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" alt="Unown" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Unown
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="Wobbuffet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="View Wobbuffet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" alt="Wobbuffet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Wobbuffet
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="Girafarig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="View Girafarig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" alt="Girafarig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Girafarig
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="Pineco">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="View Pineco on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" alt="Pineco" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Pineco
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="Forretress">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="View Forretress on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" alt="Forretress" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Forretress
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="Dunsparce">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="View Dunsparce on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" alt="Dunsparce" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Dunsparce
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="Gligar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="View Gligar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" alt="Gligar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Gligar
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="Steelix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="View Steelix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" alt="Steelix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Steelix
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="Snubbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="View Snubbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" alt="Snubbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Snubbull
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="Granbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="View Granbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" alt="Granbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Granbull
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="Qwilfish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="View Qwilfish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" alt="Qwilfish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Qwilfish
@@ -2184,8 +2184,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="Scizor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="View Scizor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" alt="Scizor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">212</span>
                             Scizor
@@ -2194,8 +2194,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="Shuckle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="View Shuckle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" alt="Shuckle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">213</span>
                             Shuckle
@@ -2204,8 +2204,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="Heracross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="View Heracross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" alt="Heracross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">214</span>
                             Heracross
@@ -2214,8 +2214,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="Sneasel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="View Sneasel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" alt="Sneasel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">215</span>
                             Sneasel
@@ -2224,8 +2224,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="Teddiursa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="View Teddiursa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" alt="Teddiursa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">216</span>
                             Teddiursa
@@ -2234,8 +2234,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="Ursaring">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="View Ursaring on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" alt="Ursaring" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">217</span>
                             Ursaring
@@ -2244,8 +2244,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="Slugma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="View Slugma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" alt="Slugma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">218</span>
                             Slugma
@@ -2254,8 +2254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="Magcargo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="View Magcargo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" alt="Magcargo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">219</span>
                             Magcargo
@@ -2264,8 +2264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="Swinub">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="View Swinub on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" alt="Swinub" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">220</span>
                             Swinub
@@ -2274,8 +2274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="Piloswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="View Piloswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" alt="Piloswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">221</span>
                             Piloswine
@@ -2284,8 +2284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="Corsola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="View Corsola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" alt="Corsola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">222</span>
                             Corsola
@@ -2294,8 +2294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">223</span>
                             Remoraid
@@ -2304,8 +2304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">224</span>
                             Octillery
@@ -2314,8 +2314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="Delibird">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="View Delibird on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" alt="Delibird" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">225</span>
                             Delibird
@@ -2324,8 +2324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">226</span>
                             Mantine
@@ -2334,8 +2334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="Skarmory">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="View Skarmory on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" alt="Skarmory" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">227</span>
                             Skarmory
@@ -2344,8 +2344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="Houndour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="View Houndour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" alt="Houndour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">228</span>
                             Houndour
@@ -2354,8 +2354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="Houndoom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="View Houndoom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" alt="Houndoom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">229</span>
                             Houndoom
@@ -2364,8 +2364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="Kingdra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="View Kingdra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" alt="Kingdra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">230</span>
                             Kingdra
@@ -2374,8 +2374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="Phanpy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="View Phanpy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" alt="Phanpy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">231</span>
                             Phanpy
@@ -2384,8 +2384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="Donphan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="View Donphan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" alt="Donphan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">232</span>
                             Donphan
@@ -2394,8 +2394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="Porygon2">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="View Porygon2 on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" alt="Porygon2" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">233</span>
                             Porygon2
@@ -2404,8 +2404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="Stantler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="View Stantler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" alt="Stantler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">234</span>
                             Stantler
@@ -2414,8 +2414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="Smeargle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="View Smeargle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" alt="Smeargle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">235</span>
                             Smeargle
@@ -2424,8 +2424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="Tyrogue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="View Tyrogue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" alt="Tyrogue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">236</span>
                             Tyrogue
@@ -2434,8 +2434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="Hitmontop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="View Hitmontop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" alt="Hitmontop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">237</span>
                             Hitmontop
@@ -2444,8 +2444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="Smoochum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="View Smoochum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" alt="Smoochum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">238</span>
                             Smoochum
@@ -2454,8 +2454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="Elekid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="View Elekid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" alt="Elekid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">239</span>
                             Elekid
@@ -2464,8 +2464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="Magby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="View Magby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" alt="Magby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">240</span>
                             Magby
@@ -2481,8 +2481,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="Miltank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="View Miltank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" alt="Miltank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">241</span>
                             Miltank
@@ -2491,8 +2491,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="Blissey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="View Blissey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" alt="Blissey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">242</span>
                             Blissey
@@ -2501,8 +2501,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="Raikou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="View Raikou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" alt="Raikou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">243</span>
                             Raikou
@@ -2511,8 +2511,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="Entei">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="View Entei on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" alt="Entei" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">244</span>
                             Entei
@@ -2521,8 +2521,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="Suicune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="View Suicune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" alt="Suicune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">245</span>
                             Suicune
@@ -2531,8 +2531,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="Larvitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="View Larvitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" alt="Larvitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">246</span>
                             Larvitar
@@ -2541,8 +2541,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="Pupitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="View Pupitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" alt="Pupitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">247</span>
                             Pupitar
@@ -2551,8 +2551,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="Tyranitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="View Tyranitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" alt="Tyranitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">248</span>
                             Tyranitar
@@ -2561,8 +2561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="Lugia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="View Lugia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" alt="Lugia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">249</span>
                             Lugia
@@ -2571,8 +2571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="Ho-Oh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="View Ho-Oh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" alt="Ho-Oh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">250</span>
                             Ho-Oh
@@ -2581,8 +2581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="Celebi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="View Celebi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" alt="Celebi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">251</span>
                             Celebi
@@ -2591,8 +2591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="Treecko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="View Treecko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" alt="Treecko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">252</span>
                             Treecko
@@ -2601,8 +2601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="Grovyle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="View Grovyle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" alt="Grovyle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">253</span>
                             Grovyle
@@ -2611,8 +2611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="Sceptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="View Sceptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" alt="Sceptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">254</span>
                             Sceptile
@@ -2621,8 +2621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="Torchic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="View Torchic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" alt="Torchic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">255</span>
                             Torchic
@@ -2631,8 +2631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="Combusken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="View Combusken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" alt="Combusken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">256</span>
                             Combusken
@@ -2641,8 +2641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="Blaziken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="View Blaziken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" alt="Blaziken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">257</span>
                             Blaziken
@@ -2651,8 +2651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="Mudkip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="View Mudkip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" alt="Mudkip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">258</span>
                             Mudkip
@@ -2661,8 +2661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="Marshtomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="View Marshtomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" alt="Marshtomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">259</span>
                             Marshtomp
@@ -2671,8 +2671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="Swampert">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="View Swampert on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" alt="Swampert" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">260</span>
                             Swampert
@@ -2681,8 +2681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="Poochyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="View Poochyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" alt="Poochyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">261</span>
                             Poochyena
@@ -2691,8 +2691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="Mightyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="View Mightyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" alt="Mightyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">262</span>
                             Mightyena
@@ -2701,8 +2701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="Zigzagoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="View Zigzagoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" alt="Zigzagoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">263</span>
                             Zigzagoon
@@ -2711,8 +2711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="Linoone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="View Linoone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" alt="Linoone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">264</span>
                             Linoone
@@ -2721,8 +2721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="Wurmple">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="View Wurmple on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" alt="Wurmple" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">265</span>
                             Wurmple
@@ -2731,8 +2731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="Silcoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="View Silcoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" alt="Silcoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">266</span>
                             Silcoon
@@ -2741,8 +2741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="Beautifly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="View Beautifly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" alt="Beautifly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">267</span>
                             Beautifly
@@ -2751,8 +2751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="Cascoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="View Cascoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" alt="Cascoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">268</span>
                             Cascoon
@@ -2761,8 +2761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="Dustox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="View Dustox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" alt="Dustox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">269</span>
                             Dustox
@@ -2771,8 +2771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="Lotad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="View Lotad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" alt="Lotad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">270</span>
                             Lotad
@@ -2788,8 +2788,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="Lombre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="View Lombre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" alt="Lombre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">271</span>
                             Lombre
@@ -2798,8 +2798,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="Ludicolo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="View Ludicolo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" alt="Ludicolo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">272</span>
                             Ludicolo
@@ -2808,8 +2808,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="Seedot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="View Seedot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" alt="Seedot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">273</span>
                             Seedot
@@ -2818,8 +2818,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="Nuzleaf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="View Nuzleaf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" alt="Nuzleaf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">274</span>
                             Nuzleaf
@@ -2828,8 +2828,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="Shiftry">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="View Shiftry on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" alt="Shiftry" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">275</span>
                             Shiftry
@@ -2838,8 +2838,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="Taillow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="View Taillow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" alt="Taillow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">276</span>
                             Taillow
@@ -2848,8 +2848,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="Swellow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="View Swellow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" alt="Swellow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">277</span>
                             Swellow
@@ -2858,8 +2858,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="Wingull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="View Wingull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" alt="Wingull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">278</span>
                             Wingull
@@ -2868,8 +2868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="Pelipper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="View Pelipper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" alt="Pelipper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">279</span>
                             Pelipper
@@ -2878,8 +2878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="Ralts">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="View Ralts on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" alt="Ralts" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">280</span>
                             Ralts
@@ -2888,8 +2888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="Kirlia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="View Kirlia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" alt="Kirlia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">281</span>
                             Kirlia
@@ -2898,8 +2898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="Gardevoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="View Gardevoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" alt="Gardevoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">282</span>
                             Gardevoir
@@ -2908,8 +2908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="Surskit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="View Surskit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" alt="Surskit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">283</span>
                             Surskit
@@ -2918,8 +2918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="Masquerain">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="View Masquerain on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" alt="Masquerain" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">284</span>
                             Masquerain
@@ -2928,8 +2928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="Shroomish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="View Shroomish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" alt="Shroomish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">285</span>
                             Shroomish
@@ -2938,8 +2938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="Breloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="View Breloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" alt="Breloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">286</span>
                             Breloom
@@ -2948,8 +2948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="Slakoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="View Slakoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" alt="Slakoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">287</span>
                             Slakoth
@@ -2958,8 +2958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="Vigoroth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="View Vigoroth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" alt="Vigoroth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">288</span>
                             Vigoroth
@@ -2968,8 +2968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="Slaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="View Slaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" alt="Slaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">289</span>
                             Slaking
@@ -2978,8 +2978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="Nincada">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="View Nincada on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" alt="Nincada" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">290</span>
                             Nincada
@@ -2988,8 +2988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="Ninjask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="View Ninjask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" alt="Ninjask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">291</span>
                             Ninjask
@@ -2998,8 +2998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="Shedinja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="View Shedinja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" alt="Shedinja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">292</span>
                             Shedinja
@@ -3008,8 +3008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="Whismur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="View Whismur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" alt="Whismur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">293</span>
                             Whismur
@@ -3018,8 +3018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="Loudred">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="View Loudred on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" alt="Loudred" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">294</span>
                             Loudred
@@ -3028,8 +3028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="Exploud">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="View Exploud on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" alt="Exploud" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">295</span>
                             Exploud
@@ -3038,8 +3038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="Makuhita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="View Makuhita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" alt="Makuhita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">296</span>
                             Makuhita
@@ -3048,8 +3048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="Hariyama">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="View Hariyama on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" alt="Hariyama" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">297</span>
                             Hariyama
@@ -3058,8 +3058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="Azurill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="View Azurill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" alt="Azurill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">298</span>
                             Azurill
@@ -3068,8 +3068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="Nosepass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="View Nosepass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" alt="Nosepass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">299</span>
                             Nosepass
@@ -3078,8 +3078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="Skitty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="View Skitty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" alt="Skitty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">300</span>
                             Skitty
@@ -3095,8 +3095,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="Delcatty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="View Delcatty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" alt="Delcatty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">301</span>
                             Delcatty
@@ -3105,8 +3105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="Sableye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="View Sableye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" alt="Sableye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">302</span>
                             Sableye
@@ -3115,8 +3115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="Mawile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="View Mawile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" alt="Mawile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">303</span>
                             Mawile
@@ -3125,8 +3125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="Aron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="View Aron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" alt="Aron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">304</span>
                             Aron
@@ -3135,8 +3135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="Lairon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="View Lairon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" alt="Lairon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">305</span>
                             Lairon
@@ -3145,8 +3145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="Aggron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="View Aggron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" alt="Aggron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">306</span>
                             Aggron
@@ -3155,8 +3155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="Meditite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="View Meditite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" alt="Meditite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">307</span>
                             Meditite
@@ -3165,8 +3165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="Medicham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="View Medicham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" alt="Medicham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">308</span>
                             Medicham
@@ -3175,8 +3175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="Electrike">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="View Electrike on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" alt="Electrike" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">309</span>
                             Electrike
@@ -3185,8 +3185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="Manectric">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="View Manectric on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" alt="Manectric" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">310</span>
                             Manectric
@@ -3195,8 +3195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="Plusle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="View Plusle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" alt="Plusle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">311</span>
                             Plusle
@@ -3205,8 +3205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="Minun">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="View Minun on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" alt="Minun" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">312</span>
                             Minun
@@ -3215,8 +3215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="Volbeat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="View Volbeat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" alt="Volbeat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">313</span>
                             Volbeat
@@ -3225,8 +3225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="Illumise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="View Illumise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" alt="Illumise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">314</span>
                             Illumise
@@ -3235,8 +3235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="Roselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="View Roselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" alt="Roselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">315</span>
                             Roselia
@@ -3245,8 +3245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="Gulpin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="View Gulpin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" alt="Gulpin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">316</span>
                             Gulpin
@@ -3255,8 +3255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="Swalot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="View Swalot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" alt="Swalot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">317</span>
                             Swalot
@@ -3265,8 +3265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="Carvanha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="View Carvanha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" alt="Carvanha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">318</span>
                             Carvanha
@@ -3275,8 +3275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="Sharpedo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="View Sharpedo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" alt="Sharpedo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">319</span>
                             Sharpedo
@@ -3285,8 +3285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="Wailmer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="View Wailmer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" alt="Wailmer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">320</span>
                             Wailmer
@@ -3295,8 +3295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="Wailord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="View Wailord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" alt="Wailord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">321</span>
                             Wailord
@@ -3305,8 +3305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="Numel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="View Numel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" alt="Numel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">322</span>
                             Numel
@@ -3315,8 +3315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="Camerupt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="View Camerupt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" alt="Camerupt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">323</span>
                             Camerupt
@@ -3325,8 +3325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="Torkoal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="View Torkoal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" alt="Torkoal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">324</span>
                             Torkoal
@@ -3335,8 +3335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="Spoink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="View Spoink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" alt="Spoink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">325</span>
                             Spoink
@@ -3345,8 +3345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="Grumpig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="View Grumpig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" alt="Grumpig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">326</span>
                             Grumpig
@@ -3355,8 +3355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="Spinda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="View Spinda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" alt="Spinda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">327</span>
                             Spinda
@@ -3365,8 +3365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="Trapinch">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="View Trapinch on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" alt="Trapinch" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">328</span>
                             Trapinch
@@ -3375,8 +3375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="Vibrava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="View Vibrava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" alt="Vibrava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">329</span>
                             Vibrava
@@ -3385,8 +3385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="Flygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="View Flygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" alt="Flygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">330</span>
                             Flygon
@@ -3402,8 +3402,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="Cacnea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="View Cacnea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" alt="Cacnea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">331</span>
                             Cacnea
@@ -3412,8 +3412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="Cacturne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="View Cacturne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" alt="Cacturne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">332</span>
                             Cacturne
@@ -3422,8 +3422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="Swablu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="View Swablu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" alt="Swablu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">333</span>
                             Swablu
@@ -3432,8 +3432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="Altaria">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="View Altaria on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" alt="Altaria" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">334</span>
                             Altaria
@@ -3442,8 +3442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="Zangoose">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="View Zangoose on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" alt="Zangoose" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">335</span>
                             Zangoose
@@ -3452,8 +3452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="Seviper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="View Seviper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" alt="Seviper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">336</span>
                             Seviper
@@ -3462,8 +3462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="Lunatone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="View Lunatone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" alt="Lunatone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">337</span>
                             Lunatone
@@ -3472,8 +3472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="Solrock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="View Solrock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" alt="Solrock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">338</span>
                             Solrock
@@ -3482,8 +3482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="Barboach">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="View Barboach on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" alt="Barboach" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">339</span>
                             Barboach
@@ -3492,8 +3492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="Whiscash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="View Whiscash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" alt="Whiscash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">340</span>
                             Whiscash
@@ -3502,8 +3502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="Corphish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="View Corphish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" alt="Corphish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">341</span>
                             Corphish
@@ -3512,8 +3512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="Crawdaunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="View Crawdaunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" alt="Crawdaunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">342</span>
                             Crawdaunt
@@ -3522,8 +3522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="Baltoy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="View Baltoy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" alt="Baltoy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">343</span>
                             Baltoy
@@ -3532,8 +3532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="Claydol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="View Claydol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" alt="Claydol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">344</span>
                             Claydol
@@ -3542,8 +3542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="Lileep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="View Lileep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" alt="Lileep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">345</span>
                             Lileep
@@ -3552,8 +3552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="Cradily">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="View Cradily on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" alt="Cradily" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">346</span>
                             Cradily
@@ -3562,8 +3562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="Anorith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="View Anorith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" alt="Anorith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">347</span>
                             Anorith
@@ -3572,8 +3572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="Armaldo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="View Armaldo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" alt="Armaldo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">348</span>
                             Armaldo
@@ -3582,8 +3582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="Feebas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="View Feebas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" alt="Feebas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">349</span>
                             Feebas
@@ -3592,8 +3592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="Milotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="View Milotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" alt="Milotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">350</span>
                             Milotic
@@ -3602,8 +3602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="Castform">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="View Castform on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" alt="Castform" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">351</span>
                             Castform
@@ -3612,8 +3612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="Kecleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="View Kecleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" alt="Kecleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">352</span>
                             Kecleon
@@ -3622,8 +3622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="Shuppet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="View Shuppet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" alt="Shuppet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">353</span>
                             Shuppet
@@ -3632,8 +3632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="Banette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="View Banette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" alt="Banette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">354</span>
                             Banette
@@ -3642,8 +3642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="Duskull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="View Duskull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" alt="Duskull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">355</span>
                             Duskull
@@ -3652,8 +3652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="Dusclops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="View Dusclops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" alt="Dusclops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">356</span>
                             Dusclops
@@ -3662,8 +3662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="Tropius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="View Tropius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" alt="Tropius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">357</span>
                             Tropius
@@ -3672,8 +3672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="Chimecho">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="View Chimecho on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" alt="Chimecho" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">358</span>
                             Chimecho
@@ -3682,8 +3682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="Absol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="View Absol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" alt="Absol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">359</span>
                             Absol
@@ -3692,8 +3692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="Wynaut">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="View Wynaut on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" alt="Wynaut" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">360</span>
                             Wynaut
@@ -3709,8 +3709,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="Snorunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="View Snorunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" alt="Snorunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">361</span>
                             Snorunt
@@ -3719,8 +3719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="Glalie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="View Glalie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" alt="Glalie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">362</span>
                             Glalie
@@ -3729,8 +3729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="Spheal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="View Spheal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" alt="Spheal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">363</span>
                             Spheal
@@ -3739,8 +3739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="Sealeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="View Sealeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" alt="Sealeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">364</span>
                             Sealeo
@@ -3749,8 +3749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="Walrein">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="View Walrein on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" alt="Walrein" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">365</span>
                             Walrein
@@ -3759,8 +3759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="Clamperl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="View Clamperl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" alt="Clamperl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">366</span>
                             Clamperl
@@ -3769,8 +3769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="Huntail">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="View Huntail on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" alt="Huntail" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">367</span>
                             Huntail
@@ -3779,8 +3779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="Gorebyss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="View Gorebyss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" alt="Gorebyss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">368</span>
                             Gorebyss
@@ -3789,8 +3789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="Relicanth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="View Relicanth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" alt="Relicanth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">369</span>
                             Relicanth
@@ -3799,8 +3799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="Luvdisc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="View Luvdisc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" alt="Luvdisc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">370</span>
                             Luvdisc
@@ -3809,8 +3809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="Bagon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="View Bagon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" alt="Bagon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">371</span>
                             Bagon
@@ -3819,8 +3819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="Shelgon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="View Shelgon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" alt="Shelgon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">372</span>
                             Shelgon
@@ -3829,8 +3829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="Salamence">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="View Salamence on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" alt="Salamence" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">373</span>
                             Salamence
@@ -3839,8 +3839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="Beldum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="View Beldum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" alt="Beldum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">374</span>
                             Beldum
@@ -3849,8 +3849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="Metang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="View Metang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" alt="Metang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">375</span>
                             Metang
@@ -3859,8 +3859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="Metagross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="View Metagross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" alt="Metagross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">376</span>
                             Metagross
@@ -3869,8 +3869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="Regirock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="View Regirock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" alt="Regirock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">377</span>
                             Regirock
@@ -3879,8 +3879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="Regice">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="View Regice on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" alt="Regice" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">378</span>
                             Regice
@@ -3889,8 +3889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="Registeel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="View Registeel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" alt="Registeel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">379</span>
                             Registeel
@@ -3899,8 +3899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="Latias">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="View Latias on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" alt="Latias" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">380</span>
                             Latias
@@ -3909,8 +3909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="Latios">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="View Latios on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" alt="Latios" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">381</span>
                             Latios
@@ -3919,8 +3919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="Kyogre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="View Kyogre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" alt="Kyogre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">382</span>
                             Kyogre
@@ -3929,8 +3929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="Groudon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="View Groudon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" alt="Groudon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">383</span>
                             Groudon
@@ -3939,8 +3939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="Rayquaza">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="View Rayquaza on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" alt="Rayquaza" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">384</span>
                             Rayquaza
@@ -3949,8 +3949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="Jirachi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="View Jirachi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" alt="Jirachi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">385</span>
                             Jirachi
@@ -3959,8 +3959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="Deoxys">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="View Deoxys on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" alt="Deoxys" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">386</span>
                             Deoxys
@@ -3969,8 +3969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="Turtwig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="View Turtwig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" alt="Turtwig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">387</span>
                             Turtwig
@@ -3979,8 +3979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="Grotle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="View Grotle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" alt="Grotle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">388</span>
                             Grotle
@@ -3989,8 +3989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="Torterra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="View Torterra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" alt="Torterra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">389</span>
                             Torterra
@@ -3999,8 +3999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="Chimchar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="View Chimchar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" alt="Chimchar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">390</span>
                             Chimchar
@@ -4016,8 +4016,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="Monferno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="View Monferno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" alt="Monferno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">391</span>
                             Monferno
@@ -4026,8 +4026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="Infernape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="View Infernape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" alt="Infernape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">392</span>
                             Infernape
@@ -4036,8 +4036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="Piplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="View Piplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" alt="Piplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">393</span>
                             Piplup
@@ -4046,8 +4046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="Prinplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="View Prinplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" alt="Prinplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">394</span>
                             Prinplup
@@ -4056,8 +4056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="Empoleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="View Empoleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" alt="Empoleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">395</span>
                             Empoleon
@@ -4066,8 +4066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="Starly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="View Starly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" alt="Starly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">396</span>
                             Starly
@@ -4076,8 +4076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="Staravia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="View Staravia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" alt="Staravia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">397</span>
                             Staravia
@@ -4086,8 +4086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="Staraptor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="View Staraptor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" alt="Staraptor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">398</span>
                             Staraptor
@@ -4096,8 +4096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="Bidoof">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="View Bidoof on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" alt="Bidoof" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">399</span>
                             Bidoof
@@ -4106,8 +4106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="Bibarel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="View Bibarel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" alt="Bibarel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">400</span>
                             Bibarel
@@ -4116,8 +4116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="Kricketot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="View Kricketot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" alt="Kricketot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">401</span>
                             Kricketot
@@ -4126,8 +4126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="Kricketune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="View Kricketune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" alt="Kricketune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">402</span>
                             Kricketune
@@ -4136,8 +4136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="Shinx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="View Shinx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" alt="Shinx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">403</span>
                             Shinx
@@ -4146,8 +4146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="Luxio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="View Luxio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" alt="Luxio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">404</span>
                             Luxio
@@ -4156,8 +4156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="Luxray">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="View Luxray on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" alt="Luxray" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">405</span>
                             Luxray
@@ -4166,8 +4166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="Budew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="View Budew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" alt="Budew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">406</span>
                             Budew
@@ -4176,8 +4176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="Roserade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="View Roserade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" alt="Roserade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">407</span>
                             Roserade
@@ -4186,8 +4186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="Cranidos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="View Cranidos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" alt="Cranidos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">408</span>
                             Cranidos
@@ -4196,8 +4196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="Rampardos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="View Rampardos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" alt="Rampardos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">409</span>
                             Rampardos
@@ -4206,8 +4206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="Shieldon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="View Shieldon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" alt="Shieldon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">410</span>
                             Shieldon
@@ -4216,8 +4216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="Bastiodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="View Bastiodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" alt="Bastiodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">411</span>
                             Bastiodon
@@ -4226,8 +4226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="Burmy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="View Burmy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" alt="Burmy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">412</span>
                             Burmy
@@ -4236,8 +4236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="Wormadam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="View Wormadam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" alt="Wormadam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">413</span>
                             Wormadam
@@ -4246,8 +4246,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="Mothim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="View Mothim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" alt="Mothim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">414</span>
                             Mothim
@@ -4256,8 +4256,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="Combee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="View Combee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" alt="Combee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">415</span>
                             Combee
@@ -4266,8 +4266,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="Vespiquen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="View Vespiquen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" alt="Vespiquen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">416</span>
                             Vespiquen
@@ -4276,8 +4276,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="Pachirisu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="View Pachirisu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" alt="Pachirisu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">417</span>
                             Pachirisu
@@ -4286,8 +4286,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="Buizel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="View Buizel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" alt="Buizel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">418</span>
                             Buizel
@@ -4296,8 +4296,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="Floatzel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="View Floatzel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" alt="Floatzel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">419</span>
                             Floatzel
@@ -4306,8 +4306,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="Cherubi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="View Cherubi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" alt="Cherubi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">420</span>
                             Cherubi
@@ -4323,8 +4323,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="Cherrim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="View Cherrim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" alt="Cherrim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">421</span>
                             Cherrim
@@ -4333,8 +4333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="Shellos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="View Shellos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" alt="Shellos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">422</span>
                             Shellos
@@ -4343,8 +4343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="Gastrodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="View Gastrodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" alt="Gastrodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">423</span>
                             Gastrodon
@@ -4353,8 +4353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="Ambipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="View Ambipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" alt="Ambipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">424</span>
                             Ambipom
@@ -4363,8 +4363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="Drifloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="View Drifloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" alt="Drifloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">425</span>
                             Drifloon
@@ -4373,8 +4373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="Drifblim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="View Drifblim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" alt="Drifblim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">426</span>
                             Drifblim
@@ -4383,8 +4383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="Buneary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="View Buneary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" alt="Buneary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">427</span>
                             Buneary
@@ -4393,8 +4393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="Lopunny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="View Lopunny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" alt="Lopunny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">428</span>
                             Lopunny
@@ -4403,8 +4403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="Mismagius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="View Mismagius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" alt="Mismagius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">429</span>
                             Mismagius
@@ -4413,8 +4413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="Honchkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="View Honchkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" alt="Honchkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">430</span>
                             Honchkrow
@@ -4423,8 +4423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="Glameow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="View Glameow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" alt="Glameow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">431</span>
                             Glameow
@@ -4433,8 +4433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="Purugly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="View Purugly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" alt="Purugly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">432</span>
                             Purugly
@@ -4443,8 +4443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="Chingling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="View Chingling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" alt="Chingling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">433</span>
                             Chingling
@@ -4453,8 +4453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="Stunky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="View Stunky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" alt="Stunky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">434</span>
                             Stunky
@@ -4463,8 +4463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="Skuntank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="View Skuntank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" alt="Skuntank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">435</span>
                             Skuntank
@@ -4473,8 +4473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="Bronzor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="View Bronzor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" alt="Bronzor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">436</span>
                             Bronzor
@@ -4483,8 +4483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="Bronzong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="View Bronzong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" alt="Bronzong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">437</span>
                             Bronzong
@@ -4493,8 +4493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="Bonsly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="View Bonsly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" alt="Bonsly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">438</span>
                             Bonsly
@@ -4503,8 +4503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="Mime Jr.">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="View Mime Jr. on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" alt="Mime Jr." loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">439</span>
                             Mime Jr.
@@ -4513,8 +4513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="Happiny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="View Happiny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" alt="Happiny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">440</span>
                             Happiny
@@ -4523,8 +4523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="Chatot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="View Chatot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" alt="Chatot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">441</span>
                             Chatot
@@ -4533,8 +4533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="Spiritomb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="View Spiritomb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" alt="Spiritomb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">442</span>
                             Spiritomb
@@ -4543,8 +4543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="Gible">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="View Gible on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" alt="Gible" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">443</span>
                             Gible
@@ -4553,8 +4553,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="Gabite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="View Gabite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" alt="Gabite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">444</span>
                             Gabite
@@ -4563,8 +4563,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="Garchomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="View Garchomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" alt="Garchomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">445</span>
                             Garchomp
@@ -4573,8 +4573,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="Munchlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="View Munchlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" alt="Munchlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">446</span>
                             Munchlax
@@ -4583,8 +4583,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="Riolu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="View Riolu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" alt="Riolu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">447</span>
                             Riolu
@@ -4593,8 +4593,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="Lucario">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="View Lucario on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" alt="Lucario" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">448</span>
                             Lucario
@@ -4603,8 +4603,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="Hippopotas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="View Hippopotas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" alt="Hippopotas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">449</span>
                             Hippopotas
@@ -4613,8 +4613,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="Hippowdon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="View Hippowdon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" alt="Hippowdon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">450</span>
                             Hippowdon
@@ -4630,8 +4630,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="Skorupi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="View Skorupi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" alt="Skorupi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">451</span>
                             Skorupi
@@ -4640,8 +4640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="Drapion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="View Drapion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" alt="Drapion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">452</span>
                             Drapion
@@ -4650,8 +4650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="Croagunk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="View Croagunk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" alt="Croagunk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">453</span>
                             Croagunk
@@ -4660,8 +4660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="Toxicroak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="View Toxicroak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" alt="Toxicroak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">454</span>
                             Toxicroak
@@ -4670,8 +4670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="Carnivine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="View Carnivine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" alt="Carnivine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">455</span>
                             Carnivine
@@ -4680,8 +4680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="Finneon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="View Finneon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" alt="Finneon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">456</span>
                             Finneon
@@ -4690,8 +4690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="Lumineon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="View Lumineon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" alt="Lumineon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">457</span>
                             Lumineon
@@ -4700,8 +4700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="Mantyke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="View Mantyke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" alt="Mantyke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">458</span>
                             Mantyke
@@ -4710,8 +4710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="Snover">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="View Snover on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" alt="Snover" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">459</span>
                             Snover
@@ -4720,8 +4720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="Abomasnow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="View Abomasnow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" alt="Abomasnow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">460</span>
                             Abomasnow
@@ -4730,8 +4730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="Weavile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="View Weavile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" alt="Weavile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">461</span>
                             Weavile
@@ -4740,8 +4740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="Magnezone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="View Magnezone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" alt="Magnezone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">462</span>
                             Magnezone
@@ -4750,8 +4750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="Lickilicky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="View Lickilicky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" alt="Lickilicky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">463</span>
                             Lickilicky
@@ -4760,8 +4760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="Rhyperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="View Rhyperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" alt="Rhyperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">464</span>
                             Rhyperior
@@ -4770,8 +4770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="Tangrowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="View Tangrowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" alt="Tangrowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">465</span>
                             Tangrowth
@@ -4780,8 +4780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="Electivire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="View Electivire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" alt="Electivire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">466</span>
                             Electivire
@@ -4790,8 +4790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="Magmortar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="View Magmortar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" alt="Magmortar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">467</span>
                             Magmortar
@@ -4800,8 +4800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="Togekiss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="View Togekiss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" alt="Togekiss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">468</span>
                             Togekiss
@@ -4810,8 +4810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="Yanmega">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="View Yanmega on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" alt="Yanmega" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">469</span>
                             Yanmega
@@ -4820,8 +4820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="Leafeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="View Leafeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" alt="Leafeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">470</span>
                             Leafeon
@@ -4830,8 +4830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="Glaceon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="View Glaceon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" alt="Glaceon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">471</span>
                             Glaceon
@@ -4840,8 +4840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="Gliscor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="View Gliscor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" alt="Gliscor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">472</span>
                             Gliscor
@@ -4850,8 +4850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="Mamoswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="View Mamoswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" alt="Mamoswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">473</span>
                             Mamoswine
@@ -4860,8 +4860,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="Porygon-Z">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="View Porygon-Z on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" alt="Porygon-Z" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">474</span>
                             Porygon-Z
@@ -4870,8 +4870,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="Gallade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="View Gallade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" alt="Gallade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">475</span>
                             Gallade
@@ -4880,8 +4880,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="Probopass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="View Probopass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" alt="Probopass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">476</span>
                             Probopass
@@ -4890,8 +4890,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="Dusknoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="View Dusknoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" alt="Dusknoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">477</span>
                             Dusknoir
@@ -4900,8 +4900,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="Froslass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="View Froslass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" alt="Froslass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">478</span>
                             Froslass
@@ -4910,8 +4910,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="Rotom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="View Rotom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" alt="Rotom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">479</span>
                             Rotom
@@ -4920,8 +4920,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="Uxie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="View Uxie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" alt="Uxie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">480</span>
                             Uxie
@@ -4937,8 +4937,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="Mesprit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="View Mesprit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" alt="Mesprit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">481</span>
                             Mesprit
@@ -4947,8 +4947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="Azelf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="View Azelf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" alt="Azelf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">482</span>
                             Azelf
@@ -4957,8 +4957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="Dialga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="View Dialga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" alt="Dialga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">483</span>
                             Dialga
@@ -4967,8 +4967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="Palkia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="View Palkia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" alt="Palkia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">484</span>
                             Palkia
@@ -4977,8 +4977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="Heatran">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="View Heatran on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" alt="Heatran" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">485</span>
                             Heatran
@@ -4987,8 +4987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="Regigigas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="View Regigigas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" alt="Regigigas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">486</span>
                             Regigigas
@@ -4997,8 +4997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="Giratina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="View Giratina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" alt="Giratina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">487</span>
                             Giratina
@@ -5007,8 +5007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="Cresselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="View Cresselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" alt="Cresselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">488</span>
                             Cresselia
@@ -5017,8 +5017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="Phione">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="View Phione on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" alt="Phione" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">489</span>
                             Phione
@@ -5027,8 +5027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="Manaphy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="View Manaphy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" alt="Manaphy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">490</span>
                             Manaphy
@@ -5037,8 +5037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darkrai/" title="Darkrai">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/491.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darkrai/" title="View Darkrai on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/491.png" alt="Darkrai" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">491</span>
                             Darkrai
@@ -5047,8 +5047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shaymin/" title="Shaymin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/492.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shaymin/" title="View Shaymin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/492.png" alt="Shaymin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">492</span>
                             Shaymin
@@ -5057,8 +5057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arceus/" title="Arceus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/493.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arceus/" title="View Arceus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/493.png" alt="Arceus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">493</span>
                             Arceus
@@ -5067,8 +5067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victini/" title="Victini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/494.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victini/" title="View Victini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/494.png" alt="Victini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">494</span>
                             Victini
@@ -5077,8 +5077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snivy/" title="Snivy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/495.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snivy/" title="View Snivy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/495.png" alt="Snivy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">495</span>
                             Snivy
@@ -5087,8 +5087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/servine/" title="Servine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/496.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/servine/" title="View Servine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/496.png" alt="Servine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">496</span>
                             Servine
@@ -5097,8 +5097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/serperior/" title="Serperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/497.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/serperior/" title="View Serperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/497.png" alt="Serperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">497</span>
                             Serperior
@@ -5107,8 +5107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tepig/" title="Tepig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/498.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tepig/" title="View Tepig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/498.png" alt="Tepig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">498</span>
                             Tepig
@@ -5117,8 +5117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pignite/" title="Pignite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/499.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pignite/" title="View Pignite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/499.png" alt="Pignite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">499</span>
                             Pignite
@@ -5127,8 +5127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/emboar/" title="Emboar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/500.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/emboar/" title="View Emboar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/500.png" alt="Emboar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">500</span>
                             Emboar
@@ -5137,8 +5137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oshawott/" title="Oshawott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/501.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oshawott/" title="View Oshawott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/501.png" alt="Oshawott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">501</span>
                             Oshawott
@@ -5147,8 +5147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewott/" title="Dewott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/502.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewott/" title="View Dewott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/502.png" alt="Dewott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">502</span>
                             Dewott
@@ -5157,8 +5157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/samurott/" title="Samurott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/503.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/samurott/" title="View Samurott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/503.png" alt="Samurott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">503</span>
                             Samurott
@@ -5167,8 +5167,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/patrat/" title="Patrat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/504.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/patrat/" title="View Patrat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/504.png" alt="Patrat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">504</span>
                             Patrat
@@ -5177,8 +5177,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/watchog/" title="Watchog">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/505.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/watchog/" title="View Watchog on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/505.png" alt="Watchog" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">505</span>
                             Watchog
@@ -5187,8 +5187,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="Lillipup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="View Lillipup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" alt="Lillipup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">506</span>
                             Lillipup
@@ -5197,8 +5197,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="Herdier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="View Herdier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" alt="Herdier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">507</span>
                             Herdier
@@ -5207,8 +5207,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="Stoutland">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="View Stoutland on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" alt="Stoutland" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">508</span>
                             Stoutland
@@ -5217,8 +5217,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="Purrloin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="View Purrloin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" alt="Purrloin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">509</span>
                             Purrloin
@@ -5227,8 +5227,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="Liepard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="View Liepard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" alt="Liepard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">510</span>
                             Liepard
@@ -5244,8 +5244,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pansage/" title="Pansage">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/511.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pansage/" title="View Pansage on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/511.png" alt="Pansage" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">511</span>
                             Pansage
@@ -5254,8 +5254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simisage/" title="Simisage">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/512.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simisage/" title="View Simisage on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/512.png" alt="Simisage" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">512</span>
                             Simisage
@@ -5264,8 +5264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pansear/" title="Pansear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/513.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pansear/" title="View Pansear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/513.png" alt="Pansear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">513</span>
                             Pansear
@@ -5274,8 +5274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simisear/" title="Simisear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/514.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simisear/" title="View Simisear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/514.png" alt="Simisear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">514</span>
                             Simisear
@@ -5284,8 +5284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/panpour/" title="Panpour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/515.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/panpour/" title="View Panpour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/515.png" alt="Panpour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">515</span>
                             Panpour
@@ -5294,8 +5294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simipour/" title="Simipour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/516.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simipour/" title="View Simipour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/516.png" alt="Simipour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">516</span>
                             Simipour
@@ -5304,8 +5304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="Munna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="View Munna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" alt="Munna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">517</span>
                             Munna
@@ -5314,8 +5314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="Musharna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="View Musharna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" alt="Musharna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">518</span>
                             Musharna
@@ -5324,8 +5324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="Pidove">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="View Pidove on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" alt="Pidove" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">519</span>
                             Pidove
@@ -5334,8 +5334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="Tranquill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="View Tranquill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" alt="Tranquill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">520</span>
                             Tranquill
@@ -5344,8 +5344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="Unfezant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="View Unfezant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" alt="Unfezant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">521</span>
                             Unfezant
@@ -5354,8 +5354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blitzle/" title="Blitzle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/522.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blitzle/" title="View Blitzle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/522.png" alt="Blitzle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">522</span>
                             Blitzle
@@ -5364,8 +5364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zebstrika/" title="Zebstrika">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/523.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zebstrika/" title="View Zebstrika on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/523.png" alt="Zebstrika" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">523</span>
                             Zebstrika
@@ -5374,8 +5374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="Roggenrola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="View Roggenrola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" alt="Roggenrola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">524</span>
                             Roggenrola
@@ -5384,8 +5384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="Boldore">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="View Boldore on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" alt="Boldore" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">525</span>
                             Boldore
@@ -5394,8 +5394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="Gigalith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="View Gigalith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" alt="Gigalith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">526</span>
                             Gigalith
@@ -5404,8 +5404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="Woobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="View Woobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" alt="Woobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">527</span>
                             Woobat
@@ -5414,8 +5414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="Swoobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="View Swoobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" alt="Swoobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">528</span>
                             Swoobat
@@ -5424,8 +5424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="Drilbur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="View Drilbur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" alt="Drilbur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">529</span>
                             Drilbur
@@ -5434,8 +5434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="Excadrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="View Excadrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" alt="Excadrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">530</span>
                             Excadrill
@@ -5444,8 +5444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/audino/" title="Audino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/531.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/audino/" title="View Audino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/531.png" alt="Audino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">531</span>
                             Audino
@@ -5454,8 +5454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="Timburr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="View Timburr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" alt="Timburr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">532</span>
                             Timburr
@@ -5464,8 +5464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="Gurdurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="View Gurdurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" alt="Gurdurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">533</span>
                             Gurdurr
@@ -5474,8 +5474,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="Conkeldurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="View Conkeldurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" alt="Conkeldurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">534</span>
                             Conkeldurr
@@ -5484,8 +5484,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="Tympole">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="View Tympole on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" alt="Tympole" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">535</span>
                             Tympole
@@ -5494,8 +5494,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="Palpitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="View Palpitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" alt="Palpitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">536</span>
                             Palpitoad
@@ -5504,8 +5504,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="Seismitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="View Seismitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" alt="Seismitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">537</span>
                             Seismitoad
@@ -5514,8 +5514,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="Throh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="View Throh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" alt="Throh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">538</span>
                             Throh
@@ -5524,8 +5524,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="Sawk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="View Sawk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" alt="Sawk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">539</span>
                             Sawk
@@ -5534,8 +5534,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sewaddle/" title="Sewaddle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/540.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sewaddle/" title="View Sewaddle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/540.png" alt="Sewaddle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">540</span>
                             Sewaddle
@@ -5551,8 +5551,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swadloon/" title="Swadloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/541.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swadloon/" title="View Swadloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/541.png" alt="Swadloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">541</span>
                             Swadloon
@@ -5561,8 +5561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leavanny/" title="Leavanny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/542.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leavanny/" title="View Leavanny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/542.png" alt="Leavanny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">542</span>
                             Leavanny
@@ -5571,8 +5571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="Venipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="View Venipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" alt="Venipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">543</span>
                             Venipede
@@ -5581,8 +5581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="Whirlipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="View Whirlipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" alt="Whirlipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">544</span>
                             Whirlipede
@@ -5591,8 +5591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="Scolipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="View Scolipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" alt="Scolipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">545</span>
                             Scolipede
@@ -5601,8 +5601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="Cottonee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="View Cottonee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" alt="Cottonee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">546</span>
                             Cottonee
@@ -5611,8 +5611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="Whimsicott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="View Whimsicott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" alt="Whimsicott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">547</span>
                             Whimsicott
@@ -5621,8 +5621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="Petilil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="View Petilil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" alt="Petilil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">548</span>
                             Petilil
@@ -5631,8 +5631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="Lilligant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="View Lilligant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" alt="Lilligant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">549</span>
                             Lilligant
@@ -5641,8 +5641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="Basculin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="View Basculin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" alt="Basculin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">550</span>
                             Basculin
@@ -5651,8 +5651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="Sandile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="View Sandile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" alt="Sandile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">551</span>
                             Sandile
@@ -5661,8 +5661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="Krokorok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="View Krokorok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" alt="Krokorok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">552</span>
                             Krokorok
@@ -5671,8 +5671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="Krookodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="View Krookodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" alt="Krookodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">553</span>
                             Krookodile
@@ -5681,8 +5681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="Darumaka">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="View Darumaka on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" alt="Darumaka" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">554</span>
                             Darumaka
@@ -5691,8 +5691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="Darmanitan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="View Darmanitan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" alt="Darmanitan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">555</span>
                             Darmanitan
@@ -5701,8 +5701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="Maractus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="View Maractus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" alt="Maractus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">556</span>
                             Maractus
@@ -5711,8 +5711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="Dwebble">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="View Dwebble on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" alt="Dwebble" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">557</span>
                             Dwebble
@@ -5721,8 +5721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="Crustle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="View Crustle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" alt="Crustle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">558</span>
                             Crustle
@@ -5731,8 +5731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="Scraggy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="View Scraggy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" alt="Scraggy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">559</span>
                             Scraggy
@@ -5741,8 +5741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="Scrafty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="View Scrafty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" alt="Scrafty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">560</span>
                             Scrafty
@@ -5751,8 +5751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="Sigilyph">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="View Sigilyph on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" alt="Sigilyph" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">561</span>
                             Sigilyph
@@ -5761,8 +5761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="Yamask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="View Yamask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" alt="Yamask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">562</span>
                             Yamask
@@ -5771,8 +5771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="Cofagrigus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="View Cofagrigus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" alt="Cofagrigus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">563</span>
                             Cofagrigus
@@ -5781,8 +5781,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tirtouga/" title="Tirtouga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/564.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tirtouga/" title="View Tirtouga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/564.png" alt="Tirtouga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">564</span>
                             Tirtouga
@@ -5791,8 +5791,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carracosta/" title="Carracosta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/565.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carracosta/" title="View Carracosta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/565.png" alt="Carracosta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">565</span>
                             Carracosta
@@ -5801,8 +5801,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/archen/" title="Archen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/566.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/archen/" title="View Archen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/566.png" alt="Archen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">566</span>
                             Archen
@@ -5811,8 +5811,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/archeops/" title="Archeops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/567.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/archeops/" title="View Archeops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/567.png" alt="Archeops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">567</span>
                             Archeops
@@ -5821,8 +5821,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="Trubbish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="View Trubbish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" alt="Trubbish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">568</span>
                             Trubbish
@@ -5831,8 +5831,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="Garbodor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="View Garbodor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" alt="Garbodor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">569</span>
                             Garbodor
@@ -5841,8 +5841,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="Zorua">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="View Zorua on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" alt="Zorua" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">570</span>
                             Zorua
@@ -5858,8 +5858,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="Zoroark">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="View Zoroark on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" alt="Zoroark" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">571</span>
                             Zoroark
@@ -5868,8 +5868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="Minccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="View Minccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" alt="Minccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">572</span>
                             Minccino
@@ -5878,8 +5878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="Cinccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="View Cinccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" alt="Cinccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">573</span>
                             Cinccino
@@ -5888,8 +5888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="Gothita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="View Gothita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" alt="Gothita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">574</span>
                             Gothita
@@ -5898,8 +5898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="Gothorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="View Gothorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" alt="Gothorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">575</span>
                             Gothorita
@@ -5908,8 +5908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="Gothitelle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="View Gothitelle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" alt="Gothitelle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">576</span>
                             Gothitelle
@@ -5918,8 +5918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="Solosis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="View Solosis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" alt="Solosis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">577</span>
                             Solosis
@@ -5928,8 +5928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="Duosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="View Duosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" alt="Duosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">578</span>
                             Duosion
@@ -5938,8 +5938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="Reuniclus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="View Reuniclus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" alt="Reuniclus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">579</span>
                             Reuniclus
@@ -5948,8 +5948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ducklett/" title="Ducklett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/580.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ducklett/" title="View Ducklett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/580.png" alt="Ducklett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">580</span>
                             Ducklett
@@ -5958,8 +5958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swanna/" title="Swanna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/581.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swanna/" title="View Swanna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/581.png" alt="Swanna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">581</span>
                             Swanna
@@ -5968,8 +5968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="Vanillite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="View Vanillite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" alt="Vanillite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">582</span>
                             Vanillite
@@ -5978,8 +5978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="Vanillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="View Vanillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" alt="Vanillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">583</span>
                             Vanillish
@@ -5988,8 +5988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="Vanilluxe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="View Vanilluxe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" alt="Vanilluxe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">584</span>
                             Vanilluxe
@@ -5998,8 +5998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deerling/" title="Deerling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/585.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deerling/" title="View Deerling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/585.png" alt="Deerling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">585</span>
                             Deerling
@@ -6008,8 +6008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sawsbuck/" title="Sawsbuck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/586.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sawsbuck/" title="View Sawsbuck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/586.png" alt="Sawsbuck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">586</span>
                             Sawsbuck
@@ -6018,8 +6018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="Emolga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="View Emolga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" alt="Emolga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">587</span>
                             Emolga
@@ -6028,8 +6028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="Karrablast">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="View Karrablast on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" alt="Karrablast" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">588</span>
                             Karrablast
@@ -6038,8 +6038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="Escavalier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="View Escavalier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" alt="Escavalier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">589</span>
                             Escavalier
@@ -6048,8 +6048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="Foongus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="View Foongus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" alt="Foongus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">590</span>
                             Foongus
@@ -6058,8 +6058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="Amoonguss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="View Amoonguss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" alt="Amoonguss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">591</span>
                             Amoonguss
@@ -6068,8 +6068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="Frillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="View Frillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" alt="Frillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">592</span>
                             Frillish
@@ -6078,8 +6078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="Jellicent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="View Jellicent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" alt="Jellicent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">593</span>
                             Jellicent
@@ -6088,8 +6088,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alomomola/" title="Alomomola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/594.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alomomola/" title="View Alomomola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/594.png" alt="Alomomola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">594</span>
                             Alomomola
@@ -6098,8 +6098,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="Joltik">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="View Joltik on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" alt="Joltik" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">595</span>
                             Joltik
@@ -6108,8 +6108,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="Galvantula">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="View Galvantula on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" alt="Galvantula" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">596</span>
                             Galvantula
@@ -6118,8 +6118,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="Ferroseed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="View Ferroseed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" alt="Ferroseed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">597</span>
                             Ferroseed
@@ -6128,8 +6128,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="Ferrothorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="View Ferrothorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" alt="Ferrothorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">598</span>
                             Ferrothorn
@@ -6138,8 +6138,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="Klink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="View Klink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" alt="Klink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">599</span>
                             Klink
@@ -6148,8 +6148,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="Klang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="View Klang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" alt="Klang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">600</span>
                             Klang
@@ -6165,8 +6165,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="Klinklang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="View Klinklang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" alt="Klinklang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">601</span>
                             Klinklang
@@ -6175,8 +6175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tynamo/" title="Tynamo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/602.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tynamo/" title="View Tynamo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/602.png" alt="Tynamo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">602</span>
                             Tynamo
@@ -6185,8 +6185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eelektrik/" title="Eelektrik">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/603.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eelektrik/" title="View Eelektrik on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/603.png" alt="Eelektrik" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">603</span>
                             Eelektrik
@@ -6195,8 +6195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eelektross/" title="Eelektross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/604.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eelektross/" title="View Eelektross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/604.png" alt="Eelektross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">604</span>
                             Eelektross
@@ -6205,8 +6205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="Elgyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="View Elgyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" alt="Elgyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">605</span>
                             Elgyem
@@ -6215,8 +6215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="Beheeyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="View Beheeyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" alt="Beheeyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">606</span>
                             Beheeyem
@@ -6225,8 +6225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="Litwick">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="View Litwick on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" alt="Litwick" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">607</span>
                             Litwick
@@ -6235,8 +6235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="Lampent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="View Lampent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" alt="Lampent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">608</span>
                             Lampent
@@ -6245,8 +6245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="Chandelure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="View Chandelure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" alt="Chandelure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">609</span>
                             Chandelure
@@ -6255,8 +6255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="Axew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="View Axew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" alt="Axew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">610</span>
                             Axew
@@ -6265,8 +6265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="Fraxure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="View Fraxure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" alt="Fraxure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">611</span>
                             Fraxure
@@ -6275,8 +6275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="Haxorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="View Haxorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" alt="Haxorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">612</span>
                             Haxorus
@@ -6285,8 +6285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="Cubchoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="View Cubchoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" alt="Cubchoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">613</span>
                             Cubchoo
@@ -6295,8 +6295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="Beartic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="View Beartic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" alt="Beartic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">614</span>
                             Beartic
@@ -6305,8 +6305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cryogonal/" title="Cryogonal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/615.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cryogonal/" title="View Cryogonal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/615.png" alt="Cryogonal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">615</span>
                             Cryogonal
@@ -6315,8 +6315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="Shelmet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="View Shelmet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" alt="Shelmet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">616</span>
                             Shelmet
@@ -6325,8 +6325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="Accelgor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="View Accelgor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" alt="Accelgor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">617</span>
                             Accelgor
@@ -6335,8 +6335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="Stunfisk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="View Stunfisk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" alt="Stunfisk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">618</span>
                             Stunfisk
@@ -6345,8 +6345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="Mienfoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="View Mienfoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" alt="Mienfoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">619</span>
                             Mienfoo
@@ -6355,8 +6355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="Mienshao">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="View Mienshao on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" alt="Mienshao" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">620</span>
                             Mienshao
@@ -6365,8 +6365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="Druddigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="View Druddigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" alt="Druddigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">621</span>
                             Druddigon
@@ -6375,8 +6375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="Golett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="View Golett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" alt="Golett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">622</span>
                             Golett
@@ -6385,8 +6385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="Golurk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="View Golurk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" alt="Golurk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">623</span>
                             Golurk
@@ -6395,8 +6395,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="Pawniard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="View Pawniard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" alt="Pawniard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">624</span>
                             Pawniard
@@ -6405,8 +6405,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="Bisharp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="View Bisharp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" alt="Bisharp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">625</span>
                             Bisharp
@@ -6415,8 +6415,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="Bouffalant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="View Bouffalant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" alt="Bouffalant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">626</span>
                             Bouffalant
@@ -6425,8 +6425,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="Rufflet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="View Rufflet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" alt="Rufflet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">627</span>
                             Rufflet
@@ -6435,8 +6435,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="Braviary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="View Braviary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" alt="Braviary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">628</span>
                             Braviary
@@ -6445,8 +6445,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="Vullaby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="View Vullaby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" alt="Vullaby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">629</span>
                             Vullaby
@@ -6455,8 +6455,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="Mandibuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="View Mandibuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" alt="Mandibuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">630</span>
                             Mandibuzz
@@ -6472,8 +6472,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="Heatmor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="View Heatmor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" alt="Heatmor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">631</span>
                             Heatmor
@@ -6482,8 +6482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="Durant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="View Durant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" alt="Durant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">632</span>
                             Durant
@@ -6492,8 +6492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="Deino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="View Deino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" alt="Deino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">633</span>
                             Deino
@@ -6502,8 +6502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="Zweilous">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="View Zweilous on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" alt="Zweilous" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">634</span>
                             Zweilous
@@ -6512,8 +6512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="Hydreigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="View Hydreigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" alt="Hydreigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">635</span>
                             Hydreigon
@@ -6522,8 +6522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="Larvesta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="View Larvesta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" alt="Larvesta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">636</span>
                             Larvesta
@@ -6532,8 +6532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="Volcarona">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="View Volcarona on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" alt="Volcarona" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">637</span>
                             Volcarona
@@ -6542,8 +6542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cobalion/" title="Cobalion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/638.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cobalion/" title="View Cobalion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/638.png" alt="Cobalion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">638</span>
                             Cobalion
@@ -6552,8 +6552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/terrakion/" title="Terrakion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/639.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/terrakion/" title="View Terrakion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/639.png" alt="Terrakion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">639</span>
                             Terrakion
@@ -6562,8 +6562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/virizion/" title="Virizion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/640.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/virizion/" title="View Virizion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/640.png" alt="Virizion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">640</span>
                             Virizion
@@ -6572,8 +6572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tornadus/" title="Tornadus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/641.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tornadus/" title="View Tornadus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/641.png" alt="Tornadus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">641</span>
                             Tornadus
@@ -6582,8 +6582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/thundurus/" title="Thundurus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/642.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/thundurus/" title="View Thundurus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/642.png" alt="Thundurus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">642</span>
                             Thundurus
@@ -6592,8 +6592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/reshiram/" title="Reshiram">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/643.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/reshiram/" title="View Reshiram on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/643.png" alt="Reshiram" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">643</span>
                             Reshiram
@@ -6602,8 +6602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zekrom/" title="Zekrom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/644.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zekrom/" title="View Zekrom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/644.png" alt="Zekrom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">644</span>
                             Zekrom
@@ -6612,8 +6612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/landorus/" title="Landorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/645.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/landorus/" title="View Landorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/645.png" alt="Landorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">645</span>
                             Landorus
@@ -6622,8 +6622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyurem/" title="Kyurem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/646.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyurem/" title="View Kyurem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/646.png" alt="Kyurem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">646</span>
                             Kyurem
@@ -6632,8 +6632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/keldeo/" title="Keldeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/647.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/keldeo/" title="View Keldeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/647.png" alt="Keldeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">647</span>
                             Keldeo
@@ -6642,8 +6642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meloetta/" title="Meloetta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/648.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meloetta/" title="View Meloetta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/648.png" alt="Meloetta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">648</span>
                             Meloetta
@@ -6652,8 +6652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/genesect/" title="Genesect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/649.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/genesect/" title="View Genesect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/649.png" alt="Genesect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">649</span>
                             Genesect
@@ -6662,8 +6662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chespin/" title="Chespin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/650.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chespin/" title="View Chespin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/650.png" alt="Chespin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">650</span>
                             Chespin
@@ -6672,8 +6672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilladin/" title="Quilladin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/651.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilladin/" title="View Quilladin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/651.png" alt="Quilladin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">651</span>
                             Quilladin
@@ -6682,8 +6682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chesnaught/" title="Chesnaught">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/652.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chesnaught/" title="View Chesnaught on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/652.png" alt="Chesnaught" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">652</span>
                             Chesnaught
@@ -6692,8 +6692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fennekin/" title="Fennekin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/653.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fennekin/" title="View Fennekin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/653.png" alt="Fennekin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">653</span>
                             Fennekin
@@ -6702,8 +6702,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/braixen/" title="Braixen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/654.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/braixen/" title="View Braixen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/654.png" alt="Braixen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">654</span>
                             Braixen
@@ -6712,8 +6712,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delphox/" title="Delphox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/655.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delphox/" title="View Delphox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/655.png" alt="Delphox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">655</span>
                             Delphox
@@ -6722,8 +6722,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froakie/" title="Froakie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/656.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froakie/" title="View Froakie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/656.png" alt="Froakie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">656</span>
                             Froakie
@@ -6732,8 +6732,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frogadier/" title="Frogadier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/657.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frogadier/" title="View Frogadier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/657.png" alt="Frogadier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">657</span>
                             Frogadier
@@ -6742,8 +6742,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/greninja/" title="Greninja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/658.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/greninja/" title="View Greninja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/658.png" alt="Greninja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">658</span>
                             Greninja
@@ -6752,8 +6752,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bunnelby/" title="Bunnelby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/659.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bunnelby/" title="View Bunnelby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/659.png" alt="Bunnelby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">659</span>
                             Bunnelby
@@ -6762,8 +6762,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diggersby/" title="Diggersby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/660.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diggersby/" title="View Diggersby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/660.png" alt="Diggersby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">660</span>
                             Diggersby
@@ -6779,8 +6779,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fletchling/" title="Fletchling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/661.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fletchling/" title="View Fletchling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/661.png" alt="Fletchling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">661</span>
                             Fletchling
@@ -6789,8 +6789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fletchinder/" title="Fletchinder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/662.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fletchinder/" title="View Fletchinder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/662.png" alt="Fletchinder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">662</span>
                             Fletchinder
@@ -6799,8 +6799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/talonflame/" title="Talonflame">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/663.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/talonflame/" title="View Talonflame on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/663.png" alt="Talonflame" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">663</span>
                             Talonflame
@@ -6809,8 +6809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scatterbug/" title="Scatterbug">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/664.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scatterbug/" title="View Scatterbug on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/664.png" alt="Scatterbug" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">664</span>
                             Scatterbug
@@ -6819,8 +6819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spewpa/" title="Spewpa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/665.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spewpa/" title="View Spewpa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/665.png" alt="Spewpa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">665</span>
                             Spewpa
@@ -6829,8 +6829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vivillon/" title="Vivillon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/666.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vivillon/" title="View Vivillon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/666.png" alt="Vivillon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">666</span>
                             Vivillon
@@ -6839,8 +6839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litleo/" title="Litleo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/667.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litleo/" title="View Litleo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/667.png" alt="Litleo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">667</span>
                             Litleo
@@ -6849,8 +6849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pyroar/" title="Pyroar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/668.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pyroar/" title="View Pyroar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/668.png" alt="Pyroar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">668</span>
                             Pyroar
@@ -6859,8 +6859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flabebe/" title="Flabébé">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/669.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flabebe/" title="View Flabébé on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/669.png" alt="Flabébé" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">669</span>
                             Flabébé
@@ -6869,8 +6869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/floette/" title="Floette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/670.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/floette/" title="View Floette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/670.png" alt="Floette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">670</span>
                             Floette
@@ -6879,8 +6879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/florges/" title="Florges">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/671.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/florges/" title="View Florges on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/671.png" alt="Florges" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">671</span>
                             Florges
@@ -6889,8 +6889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiddo/" title="Skiddo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/672.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiddo/" title="View Skiddo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/672.png" alt="Skiddo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">672</span>
                             Skiddo
@@ -6899,8 +6899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gogoat/" title="Gogoat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/673.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gogoat/" title="View Gogoat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/673.png" alt="Gogoat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">673</span>
                             Gogoat
@@ -6909,8 +6909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pancham/" title="Pancham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/674.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pancham/" title="View Pancham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/674.png" alt="Pancham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">674</span>
                             Pancham
@@ -6919,8 +6919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pangoro/" title="Pangoro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/675.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pangoro/" title="View Pangoro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/675.png" alt="Pangoro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">675</span>
                             Pangoro
@@ -6929,8 +6929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furfrou/" title="Furfrou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/676.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furfrou/" title="View Furfrou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/676.png" alt="Furfrou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">676</span>
                             Furfrou
@@ -6939,8 +6939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espurr/" title="Espurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/677.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espurr/" title="View Espurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/677.png" alt="Espurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">677</span>
                             Espurr
@@ -6949,8 +6949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowstic/" title="Meowstic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/678.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowstic/" title="View Meowstic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/678.png" alt="Meowstic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">678</span>
                             Meowstic
@@ -6959,8 +6959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honedge/" title="Honedge">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/679.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honedge/" title="View Honedge on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/679.png" alt="Honedge" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">679</span>
                             Honedge
@@ -6969,8 +6969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doublade/" title="Doublade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/680.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doublade/" title="View Doublade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/680.png" alt="Doublade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">680</span>
                             Doublade
@@ -6979,8 +6979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aegislash/" title="Aegislash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/681.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aegislash/" title="View Aegislash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/681.png" alt="Aegislash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">681</span>
                             Aegislash
@@ -6989,8 +6989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spritzee/" title="Spritzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/682.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spritzee/" title="View Spritzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/682.png" alt="Spritzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">682</span>
                             Spritzee
@@ -6999,8 +6999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aromatisse/" title="Aromatisse">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/683.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aromatisse/" title="View Aromatisse on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/683.png" alt="Aromatisse" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">683</span>
                             Aromatisse
@@ -7009,8 +7009,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swirlix/" title="Swirlix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/684.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swirlix/" title="View Swirlix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/684.png" alt="Swirlix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">684</span>
                             Swirlix
@@ -7019,8 +7019,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slurpuff/" title="Slurpuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/685.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slurpuff/" title="View Slurpuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/685.png" alt="Slurpuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">685</span>
                             Slurpuff
@@ -7029,8 +7029,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="Inkay">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="View Inkay on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" alt="Inkay" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">686</span>
                             Inkay
@@ -7039,8 +7039,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="Malamar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="View Malamar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" alt="Malamar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">687</span>
                             Malamar
@@ -7049,8 +7049,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/binacle/" title="Binacle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/688.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/binacle/" title="View Binacle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/688.png" alt="Binacle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">688</span>
                             Binacle
@@ -7059,8 +7059,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barbaracle/" title="Barbaracle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/689.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barbaracle/" title="View Barbaracle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/689.png" alt="Barbaracle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">689</span>
                             Barbaracle
@@ -7069,8 +7069,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skrelp/" title="Skrelp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/690.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skrelp/" title="View Skrelp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/690.png" alt="Skrelp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">690</span>
                             Skrelp
@@ -7086,8 +7086,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragalge/" title="Dragalge">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/691.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragalge/" title="View Dragalge on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/691.png" alt="Dragalge" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">691</span>
                             Dragalge
@@ -7096,8 +7096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clauncher/" title="Clauncher">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/692.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clauncher/" title="View Clauncher on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/692.png" alt="Clauncher" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">692</span>
                             Clauncher
@@ -7106,8 +7106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clawitzer/" title="Clawitzer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/693.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clawitzer/" title="View Clawitzer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/693.png" alt="Clawitzer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">693</span>
                             Clawitzer
@@ -7116,8 +7116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/helioptile/" title="Helioptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/694.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/helioptile/" title="View Helioptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/694.png" alt="Helioptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">694</span>
                             Helioptile
@@ -7126,8 +7126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heliolisk/" title="Heliolisk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/695.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heliolisk/" title="View Heliolisk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/695.png" alt="Heliolisk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">695</span>
                             Heliolisk
@@ -7136,8 +7136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrunt/" title="Tyrunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/696.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrunt/" title="View Tyrunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/696.png" alt="Tyrunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">696</span>
                             Tyrunt
@@ -7146,8 +7146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrantrum/" title="Tyrantrum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/697.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrantrum/" title="View Tyrantrum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/697.png" alt="Tyrantrum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">697</span>
                             Tyrantrum
@@ -7156,8 +7156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/amaura/" title="Amaura">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/698.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/amaura/" title="View Amaura on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/698.png" alt="Amaura" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">698</span>
                             Amaura
@@ -7166,8 +7166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aurorus/" title="Aurorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/699.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aurorus/" title="View Aurorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/699.png" alt="Aurorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">699</span>
                             Aurorus
@@ -7176,8 +7176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sylveon/" title="Sylveon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/700.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sylveon/" title="View Sylveon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/700.png" alt="Sylveon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">700</span>
                             Sylveon
@@ -7186,8 +7186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hawlucha/" title="Hawlucha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/701.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hawlucha/" title="View Hawlucha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/701.png" alt="Hawlucha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">701</span>
                             Hawlucha
@@ -7196,8 +7196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dedenne/" title="Dedenne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/702.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dedenne/" title="View Dedenne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/702.png" alt="Dedenne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">702</span>
                             Dedenne
@@ -7206,8 +7206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carbink/" title="Carbink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/703.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carbink/" title="View Carbink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/703.png" alt="Carbink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">703</span>
                             Carbink
@@ -7216,8 +7216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="Goomy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="View Goomy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" alt="Goomy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">704</span>
                             Goomy
@@ -7226,8 +7226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="Sliggoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="View Sliggoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" alt="Sliggoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">705</span>
                             Sliggoo
@@ -7236,8 +7236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="Goodra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="View Goodra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" alt="Goodra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">706</span>
                             Goodra
@@ -7246,8 +7246,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klefki/" title="Klefki">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/707.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klefki/" title="View Klefki on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/707.png" alt="Klefki" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">707</span>
                             Klefki
@@ -7256,8 +7256,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phantump/" title="Phantump">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/708.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phantump/" title="View Phantump on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/708.png" alt="Phantump" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">708</span>
                             Phantump
@@ -7266,8 +7266,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trevenant/" title="Trevenant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/709.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trevenant/" title="View Trevenant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/709.png" alt="Trevenant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">709</span>
                             Trevenant
@@ -7276,8 +7276,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pumpkaboo/" title="Pumpkaboo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/710.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pumpkaboo/" title="View Pumpkaboo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/710.png" alt="Pumpkaboo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">710</span>
                             Pumpkaboo
@@ -7286,8 +7286,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gourgeist/" title="Gourgeist">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/711.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gourgeist/" title="View Gourgeist on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/711.png" alt="Gourgeist" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">711</span>
                             Gourgeist
@@ -7296,8 +7296,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bergmite/" title="Bergmite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/712.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bergmite/" title="View Bergmite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/712.png" alt="Bergmite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">712</span>
                             Bergmite
@@ -7306,8 +7306,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/avalugg/" title="Avalugg">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/713.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/avalugg/" title="View Avalugg on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/713.png" alt="Avalugg" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">713</span>
                             Avalugg
@@ -7316,8 +7316,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noibat/" title="Noibat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/714.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noibat/" title="View Noibat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/714.png" alt="Noibat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">714</span>
                             Noibat
@@ -7326,8 +7326,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noivern/" title="Noivern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/715.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noivern/" title="View Noivern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/715.png" alt="Noivern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">715</span>
                             Noivern
@@ -7336,8 +7336,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xerneas/" title="Xerneas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/716.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xerneas/" title="View Xerneas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/716.png" alt="Xerneas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">716</span>
                             Xerneas
@@ -7346,8 +7346,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yveltal/" title="Yveltal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/717.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yveltal/" title="View Yveltal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/717.png" alt="Yveltal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">717</span>
                             Yveltal
@@ -7356,8 +7356,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zygarde/" title="Zygarde">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/718.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zygarde/" title="View Zygarde on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/718.png" alt="Zygarde" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">718</span>
                             Zygarde
@@ -7371,8 +7371,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/red-blue-yellow.html
+++ b/docs/red-blue-yellow.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Bulbasaur
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Ivysaur
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Venusaur
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Charmander
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Charmeleon
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Charizard
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Squirtle
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Wartortle
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Blastoise
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Caterpie
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Metapod
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Butterfree
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="Weedle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="View Weedle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" alt="Weedle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Weedle
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="Kakuna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="View Kakuna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" alt="Kakuna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Kakuna
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="Beedrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="View Beedrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" alt="Beedrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Beedrill
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="Pidgey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="View Pidgey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" alt="Pidgey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Pidgey
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="Pidgeotto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="View Pidgeotto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" alt="Pidgeotto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Pidgeotto
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="Pidgeot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="View Pidgeot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" alt="Pidgeot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Pidgeot
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="Rattata">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="View Rattata on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" alt="Rattata" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Rattata
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="Raticate">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="View Raticate on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" alt="Raticate" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Raticate
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="Spearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="View Spearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" alt="Spearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Spearow
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="Fearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="View Fearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" alt="Fearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fearow
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="Ekans">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="View Ekans on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" alt="Ekans" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Ekans
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="Arbok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="View Arbok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" alt="Arbok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Arbok
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Pikachu
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Raichu
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Sandshrew
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Sandslash
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="Nidoran♀">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="View Nidoran♀ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" alt="Nidoran♀" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nidoran♀
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="Nidorina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="View Nidorina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" alt="Nidorina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Nidorina
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="Nidoqueen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="View Nidoqueen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" alt="Nidoqueen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Nidoqueen
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="Nidoran♂">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="View Nidoran♂ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" alt="Nidoran♂" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Nidoran♂
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="Nidorino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="View Nidorino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" alt="Nidorino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Nidorino
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="Nidoking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="View Nidoking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" alt="Nidoking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Nidoking
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Clefairy
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Clefable
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Vulpix
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ninetales
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Jigglypuff
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Wigglytuff
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="Zubat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="View Zubat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" alt="Zubat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Zubat
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="Golbat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="View Golbat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" alt="Golbat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Golbat
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Oddish
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Gloom
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Vileplume
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="Paras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="View Paras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" alt="Paras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Paras
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="Parasect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="View Parasect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" alt="Parasect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Parasect
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="Venonat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="View Venonat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" alt="Venonat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Venonat
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="Venomoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="View Venomoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" alt="Venomoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Venomoth
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Diglett
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Dugtrio
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Meowth
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Persian
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Psyduck
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Golduck
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="Mankey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="View Mankey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" alt="Mankey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Mankey
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="Primeape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="View Primeape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" alt="Primeape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Primeape
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Growlithe
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Arcanine
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Poliwag
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Poliwhirl
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Poliwrath
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Abra
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Kadabra
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Alakazam
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Machop
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Machoke
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Machamp
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="Bellsprout">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="View Bellsprout on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" alt="Bellsprout" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Bellsprout
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="Weepinbell">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="View Weepinbell on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" alt="Weepinbell" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Weepinbell
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="Victreebel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="View Victreebel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" alt="Victreebel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Victreebel
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Tentacool
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Tentacruel
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="Geodude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="View Geodude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" alt="Geodude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Geodude
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="Graveler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="View Graveler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" alt="Graveler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Graveler
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="Golem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="View Golem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" alt="Golem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Golem
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Ponyta
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Rapidash
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Slowpoke
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Slowbro
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Magnemite
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Magneton
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="Farfetch’d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="View Farfetch’d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch’d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Farfetch’d
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="Doduo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="View Doduo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" alt="Doduo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Doduo
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="Dodrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="View Dodrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" alt="Dodrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Dodrio
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="Seel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="View Seel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" alt="Seel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Seel
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="Dewgong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="View Dewgong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" alt="Dewgong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Dewgong
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="Grimer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="View Grimer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" alt="Grimer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Grimer
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="Muk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="View Muk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" alt="Muk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Muk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Shellder
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Cloyster
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Gastly
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Haunter
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Gengar
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Onix
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="Drowzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="View Drowzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" alt="Drowzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Drowzee
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="Hypno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="View Hypno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" alt="Hypno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Hypno
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="Voltorb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="View Voltorb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" alt="Voltorb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Voltorb
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="Electrode">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="View Electrode on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" alt="Electrode" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Electrode
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Exeggcute
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Exeggutor
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Cubone
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Marowak
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Hitmonlee
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Hitmonchan
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Lickitung
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Koffing
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Weezing
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Rhyhorn
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Rhydon
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Chansey
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Tangela
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Kangaskhan
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Horsea
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Seadra
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Goldeen
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Seaking
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Staryu
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Starmie
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Mr. Mime
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Scyther
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="Jynx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="View Jynx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" alt="Jynx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Jynx
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="Electabuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="View Electabuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" alt="Electabuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Electabuzz
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="Magmar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="View Magmar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" alt="Magmar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Magmar
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Pinsir
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Tauros
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Magikarp
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Gyarados
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Lapras
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Ditto
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Eevee
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Vaporeon
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Jolteon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Flareon
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Porygon
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="Omanyte">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="View Omanyte on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" alt="Omanyte" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Omanyte
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="Omastar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="View Omastar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" alt="Omastar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Omastar
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="Kabuto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="View Kabuto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" alt="Kabuto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Kabuto
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="Kabutops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="View Kabutops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" alt="Kabutops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Kabutops
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="Aerodactyl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="View Aerodactyl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" alt="Aerodactyl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Aerodactyl
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Snorlax
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="Articuno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="View Articuno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" alt="Articuno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Articuno
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="Zapdos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="View Zapdos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" alt="Zapdos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Zapdos
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="Moltres">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="View Moltres on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" alt="Moltres" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Moltres
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="Dratini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="View Dratini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" alt="Dratini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Dratini
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="Dragonair">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="View Dragonair on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" alt="Dragonair" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Dragonair
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="Dragonite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="View Dragonite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" alt="Dragonite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Dragonite
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="Mewtwo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="View Mewtwo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" alt="Mewtwo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Mewtwo
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="Mew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="View Mew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" alt="Mew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Mew
@@ -1575,8 +1575,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/ruby-sapphire-emerald.html
+++ b/docs/ruby-sapphire-emerald.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Bulbasaur
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Ivysaur
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Venusaur
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Charmander
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Charmeleon
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Charizard
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Squirtle
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Wartortle
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Blastoise
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Caterpie
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Metapod
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Butterfree
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="Weedle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="View Weedle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" alt="Weedle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Weedle
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="Kakuna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="View Kakuna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" alt="Kakuna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Kakuna
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="Beedrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="View Beedrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" alt="Beedrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Beedrill
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="Pidgey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="View Pidgey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" alt="Pidgey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Pidgey
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="Pidgeotto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="View Pidgeotto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" alt="Pidgeotto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Pidgeotto
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="Pidgeot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="View Pidgeot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" alt="Pidgeot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Pidgeot
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="Rattata">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="View Rattata on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" alt="Rattata" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Rattata
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="Raticate">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="View Raticate on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" alt="Raticate" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Raticate
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="Spearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="View Spearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" alt="Spearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Spearow
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="Fearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="View Fearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" alt="Fearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fearow
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="Ekans">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="View Ekans on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" alt="Ekans" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Ekans
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="Arbok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="View Arbok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" alt="Arbok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Arbok
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Pikachu
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Raichu
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Sandshrew
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Sandslash
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="Nidoran♀">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="View Nidoran♀ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" alt="Nidoran♀" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nidoran♀
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="Nidorina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="View Nidorina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" alt="Nidorina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Nidorina
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="Nidoqueen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="View Nidoqueen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" alt="Nidoqueen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Nidoqueen
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="Nidoran♂">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="View Nidoran♂ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" alt="Nidoran♂" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Nidoran♂
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="Nidorino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="View Nidorino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" alt="Nidorino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Nidorino
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="Nidoking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="View Nidoking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" alt="Nidoking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Nidoking
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Clefairy
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Clefable
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Vulpix
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ninetales
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Jigglypuff
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Wigglytuff
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="Zubat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="View Zubat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" alt="Zubat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Zubat
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="Golbat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="View Golbat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" alt="Golbat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Golbat
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Oddish
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Gloom
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Vileplume
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="Paras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="View Paras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" alt="Paras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Paras
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="Parasect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="View Parasect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" alt="Parasect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Parasect
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="Venonat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="View Venonat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" alt="Venonat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Venonat
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="Venomoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="View Venomoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" alt="Venomoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Venomoth
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Diglett
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Dugtrio
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Meowth
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Persian
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Psyduck
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Golduck
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="Mankey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="View Mankey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" alt="Mankey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Mankey
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="Primeape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="View Primeape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" alt="Primeape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Primeape
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Growlithe
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Arcanine
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Poliwag
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Poliwhirl
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Poliwrath
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Abra
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Kadabra
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Alakazam
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Machop
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Machoke
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Machamp
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="Bellsprout">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="View Bellsprout on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" alt="Bellsprout" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Bellsprout
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="Weepinbell">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="View Weepinbell on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" alt="Weepinbell" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Weepinbell
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="Victreebel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="View Victreebel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" alt="Victreebel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Victreebel
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Tentacool
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Tentacruel
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="Geodude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="View Geodude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" alt="Geodude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Geodude
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="Graveler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="View Graveler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" alt="Graveler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Graveler
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="Golem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="View Golem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" alt="Golem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Golem
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Ponyta
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Rapidash
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Slowpoke
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Slowbro
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Magnemite
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Magneton
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="Farfetch’d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="View Farfetch’d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch’d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Farfetch’d
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="Doduo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="View Doduo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" alt="Doduo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Doduo
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="Dodrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="View Dodrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" alt="Dodrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Dodrio
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="Seel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="View Seel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" alt="Seel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Seel
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="Dewgong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="View Dewgong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" alt="Dewgong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Dewgong
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="Grimer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="View Grimer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" alt="Grimer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Grimer
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="Muk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="View Muk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" alt="Muk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Muk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Shellder
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Cloyster
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Gastly
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Haunter
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Gengar
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Onix
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="Drowzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="View Drowzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" alt="Drowzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Drowzee
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="Hypno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="View Hypno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" alt="Hypno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Hypno
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="Voltorb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="View Voltorb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" alt="Voltorb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Voltorb
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="Electrode">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="View Electrode on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" alt="Electrode" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Electrode
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Exeggcute
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Exeggutor
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Cubone
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Marowak
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Hitmonlee
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Hitmonchan
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Lickitung
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Koffing
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Weezing
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Rhyhorn
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Rhydon
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Chansey
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Tangela
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Kangaskhan
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Horsea
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Seadra
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Goldeen
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Seaking
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Staryu
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Starmie
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Mr. Mime
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Scyther
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="Jynx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="View Jynx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" alt="Jynx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Jynx
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="Electabuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="View Electabuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" alt="Electabuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Electabuzz
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="Magmar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="View Magmar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" alt="Magmar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Magmar
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Pinsir
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Tauros
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Magikarp
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Gyarados
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Lapras
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Ditto
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Eevee
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Vaporeon
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Jolteon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Flareon
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Porygon
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="Omanyte">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="View Omanyte on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" alt="Omanyte" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Omanyte
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="Omastar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="View Omastar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" alt="Omastar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Omastar
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="Kabuto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="View Kabuto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" alt="Kabuto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Kabuto
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="Kabutops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="View Kabutops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" alt="Kabutops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Kabutops
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="Aerodactyl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="View Aerodactyl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" alt="Aerodactyl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Aerodactyl
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Snorlax
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="Articuno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="View Articuno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" alt="Articuno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Articuno
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="Zapdos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="View Zapdos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" alt="Zapdos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Zapdos
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="Moltres">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="View Moltres on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" alt="Moltres" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Moltres
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="Dratini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="View Dratini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" alt="Dratini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Dratini
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="Dragonair">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="View Dragonair on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" alt="Dragonair" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Dragonair
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="Dragonite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="View Dragonite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" alt="Dragonite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Dragonite
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="Mewtwo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="View Mewtwo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" alt="Mewtwo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Mewtwo
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="Mew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="View Mew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" alt="Mew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Mew
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="Chikorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="View Chikorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" alt="Chikorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Chikorita
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="Bayleef">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="View Bayleef on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" alt="Bayleef" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Bayleef
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="Meganium">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="View Meganium on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" alt="Meganium" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Meganium
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="Cyndaquil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="View Cyndaquil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" alt="Cyndaquil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Cyndaquil
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="Quilava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="View Quilava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" alt="Quilava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Quilava
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="Typhlosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="View Typhlosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" alt="Typhlosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Typhlosion
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="Totodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="View Totodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" alt="Totodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Totodile
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="Croconaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="View Croconaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" alt="Croconaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Croconaw
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="Feraligatr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="View Feraligatr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" alt="Feraligatr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Feraligatr
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="Sentret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="View Sentret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" alt="Sentret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Sentret
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="Furret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="View Furret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" alt="Furret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Furret
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="Hoothoot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="View Hoothoot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" alt="Hoothoot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Hoothoot
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="Noctowl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="View Noctowl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" alt="Noctowl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Noctowl
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="Ledyba">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="View Ledyba on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" alt="Ledyba" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Ledyba
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="Ledian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="View Ledian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" alt="Ledian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Ledian
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="Spinarak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="View Spinarak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" alt="Spinarak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Spinarak
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="Ariados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="View Ariados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" alt="Ariados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Ariados
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="Crobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="View Crobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" alt="Crobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Crobat
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Chinchou
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Lanturn
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Pichu
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="Cleffa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="View Cleffa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" alt="Cleffa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Cleffa
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="Igglybuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="View Igglybuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" alt="Igglybuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Igglybuff
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="Togepi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="View Togepi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" alt="Togepi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Togepi
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="Togetic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="View Togetic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" alt="Togetic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Togetic
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="Natu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="View Natu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" alt="Natu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Natu
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="Xatu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="View Xatu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" alt="Xatu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Xatu
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="Mareep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="View Mareep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" alt="Mareep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Mareep
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="Flaaffy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="View Flaaffy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" alt="Flaaffy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Flaaffy
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="Ampharos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="View Ampharos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" alt="Ampharos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Ampharos
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="Bellossom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="View Bellossom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" alt="Bellossom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Bellossom
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="Marill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="View Marill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" alt="Marill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Marill
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="Azumarill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="View Azumarill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" alt="Azumarill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Azumarill
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="Sudowoodo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="View Sudowoodo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" alt="Sudowoodo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Sudowoodo
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="Politoed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="View Politoed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" alt="Politoed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Politoed
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="Hoppip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="View Hoppip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" alt="Hoppip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Hoppip
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="Skiploom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="View Skiploom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" alt="Skiploom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Skiploom
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="Jumpluff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="View Jumpluff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" alt="Jumpluff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Jumpluff
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="Aipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="View Aipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" alt="Aipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Aipom
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="Sunkern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="View Sunkern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" alt="Sunkern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Sunkern
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="Sunflora">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="View Sunflora on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" alt="Sunflora" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Sunflora
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="Yanma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="View Yanma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" alt="Yanma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Yanma
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Wooper
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Quagsire
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="Espeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="View Espeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" alt="Espeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Espeon
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="Umbreon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="View Umbreon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" alt="Umbreon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Umbreon
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="Murkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="View Murkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" alt="Murkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Murkrow
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="Slowking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="View Slowking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" alt="Slowking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Slowking
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="Misdreavus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="View Misdreavus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" alt="Misdreavus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Misdreavus
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="Unown">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="View Unown on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" alt="Unown" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Unown
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="Wobbuffet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="View Wobbuffet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" alt="Wobbuffet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Wobbuffet
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="Girafarig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="View Girafarig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" alt="Girafarig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Girafarig
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="Pineco">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="View Pineco on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" alt="Pineco" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Pineco
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="Forretress">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="View Forretress on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" alt="Forretress" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Forretress
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="Dunsparce">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="View Dunsparce on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" alt="Dunsparce" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Dunsparce
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="Gligar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="View Gligar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" alt="Gligar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Gligar
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="Steelix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="View Steelix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" alt="Steelix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Steelix
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="Snubbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="View Snubbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" alt="Snubbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Snubbull
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="Granbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="View Granbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" alt="Granbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Granbull
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="Qwilfish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="View Qwilfish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" alt="Qwilfish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Qwilfish
@@ -2184,8 +2184,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="Scizor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="View Scizor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" alt="Scizor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">212</span>
                             Scizor
@@ -2194,8 +2194,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="Shuckle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="View Shuckle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" alt="Shuckle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">213</span>
                             Shuckle
@@ -2204,8 +2204,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="Heracross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="View Heracross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" alt="Heracross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">214</span>
                             Heracross
@@ -2214,8 +2214,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="Sneasel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="View Sneasel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" alt="Sneasel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">215</span>
                             Sneasel
@@ -2224,8 +2224,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="Teddiursa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="View Teddiursa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" alt="Teddiursa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">216</span>
                             Teddiursa
@@ -2234,8 +2234,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="Ursaring">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="View Ursaring on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" alt="Ursaring" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">217</span>
                             Ursaring
@@ -2244,8 +2244,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="Slugma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="View Slugma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" alt="Slugma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">218</span>
                             Slugma
@@ -2254,8 +2254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="Magcargo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="View Magcargo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" alt="Magcargo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">219</span>
                             Magcargo
@@ -2264,8 +2264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="Swinub">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="View Swinub on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" alt="Swinub" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">220</span>
                             Swinub
@@ -2274,8 +2274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="Piloswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="View Piloswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" alt="Piloswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">221</span>
                             Piloswine
@@ -2284,8 +2284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="Corsola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="View Corsola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" alt="Corsola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">222</span>
                             Corsola
@@ -2294,8 +2294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">223</span>
                             Remoraid
@@ -2304,8 +2304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">224</span>
                             Octillery
@@ -2314,8 +2314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="Delibird">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="View Delibird on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" alt="Delibird" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">225</span>
                             Delibird
@@ -2324,8 +2324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">226</span>
                             Mantine
@@ -2334,8 +2334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="Skarmory">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="View Skarmory on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" alt="Skarmory" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">227</span>
                             Skarmory
@@ -2344,8 +2344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="Houndour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="View Houndour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" alt="Houndour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">228</span>
                             Houndour
@@ -2354,8 +2354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="Houndoom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="View Houndoom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" alt="Houndoom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">229</span>
                             Houndoom
@@ -2364,8 +2364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="Kingdra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="View Kingdra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" alt="Kingdra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">230</span>
                             Kingdra
@@ -2374,8 +2374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="Phanpy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="View Phanpy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" alt="Phanpy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">231</span>
                             Phanpy
@@ -2384,8 +2384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="Donphan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="View Donphan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" alt="Donphan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">232</span>
                             Donphan
@@ -2394,8 +2394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="Porygon2">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="View Porygon2 on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" alt="Porygon2" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">233</span>
                             Porygon2
@@ -2404,8 +2404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="Stantler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="View Stantler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" alt="Stantler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">234</span>
                             Stantler
@@ -2414,8 +2414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="Smeargle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="View Smeargle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" alt="Smeargle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">235</span>
                             Smeargle
@@ -2424,8 +2424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="Tyrogue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="View Tyrogue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" alt="Tyrogue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">236</span>
                             Tyrogue
@@ -2434,8 +2434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="Hitmontop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="View Hitmontop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" alt="Hitmontop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">237</span>
                             Hitmontop
@@ -2444,8 +2444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="Smoochum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="View Smoochum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" alt="Smoochum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">238</span>
                             Smoochum
@@ -2454,8 +2454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="Elekid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="View Elekid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" alt="Elekid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">239</span>
                             Elekid
@@ -2464,8 +2464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="Magby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="View Magby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" alt="Magby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">240</span>
                             Magby
@@ -2481,8 +2481,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="Miltank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="View Miltank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" alt="Miltank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">241</span>
                             Miltank
@@ -2491,8 +2491,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="Blissey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="View Blissey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" alt="Blissey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">242</span>
                             Blissey
@@ -2501,8 +2501,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="Raikou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="View Raikou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" alt="Raikou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">243</span>
                             Raikou
@@ -2511,8 +2511,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="Entei">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="View Entei on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" alt="Entei" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">244</span>
                             Entei
@@ -2521,8 +2521,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="Suicune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="View Suicune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" alt="Suicune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">245</span>
                             Suicune
@@ -2531,8 +2531,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="Larvitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="View Larvitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" alt="Larvitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">246</span>
                             Larvitar
@@ -2541,8 +2541,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="Pupitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="View Pupitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" alt="Pupitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">247</span>
                             Pupitar
@@ -2551,8 +2551,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="Tyranitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="View Tyranitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" alt="Tyranitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">248</span>
                             Tyranitar
@@ -2561,8 +2561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="Lugia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="View Lugia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" alt="Lugia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">249</span>
                             Lugia
@@ -2571,8 +2571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="Ho-Oh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="View Ho-Oh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" alt="Ho-Oh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">250</span>
                             Ho-Oh
@@ -2581,8 +2581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="Celebi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="View Celebi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" alt="Celebi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">251</span>
                             Celebi
@@ -2591,8 +2591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="Treecko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="View Treecko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" alt="Treecko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">252</span>
                             Treecko
@@ -2601,8 +2601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="Grovyle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="View Grovyle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" alt="Grovyle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">253</span>
                             Grovyle
@@ -2611,8 +2611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="Sceptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="View Sceptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" alt="Sceptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">254</span>
                             Sceptile
@@ -2621,8 +2621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="Torchic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="View Torchic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" alt="Torchic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">255</span>
                             Torchic
@@ -2631,8 +2631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="Combusken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="View Combusken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" alt="Combusken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">256</span>
                             Combusken
@@ -2641,8 +2641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="Blaziken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="View Blaziken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" alt="Blaziken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">257</span>
                             Blaziken
@@ -2651,8 +2651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="Mudkip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="View Mudkip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" alt="Mudkip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">258</span>
                             Mudkip
@@ -2661,8 +2661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="Marshtomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="View Marshtomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" alt="Marshtomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">259</span>
                             Marshtomp
@@ -2671,8 +2671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="Swampert">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="View Swampert on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" alt="Swampert" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">260</span>
                             Swampert
@@ -2681,8 +2681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="Poochyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="View Poochyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" alt="Poochyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">261</span>
                             Poochyena
@@ -2691,8 +2691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="Mightyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="View Mightyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" alt="Mightyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">262</span>
                             Mightyena
@@ -2701,8 +2701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="Zigzagoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="View Zigzagoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" alt="Zigzagoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">263</span>
                             Zigzagoon
@@ -2711,8 +2711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="Linoone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="View Linoone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" alt="Linoone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">264</span>
                             Linoone
@@ -2721,8 +2721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="Wurmple">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="View Wurmple on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" alt="Wurmple" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">265</span>
                             Wurmple
@@ -2731,8 +2731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="Silcoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="View Silcoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" alt="Silcoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">266</span>
                             Silcoon
@@ -2741,8 +2741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="Beautifly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="View Beautifly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" alt="Beautifly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">267</span>
                             Beautifly
@@ -2751,8 +2751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="Cascoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="View Cascoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" alt="Cascoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">268</span>
                             Cascoon
@@ -2761,8 +2761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="Dustox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="View Dustox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" alt="Dustox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">269</span>
                             Dustox
@@ -2771,8 +2771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="Lotad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="View Lotad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" alt="Lotad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">270</span>
                             Lotad
@@ -2788,8 +2788,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="Lombre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="View Lombre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" alt="Lombre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">271</span>
                             Lombre
@@ -2798,8 +2798,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="Ludicolo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="View Ludicolo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" alt="Ludicolo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">272</span>
                             Ludicolo
@@ -2808,8 +2808,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="Seedot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="View Seedot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" alt="Seedot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">273</span>
                             Seedot
@@ -2818,8 +2818,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="Nuzleaf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="View Nuzleaf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" alt="Nuzleaf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">274</span>
                             Nuzleaf
@@ -2828,8 +2828,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="Shiftry">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="View Shiftry on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" alt="Shiftry" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">275</span>
                             Shiftry
@@ -2838,8 +2838,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="Taillow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="View Taillow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" alt="Taillow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">276</span>
                             Taillow
@@ -2848,8 +2848,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="Swellow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="View Swellow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" alt="Swellow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">277</span>
                             Swellow
@@ -2858,8 +2858,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="Wingull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="View Wingull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" alt="Wingull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">278</span>
                             Wingull
@@ -2868,8 +2868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="Pelipper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="View Pelipper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" alt="Pelipper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">279</span>
                             Pelipper
@@ -2878,8 +2878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="Ralts">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="View Ralts on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" alt="Ralts" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">280</span>
                             Ralts
@@ -2888,8 +2888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="Kirlia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="View Kirlia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" alt="Kirlia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">281</span>
                             Kirlia
@@ -2898,8 +2898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="Gardevoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="View Gardevoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" alt="Gardevoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">282</span>
                             Gardevoir
@@ -2908,8 +2908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="Surskit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="View Surskit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" alt="Surskit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">283</span>
                             Surskit
@@ -2918,8 +2918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="Masquerain">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="View Masquerain on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" alt="Masquerain" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">284</span>
                             Masquerain
@@ -2928,8 +2928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="Shroomish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="View Shroomish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" alt="Shroomish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">285</span>
                             Shroomish
@@ -2938,8 +2938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="Breloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="View Breloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" alt="Breloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">286</span>
                             Breloom
@@ -2948,8 +2948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="Slakoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="View Slakoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" alt="Slakoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">287</span>
                             Slakoth
@@ -2958,8 +2958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="Vigoroth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="View Vigoroth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" alt="Vigoroth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">288</span>
                             Vigoroth
@@ -2968,8 +2968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="Slaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="View Slaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" alt="Slaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">289</span>
                             Slaking
@@ -2978,8 +2978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="Nincada">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="View Nincada on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" alt="Nincada" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">290</span>
                             Nincada
@@ -2988,8 +2988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="Ninjask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="View Ninjask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" alt="Ninjask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">291</span>
                             Ninjask
@@ -2998,8 +2998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="Shedinja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="View Shedinja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" alt="Shedinja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">292</span>
                             Shedinja
@@ -3008,8 +3008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="Whismur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="View Whismur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" alt="Whismur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">293</span>
                             Whismur
@@ -3018,8 +3018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="Loudred">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="View Loudred on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" alt="Loudred" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">294</span>
                             Loudred
@@ -3028,8 +3028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="Exploud">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="View Exploud on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" alt="Exploud" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">295</span>
                             Exploud
@@ -3038,8 +3038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="Makuhita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="View Makuhita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" alt="Makuhita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">296</span>
                             Makuhita
@@ -3048,8 +3048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="Hariyama">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="View Hariyama on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" alt="Hariyama" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">297</span>
                             Hariyama
@@ -3058,8 +3058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="Azurill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="View Azurill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" alt="Azurill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">298</span>
                             Azurill
@@ -3068,8 +3068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="Nosepass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="View Nosepass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" alt="Nosepass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">299</span>
                             Nosepass
@@ -3078,8 +3078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="Skitty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="View Skitty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" alt="Skitty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">300</span>
                             Skitty
@@ -3095,8 +3095,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="Delcatty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="View Delcatty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" alt="Delcatty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">301</span>
                             Delcatty
@@ -3105,8 +3105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="Sableye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="View Sableye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" alt="Sableye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">302</span>
                             Sableye
@@ -3115,8 +3115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="Mawile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="View Mawile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" alt="Mawile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">303</span>
                             Mawile
@@ -3125,8 +3125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="Aron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="View Aron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" alt="Aron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">304</span>
                             Aron
@@ -3135,8 +3135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="Lairon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="View Lairon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" alt="Lairon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">305</span>
                             Lairon
@@ -3145,8 +3145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="Aggron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="View Aggron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" alt="Aggron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">306</span>
                             Aggron
@@ -3155,8 +3155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="Meditite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="View Meditite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" alt="Meditite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">307</span>
                             Meditite
@@ -3165,8 +3165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="Medicham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="View Medicham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" alt="Medicham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">308</span>
                             Medicham
@@ -3175,8 +3175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="Electrike">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="View Electrike on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" alt="Electrike" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">309</span>
                             Electrike
@@ -3185,8 +3185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="Manectric">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="View Manectric on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" alt="Manectric" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">310</span>
                             Manectric
@@ -3195,8 +3195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="Plusle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="View Plusle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" alt="Plusle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">311</span>
                             Plusle
@@ -3205,8 +3205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="Minun">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="View Minun on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" alt="Minun" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">312</span>
                             Minun
@@ -3215,8 +3215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="Volbeat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="View Volbeat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" alt="Volbeat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">313</span>
                             Volbeat
@@ -3225,8 +3225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="Illumise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="View Illumise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" alt="Illumise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">314</span>
                             Illumise
@@ -3235,8 +3235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="Roselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="View Roselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" alt="Roselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">315</span>
                             Roselia
@@ -3245,8 +3245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="Gulpin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="View Gulpin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" alt="Gulpin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">316</span>
                             Gulpin
@@ -3255,8 +3255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="Swalot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="View Swalot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" alt="Swalot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">317</span>
                             Swalot
@@ -3265,8 +3265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="Carvanha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="View Carvanha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" alt="Carvanha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">318</span>
                             Carvanha
@@ -3275,8 +3275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="Sharpedo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="View Sharpedo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" alt="Sharpedo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">319</span>
                             Sharpedo
@@ -3285,8 +3285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="Wailmer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="View Wailmer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" alt="Wailmer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">320</span>
                             Wailmer
@@ -3295,8 +3295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="Wailord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="View Wailord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" alt="Wailord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">321</span>
                             Wailord
@@ -3305,8 +3305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="Numel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="View Numel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" alt="Numel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">322</span>
                             Numel
@@ -3315,8 +3315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="Camerupt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="View Camerupt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" alt="Camerupt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">323</span>
                             Camerupt
@@ -3325,8 +3325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="Torkoal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="View Torkoal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" alt="Torkoal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">324</span>
                             Torkoal
@@ -3335,8 +3335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="Spoink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="View Spoink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" alt="Spoink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">325</span>
                             Spoink
@@ -3345,8 +3345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="Grumpig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="View Grumpig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" alt="Grumpig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">326</span>
                             Grumpig
@@ -3355,8 +3355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="Spinda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="View Spinda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" alt="Spinda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">327</span>
                             Spinda
@@ -3365,8 +3365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="Trapinch">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="View Trapinch on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" alt="Trapinch" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">328</span>
                             Trapinch
@@ -3375,8 +3375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="Vibrava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="View Vibrava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" alt="Vibrava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">329</span>
                             Vibrava
@@ -3385,8 +3385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="Flygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="View Flygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" alt="Flygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">330</span>
                             Flygon
@@ -3402,8 +3402,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="Cacnea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="View Cacnea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" alt="Cacnea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">331</span>
                             Cacnea
@@ -3412,8 +3412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="Cacturne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="View Cacturne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" alt="Cacturne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">332</span>
                             Cacturne
@@ -3422,8 +3422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="Swablu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="View Swablu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" alt="Swablu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">333</span>
                             Swablu
@@ -3432,8 +3432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="Altaria">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="View Altaria on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" alt="Altaria" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">334</span>
                             Altaria
@@ -3442,8 +3442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="Zangoose">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="View Zangoose on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" alt="Zangoose" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">335</span>
                             Zangoose
@@ -3452,8 +3452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="Seviper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="View Seviper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" alt="Seviper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">336</span>
                             Seviper
@@ -3462,8 +3462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="Lunatone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="View Lunatone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" alt="Lunatone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">337</span>
                             Lunatone
@@ -3472,8 +3472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="Solrock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="View Solrock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" alt="Solrock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">338</span>
                             Solrock
@@ -3482,8 +3482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="Barboach">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="View Barboach on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" alt="Barboach" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">339</span>
                             Barboach
@@ -3492,8 +3492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="Whiscash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="View Whiscash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" alt="Whiscash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">340</span>
                             Whiscash
@@ -3502,8 +3502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="Corphish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="View Corphish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" alt="Corphish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">341</span>
                             Corphish
@@ -3512,8 +3512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="Crawdaunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="View Crawdaunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" alt="Crawdaunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">342</span>
                             Crawdaunt
@@ -3522,8 +3522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="Baltoy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="View Baltoy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" alt="Baltoy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">343</span>
                             Baltoy
@@ -3532,8 +3532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="Claydol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="View Claydol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" alt="Claydol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">344</span>
                             Claydol
@@ -3542,8 +3542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="Lileep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="View Lileep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" alt="Lileep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">345</span>
                             Lileep
@@ -3552,8 +3552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="Cradily">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="View Cradily on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" alt="Cradily" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">346</span>
                             Cradily
@@ -3562,8 +3562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="Anorith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="View Anorith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" alt="Anorith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">347</span>
                             Anorith
@@ -3572,8 +3572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="Armaldo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="View Armaldo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" alt="Armaldo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">348</span>
                             Armaldo
@@ -3582,8 +3582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="Feebas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="View Feebas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" alt="Feebas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">349</span>
                             Feebas
@@ -3592,8 +3592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="Milotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="View Milotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" alt="Milotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">350</span>
                             Milotic
@@ -3602,8 +3602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="Castform">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="View Castform on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" alt="Castform" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">351</span>
                             Castform
@@ -3612,8 +3612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="Kecleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="View Kecleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" alt="Kecleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">352</span>
                             Kecleon
@@ -3622,8 +3622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="Shuppet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="View Shuppet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" alt="Shuppet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">353</span>
                             Shuppet
@@ -3632,8 +3632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="Banette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="View Banette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" alt="Banette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">354</span>
                             Banette
@@ -3642,8 +3642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="Duskull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="View Duskull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" alt="Duskull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">355</span>
                             Duskull
@@ -3652,8 +3652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="Dusclops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="View Dusclops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" alt="Dusclops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">356</span>
                             Dusclops
@@ -3662,8 +3662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="Tropius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="View Tropius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" alt="Tropius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">357</span>
                             Tropius
@@ -3672,8 +3672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="Chimecho">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="View Chimecho on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" alt="Chimecho" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">358</span>
                             Chimecho
@@ -3682,8 +3682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="Absol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="View Absol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" alt="Absol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">359</span>
                             Absol
@@ -3692,8 +3692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="Wynaut">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="View Wynaut on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" alt="Wynaut" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">360</span>
                             Wynaut
@@ -3709,8 +3709,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="Snorunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="View Snorunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" alt="Snorunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">361</span>
                             Snorunt
@@ -3719,8 +3719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="Glalie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="View Glalie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" alt="Glalie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">362</span>
                             Glalie
@@ -3729,8 +3729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="Spheal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="View Spheal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" alt="Spheal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">363</span>
                             Spheal
@@ -3739,8 +3739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="Sealeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="View Sealeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" alt="Sealeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">364</span>
                             Sealeo
@@ -3749,8 +3749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="Walrein">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="View Walrein on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" alt="Walrein" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">365</span>
                             Walrein
@@ -3759,8 +3759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="Clamperl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="View Clamperl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" alt="Clamperl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">366</span>
                             Clamperl
@@ -3769,8 +3769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="Huntail">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="View Huntail on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" alt="Huntail" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">367</span>
                             Huntail
@@ -3779,8 +3779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="Gorebyss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="View Gorebyss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" alt="Gorebyss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">368</span>
                             Gorebyss
@@ -3789,8 +3789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="Relicanth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="View Relicanth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" alt="Relicanth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">369</span>
                             Relicanth
@@ -3799,8 +3799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="Luvdisc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="View Luvdisc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" alt="Luvdisc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">370</span>
                             Luvdisc
@@ -3809,8 +3809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="Bagon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="View Bagon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" alt="Bagon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">371</span>
                             Bagon
@@ -3819,8 +3819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="Shelgon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="View Shelgon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" alt="Shelgon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">372</span>
                             Shelgon
@@ -3829,8 +3829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="Salamence">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="View Salamence on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" alt="Salamence" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">373</span>
                             Salamence
@@ -3839,8 +3839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="Beldum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="View Beldum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" alt="Beldum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">374</span>
                             Beldum
@@ -3849,8 +3849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="Metang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="View Metang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" alt="Metang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">375</span>
                             Metang
@@ -3859,8 +3859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="Metagross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="View Metagross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" alt="Metagross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">376</span>
                             Metagross
@@ -3869,8 +3869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="Regirock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="View Regirock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" alt="Regirock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">377</span>
                             Regirock
@@ -3879,8 +3879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="Regice">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="View Regice on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" alt="Regice" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">378</span>
                             Regice
@@ -3889,8 +3889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="Registeel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="View Registeel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" alt="Registeel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">379</span>
                             Registeel
@@ -3899,8 +3899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="Latias">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="View Latias on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" alt="Latias" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">380</span>
                             Latias
@@ -3909,8 +3909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="Latios">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="View Latios on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" alt="Latios" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">381</span>
                             Latios
@@ -3919,8 +3919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="Kyogre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="View Kyogre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" alt="Kyogre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">382</span>
                             Kyogre
@@ -3929,8 +3929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="Groudon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="View Groudon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" alt="Groudon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">383</span>
                             Groudon
@@ -3939,8 +3939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="Rayquaza">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="View Rayquaza on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" alt="Rayquaza" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">384</span>
                             Rayquaza
@@ -3949,8 +3949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="Jirachi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="View Jirachi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" alt="Jirachi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">385</span>
                             Jirachi
@@ -3959,8 +3959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="Deoxys">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="View Deoxys on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" alt="Deoxys" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">386</span>
                             Deoxys
@@ -3974,8 +3974,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/sun-moon.html
+++ b/docs/sun-moon.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Bulbasaur
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Ivysaur
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Venusaur
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Charmander
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Charmeleon
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Charizard
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Squirtle
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Wartortle
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Blastoise
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Caterpie
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Metapod
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Butterfree
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="Weedle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="View Weedle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" alt="Weedle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Weedle
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="Kakuna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="View Kakuna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" alt="Kakuna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Kakuna
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="Beedrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="View Beedrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" alt="Beedrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Beedrill
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="Pidgey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="View Pidgey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" alt="Pidgey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Pidgey
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="Pidgeotto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="View Pidgeotto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" alt="Pidgeotto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Pidgeotto
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="Pidgeot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="View Pidgeot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" alt="Pidgeot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Pidgeot
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="Rattata">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="View Rattata on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" alt="Rattata" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Rattata
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="Raticate">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="View Raticate on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" alt="Raticate" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Raticate
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="Spearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="View Spearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" alt="Spearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Spearow
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="Fearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="View Fearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" alt="Fearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fearow
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="Ekans">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="View Ekans on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" alt="Ekans" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Ekans
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="Arbok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="View Arbok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" alt="Arbok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Arbok
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Pikachu
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Raichu
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Sandshrew
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Sandslash
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="Nidoran♀">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="View Nidoran♀ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" alt="Nidoran♀" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nidoran♀
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="Nidorina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="View Nidorina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" alt="Nidorina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Nidorina
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="Nidoqueen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="View Nidoqueen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" alt="Nidoqueen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Nidoqueen
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="Nidoran♂">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="View Nidoran♂ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" alt="Nidoran♂" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Nidoran♂
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="Nidorino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="View Nidorino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" alt="Nidorino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Nidorino
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="Nidoking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="View Nidoking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" alt="Nidoking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Nidoking
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Clefairy
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Clefable
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Vulpix
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ninetales
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Jigglypuff
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Wigglytuff
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="Zubat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="View Zubat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" alt="Zubat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Zubat
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="Golbat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="View Golbat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" alt="Golbat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Golbat
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Oddish
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Gloom
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Vileplume
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="Paras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="View Paras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" alt="Paras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Paras
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="Parasect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="View Parasect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" alt="Parasect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Parasect
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="Venonat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="View Venonat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" alt="Venonat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Venonat
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="Venomoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="View Venomoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" alt="Venomoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Venomoth
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Diglett
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Dugtrio
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Meowth
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Persian
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Psyduck
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Golduck
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="Mankey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="View Mankey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" alt="Mankey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Mankey
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="Primeape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="View Primeape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" alt="Primeape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Primeape
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Growlithe
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Arcanine
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Poliwag
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Poliwhirl
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Poliwrath
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Abra
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Kadabra
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Alakazam
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Machop
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Machoke
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Machamp
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="Bellsprout">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="View Bellsprout on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" alt="Bellsprout" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Bellsprout
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="Weepinbell">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="View Weepinbell on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" alt="Weepinbell" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Weepinbell
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="Victreebel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="View Victreebel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" alt="Victreebel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Victreebel
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Tentacool
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Tentacruel
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="Geodude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="View Geodude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" alt="Geodude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Geodude
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="Graveler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="View Graveler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" alt="Graveler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Graveler
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="Golem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="View Golem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" alt="Golem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Golem
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Ponyta
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Rapidash
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Slowpoke
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Slowbro
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Magnemite
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Magneton
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="Farfetch’d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="View Farfetch’d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch’d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Farfetch’d
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="Doduo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="View Doduo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" alt="Doduo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Doduo
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="Dodrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="View Dodrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" alt="Dodrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Dodrio
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="Seel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="View Seel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" alt="Seel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Seel
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="Dewgong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="View Dewgong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" alt="Dewgong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Dewgong
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="Grimer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="View Grimer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" alt="Grimer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Grimer
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="Muk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="View Muk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" alt="Muk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Muk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Shellder
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Cloyster
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Gastly
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Haunter
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Gengar
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Onix
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="Drowzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="View Drowzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" alt="Drowzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Drowzee
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="Hypno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="View Hypno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" alt="Hypno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Hypno
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="Voltorb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="View Voltorb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" alt="Voltorb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Voltorb
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="Electrode">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="View Electrode on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" alt="Electrode" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Electrode
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Exeggcute
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Exeggutor
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Cubone
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Marowak
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Hitmonlee
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Hitmonchan
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Lickitung
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Koffing
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Weezing
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Rhyhorn
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Rhydon
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Chansey
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Tangela
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Kangaskhan
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Horsea
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Seadra
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Goldeen
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Seaking
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Staryu
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Starmie
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Mr. Mime
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Scyther
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="Jynx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="View Jynx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" alt="Jynx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Jynx
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="Electabuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="View Electabuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" alt="Electabuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Electabuzz
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="Magmar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="View Magmar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" alt="Magmar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Magmar
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Pinsir
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Tauros
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Magikarp
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Gyarados
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Lapras
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Ditto
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Eevee
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Vaporeon
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Jolteon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Flareon
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Porygon
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="Omanyte">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="View Omanyte on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" alt="Omanyte" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Omanyte
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="Omastar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="View Omastar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" alt="Omastar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Omastar
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="Kabuto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="View Kabuto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" alt="Kabuto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Kabuto
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="Kabutops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="View Kabutops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" alt="Kabutops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Kabutops
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="Aerodactyl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="View Aerodactyl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" alt="Aerodactyl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Aerodactyl
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Snorlax
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="Articuno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="View Articuno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" alt="Articuno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Articuno
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="Zapdos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="View Zapdos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" alt="Zapdos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Zapdos
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="Moltres">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="View Moltres on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" alt="Moltres" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Moltres
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="Dratini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="View Dratini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" alt="Dratini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Dratini
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="Dragonair">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="View Dragonair on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" alt="Dragonair" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Dragonair
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="Dragonite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="View Dragonite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" alt="Dragonite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Dragonite
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="Mewtwo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="View Mewtwo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" alt="Mewtwo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Mewtwo
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="Mew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="View Mew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" alt="Mew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Mew
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="Chikorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="View Chikorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" alt="Chikorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Chikorita
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="Bayleef">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="View Bayleef on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" alt="Bayleef" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Bayleef
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="Meganium">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="View Meganium on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" alt="Meganium" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Meganium
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="Cyndaquil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="View Cyndaquil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" alt="Cyndaquil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Cyndaquil
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="Quilava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="View Quilava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" alt="Quilava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Quilava
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="Typhlosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="View Typhlosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" alt="Typhlosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Typhlosion
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="Totodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="View Totodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" alt="Totodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Totodile
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="Croconaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="View Croconaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" alt="Croconaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Croconaw
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="Feraligatr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="View Feraligatr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" alt="Feraligatr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Feraligatr
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="Sentret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="View Sentret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" alt="Sentret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Sentret
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="Furret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="View Furret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" alt="Furret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Furret
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="Hoothoot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="View Hoothoot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" alt="Hoothoot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Hoothoot
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="Noctowl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="View Noctowl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" alt="Noctowl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Noctowl
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="Ledyba">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="View Ledyba on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" alt="Ledyba" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Ledyba
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="Ledian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="View Ledian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" alt="Ledian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Ledian
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="Spinarak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="View Spinarak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" alt="Spinarak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Spinarak
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="Ariados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="View Ariados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" alt="Ariados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Ariados
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="Crobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="View Crobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" alt="Crobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Crobat
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Chinchou
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Lanturn
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Pichu
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="Cleffa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="View Cleffa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" alt="Cleffa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Cleffa
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="Igglybuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="View Igglybuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" alt="Igglybuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Igglybuff
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="Togepi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="View Togepi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" alt="Togepi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Togepi
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="Togetic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="View Togetic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" alt="Togetic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Togetic
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="Natu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="View Natu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" alt="Natu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Natu
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="Xatu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="View Xatu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" alt="Xatu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Xatu
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="Mareep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="View Mareep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" alt="Mareep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Mareep
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="Flaaffy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="View Flaaffy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" alt="Flaaffy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Flaaffy
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="Ampharos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="View Ampharos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" alt="Ampharos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Ampharos
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="Bellossom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="View Bellossom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" alt="Bellossom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Bellossom
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="Marill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="View Marill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" alt="Marill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Marill
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="Azumarill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="View Azumarill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" alt="Azumarill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Azumarill
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="Sudowoodo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="View Sudowoodo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" alt="Sudowoodo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Sudowoodo
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="Politoed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="View Politoed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" alt="Politoed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Politoed
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="Hoppip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="View Hoppip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" alt="Hoppip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Hoppip
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="Skiploom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="View Skiploom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" alt="Skiploom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Skiploom
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="Jumpluff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="View Jumpluff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" alt="Jumpluff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Jumpluff
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="Aipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="View Aipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" alt="Aipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Aipom
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="Sunkern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="View Sunkern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" alt="Sunkern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Sunkern
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="Sunflora">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="View Sunflora on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" alt="Sunflora" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Sunflora
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="Yanma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="View Yanma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" alt="Yanma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Yanma
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Wooper
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Quagsire
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="Espeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="View Espeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" alt="Espeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Espeon
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="Umbreon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="View Umbreon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" alt="Umbreon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Umbreon
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="Murkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="View Murkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" alt="Murkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Murkrow
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="Slowking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="View Slowking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" alt="Slowking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Slowking
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="Misdreavus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="View Misdreavus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" alt="Misdreavus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Misdreavus
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="Unown">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="View Unown on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" alt="Unown" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Unown
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="Wobbuffet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="View Wobbuffet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" alt="Wobbuffet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Wobbuffet
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="Girafarig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="View Girafarig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" alt="Girafarig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Girafarig
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="Pineco">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="View Pineco on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" alt="Pineco" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Pineco
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="Forretress">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="View Forretress on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" alt="Forretress" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Forretress
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="Dunsparce">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="View Dunsparce on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" alt="Dunsparce" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Dunsparce
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="Gligar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="View Gligar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" alt="Gligar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Gligar
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="Steelix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="View Steelix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" alt="Steelix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Steelix
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="Snubbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="View Snubbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" alt="Snubbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Snubbull
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="Granbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="View Granbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" alt="Granbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Granbull
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="Qwilfish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="View Qwilfish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" alt="Qwilfish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Qwilfish
@@ -2184,8 +2184,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="Scizor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="View Scizor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" alt="Scizor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">212</span>
                             Scizor
@@ -2194,8 +2194,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="Shuckle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="View Shuckle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" alt="Shuckle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">213</span>
                             Shuckle
@@ -2204,8 +2204,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="Heracross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="View Heracross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" alt="Heracross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">214</span>
                             Heracross
@@ -2214,8 +2214,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="Sneasel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="View Sneasel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" alt="Sneasel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">215</span>
                             Sneasel
@@ -2224,8 +2224,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="Teddiursa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="View Teddiursa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" alt="Teddiursa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">216</span>
                             Teddiursa
@@ -2234,8 +2234,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="Ursaring">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="View Ursaring on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" alt="Ursaring" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">217</span>
                             Ursaring
@@ -2244,8 +2244,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="Slugma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="View Slugma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" alt="Slugma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">218</span>
                             Slugma
@@ -2254,8 +2254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="Magcargo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="View Magcargo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" alt="Magcargo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">219</span>
                             Magcargo
@@ -2264,8 +2264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="Swinub">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="View Swinub on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" alt="Swinub" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">220</span>
                             Swinub
@@ -2274,8 +2274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="Piloswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="View Piloswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" alt="Piloswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">221</span>
                             Piloswine
@@ -2284,8 +2284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="Corsola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="View Corsola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" alt="Corsola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">222</span>
                             Corsola
@@ -2294,8 +2294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">223</span>
                             Remoraid
@@ -2304,8 +2304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">224</span>
                             Octillery
@@ -2314,8 +2314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="Delibird">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="View Delibird on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" alt="Delibird" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">225</span>
                             Delibird
@@ -2324,8 +2324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">226</span>
                             Mantine
@@ -2334,8 +2334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="Skarmory">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="View Skarmory on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" alt="Skarmory" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">227</span>
                             Skarmory
@@ -2344,8 +2344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="Houndour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="View Houndour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" alt="Houndour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">228</span>
                             Houndour
@@ -2354,8 +2354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="Houndoom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="View Houndoom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" alt="Houndoom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">229</span>
                             Houndoom
@@ -2364,8 +2364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="Kingdra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="View Kingdra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" alt="Kingdra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">230</span>
                             Kingdra
@@ -2374,8 +2374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="Phanpy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="View Phanpy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" alt="Phanpy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">231</span>
                             Phanpy
@@ -2384,8 +2384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="Donphan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="View Donphan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" alt="Donphan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">232</span>
                             Donphan
@@ -2394,8 +2394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="Porygon2">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="View Porygon2 on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" alt="Porygon2" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">233</span>
                             Porygon2
@@ -2404,8 +2404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="Stantler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="View Stantler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" alt="Stantler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">234</span>
                             Stantler
@@ -2414,8 +2414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="Smeargle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="View Smeargle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" alt="Smeargle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">235</span>
                             Smeargle
@@ -2424,8 +2424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="Tyrogue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="View Tyrogue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" alt="Tyrogue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">236</span>
                             Tyrogue
@@ -2434,8 +2434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="Hitmontop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="View Hitmontop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" alt="Hitmontop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">237</span>
                             Hitmontop
@@ -2444,8 +2444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="Smoochum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="View Smoochum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" alt="Smoochum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">238</span>
                             Smoochum
@@ -2454,8 +2454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="Elekid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="View Elekid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" alt="Elekid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">239</span>
                             Elekid
@@ -2464,8 +2464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="Magby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="View Magby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" alt="Magby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">240</span>
                             Magby
@@ -2481,8 +2481,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="Miltank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="View Miltank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" alt="Miltank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">241</span>
                             Miltank
@@ -2491,8 +2491,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="Blissey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="View Blissey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" alt="Blissey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">242</span>
                             Blissey
@@ -2501,8 +2501,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="Raikou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="View Raikou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" alt="Raikou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">243</span>
                             Raikou
@@ -2511,8 +2511,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="Entei">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="View Entei on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" alt="Entei" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">244</span>
                             Entei
@@ -2521,8 +2521,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="Suicune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="View Suicune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" alt="Suicune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">245</span>
                             Suicune
@@ -2531,8 +2531,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="Larvitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="View Larvitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" alt="Larvitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">246</span>
                             Larvitar
@@ -2541,8 +2541,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="Pupitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="View Pupitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" alt="Pupitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">247</span>
                             Pupitar
@@ -2551,8 +2551,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="Tyranitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="View Tyranitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" alt="Tyranitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">248</span>
                             Tyranitar
@@ -2561,8 +2561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="Lugia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="View Lugia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" alt="Lugia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">249</span>
                             Lugia
@@ -2571,8 +2571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="Ho-Oh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="View Ho-Oh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" alt="Ho-Oh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">250</span>
                             Ho-Oh
@@ -2581,8 +2581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="Celebi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="View Celebi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" alt="Celebi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">251</span>
                             Celebi
@@ -2591,8 +2591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="Treecko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="View Treecko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" alt="Treecko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">252</span>
                             Treecko
@@ -2601,8 +2601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="Grovyle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="View Grovyle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" alt="Grovyle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">253</span>
                             Grovyle
@@ -2611,8 +2611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="Sceptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="View Sceptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" alt="Sceptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">254</span>
                             Sceptile
@@ -2621,8 +2621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="Torchic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="View Torchic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" alt="Torchic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">255</span>
                             Torchic
@@ -2631,8 +2631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="Combusken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="View Combusken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" alt="Combusken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">256</span>
                             Combusken
@@ -2641,8 +2641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="Blaziken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="View Blaziken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" alt="Blaziken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">257</span>
                             Blaziken
@@ -2651,8 +2651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="Mudkip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="View Mudkip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" alt="Mudkip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">258</span>
                             Mudkip
@@ -2661,8 +2661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="Marshtomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="View Marshtomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" alt="Marshtomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">259</span>
                             Marshtomp
@@ -2671,8 +2671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="Swampert">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="View Swampert on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" alt="Swampert" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">260</span>
                             Swampert
@@ -2681,8 +2681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="Poochyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="View Poochyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" alt="Poochyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">261</span>
                             Poochyena
@@ -2691,8 +2691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="Mightyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="View Mightyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" alt="Mightyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">262</span>
                             Mightyena
@@ -2701,8 +2701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="Zigzagoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="View Zigzagoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" alt="Zigzagoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">263</span>
                             Zigzagoon
@@ -2711,8 +2711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="Linoone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="View Linoone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" alt="Linoone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">264</span>
                             Linoone
@@ -2721,8 +2721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="Wurmple">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="View Wurmple on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" alt="Wurmple" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">265</span>
                             Wurmple
@@ -2731,8 +2731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="Silcoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="View Silcoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" alt="Silcoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">266</span>
                             Silcoon
@@ -2741,8 +2741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="Beautifly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="View Beautifly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" alt="Beautifly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">267</span>
                             Beautifly
@@ -2751,8 +2751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="Cascoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="View Cascoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" alt="Cascoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">268</span>
                             Cascoon
@@ -2761,8 +2761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="Dustox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="View Dustox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" alt="Dustox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">269</span>
                             Dustox
@@ -2771,8 +2771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="Lotad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="View Lotad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" alt="Lotad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">270</span>
                             Lotad
@@ -2788,8 +2788,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="Lombre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="View Lombre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" alt="Lombre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">271</span>
                             Lombre
@@ -2798,8 +2798,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="Ludicolo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="View Ludicolo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" alt="Ludicolo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">272</span>
                             Ludicolo
@@ -2808,8 +2808,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="Seedot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="View Seedot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" alt="Seedot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">273</span>
                             Seedot
@@ -2818,8 +2818,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="Nuzleaf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="View Nuzleaf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" alt="Nuzleaf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">274</span>
                             Nuzleaf
@@ -2828,8 +2828,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="Shiftry">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="View Shiftry on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" alt="Shiftry" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">275</span>
                             Shiftry
@@ -2838,8 +2838,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="Taillow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="View Taillow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" alt="Taillow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">276</span>
                             Taillow
@@ -2848,8 +2848,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="Swellow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="View Swellow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" alt="Swellow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">277</span>
                             Swellow
@@ -2858,8 +2858,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="Wingull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="View Wingull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" alt="Wingull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">278</span>
                             Wingull
@@ -2868,8 +2868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="Pelipper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="View Pelipper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" alt="Pelipper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">279</span>
                             Pelipper
@@ -2878,8 +2878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="Ralts">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="View Ralts on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" alt="Ralts" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">280</span>
                             Ralts
@@ -2888,8 +2888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="Kirlia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="View Kirlia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" alt="Kirlia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">281</span>
                             Kirlia
@@ -2898,8 +2898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="Gardevoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="View Gardevoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" alt="Gardevoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">282</span>
                             Gardevoir
@@ -2908,8 +2908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="Surskit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="View Surskit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" alt="Surskit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">283</span>
                             Surskit
@@ -2918,8 +2918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="Masquerain">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="View Masquerain on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" alt="Masquerain" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">284</span>
                             Masquerain
@@ -2928,8 +2928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="Shroomish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="View Shroomish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" alt="Shroomish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">285</span>
                             Shroomish
@@ -2938,8 +2938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="Breloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="View Breloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" alt="Breloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">286</span>
                             Breloom
@@ -2948,8 +2948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="Slakoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="View Slakoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" alt="Slakoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">287</span>
                             Slakoth
@@ -2958,8 +2958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="Vigoroth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="View Vigoroth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" alt="Vigoroth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">288</span>
                             Vigoroth
@@ -2968,8 +2968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="Slaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="View Slaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" alt="Slaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">289</span>
                             Slaking
@@ -2978,8 +2978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="Nincada">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="View Nincada on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" alt="Nincada" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">290</span>
                             Nincada
@@ -2988,8 +2988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="Ninjask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="View Ninjask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" alt="Ninjask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">291</span>
                             Ninjask
@@ -2998,8 +2998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="Shedinja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="View Shedinja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" alt="Shedinja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">292</span>
                             Shedinja
@@ -3008,8 +3008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="Whismur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="View Whismur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" alt="Whismur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">293</span>
                             Whismur
@@ -3018,8 +3018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="Loudred">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="View Loudred on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" alt="Loudred" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">294</span>
                             Loudred
@@ -3028,8 +3028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="Exploud">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="View Exploud on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" alt="Exploud" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">295</span>
                             Exploud
@@ -3038,8 +3038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="Makuhita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="View Makuhita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" alt="Makuhita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">296</span>
                             Makuhita
@@ -3048,8 +3048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="Hariyama">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="View Hariyama on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" alt="Hariyama" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">297</span>
                             Hariyama
@@ -3058,8 +3058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="Azurill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="View Azurill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" alt="Azurill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">298</span>
                             Azurill
@@ -3068,8 +3068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="Nosepass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="View Nosepass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" alt="Nosepass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">299</span>
                             Nosepass
@@ -3078,8 +3078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="Skitty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="View Skitty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" alt="Skitty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">300</span>
                             Skitty
@@ -3095,8 +3095,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="Delcatty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="View Delcatty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" alt="Delcatty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">301</span>
                             Delcatty
@@ -3105,8 +3105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="Sableye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="View Sableye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" alt="Sableye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">302</span>
                             Sableye
@@ -3115,8 +3115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="Mawile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="View Mawile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" alt="Mawile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">303</span>
                             Mawile
@@ -3125,8 +3125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="Aron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="View Aron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" alt="Aron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">304</span>
                             Aron
@@ -3135,8 +3135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="Lairon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="View Lairon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" alt="Lairon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">305</span>
                             Lairon
@@ -3145,8 +3145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="Aggron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="View Aggron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" alt="Aggron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">306</span>
                             Aggron
@@ -3155,8 +3155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="Meditite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="View Meditite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" alt="Meditite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">307</span>
                             Meditite
@@ -3165,8 +3165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="Medicham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="View Medicham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" alt="Medicham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">308</span>
                             Medicham
@@ -3175,8 +3175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="Electrike">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="View Electrike on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" alt="Electrike" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">309</span>
                             Electrike
@@ -3185,8 +3185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="Manectric">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="View Manectric on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" alt="Manectric" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">310</span>
                             Manectric
@@ -3195,8 +3195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="Plusle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="View Plusle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" alt="Plusle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">311</span>
                             Plusle
@@ -3205,8 +3205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="Minun">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="View Minun on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" alt="Minun" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">312</span>
                             Minun
@@ -3215,8 +3215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="Volbeat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="View Volbeat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" alt="Volbeat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">313</span>
                             Volbeat
@@ -3225,8 +3225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="Illumise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="View Illumise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" alt="Illumise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">314</span>
                             Illumise
@@ -3235,8 +3235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="Roselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="View Roselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" alt="Roselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">315</span>
                             Roselia
@@ -3245,8 +3245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="Gulpin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="View Gulpin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" alt="Gulpin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">316</span>
                             Gulpin
@@ -3255,8 +3255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="Swalot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="View Swalot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" alt="Swalot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">317</span>
                             Swalot
@@ -3265,8 +3265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="Carvanha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="View Carvanha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" alt="Carvanha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">318</span>
                             Carvanha
@@ -3275,8 +3275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="Sharpedo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="View Sharpedo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" alt="Sharpedo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">319</span>
                             Sharpedo
@@ -3285,8 +3285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="Wailmer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="View Wailmer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" alt="Wailmer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">320</span>
                             Wailmer
@@ -3295,8 +3295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="Wailord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="View Wailord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" alt="Wailord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">321</span>
                             Wailord
@@ -3305,8 +3305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="Numel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="View Numel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" alt="Numel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">322</span>
                             Numel
@@ -3315,8 +3315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="Camerupt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="View Camerupt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" alt="Camerupt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">323</span>
                             Camerupt
@@ -3325,8 +3325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="Torkoal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="View Torkoal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" alt="Torkoal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">324</span>
                             Torkoal
@@ -3335,8 +3335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="Spoink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="View Spoink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" alt="Spoink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">325</span>
                             Spoink
@@ -3345,8 +3345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="Grumpig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="View Grumpig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" alt="Grumpig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">326</span>
                             Grumpig
@@ -3355,8 +3355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="Spinda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="View Spinda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" alt="Spinda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">327</span>
                             Spinda
@@ -3365,8 +3365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="Trapinch">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="View Trapinch on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" alt="Trapinch" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">328</span>
                             Trapinch
@@ -3375,8 +3375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="Vibrava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="View Vibrava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" alt="Vibrava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">329</span>
                             Vibrava
@@ -3385,8 +3385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="Flygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="View Flygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" alt="Flygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">330</span>
                             Flygon
@@ -3402,8 +3402,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="Cacnea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="View Cacnea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" alt="Cacnea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">331</span>
                             Cacnea
@@ -3412,8 +3412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="Cacturne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="View Cacturne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" alt="Cacturne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">332</span>
                             Cacturne
@@ -3422,8 +3422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="Swablu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="View Swablu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" alt="Swablu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">333</span>
                             Swablu
@@ -3432,8 +3432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="Altaria">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="View Altaria on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" alt="Altaria" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">334</span>
                             Altaria
@@ -3442,8 +3442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="Zangoose">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="View Zangoose on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" alt="Zangoose" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">335</span>
                             Zangoose
@@ -3452,8 +3452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="Seviper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="View Seviper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" alt="Seviper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">336</span>
                             Seviper
@@ -3462,8 +3462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="Lunatone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="View Lunatone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" alt="Lunatone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">337</span>
                             Lunatone
@@ -3472,8 +3472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="Solrock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="View Solrock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" alt="Solrock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">338</span>
                             Solrock
@@ -3482,8 +3482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="Barboach">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="View Barboach on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" alt="Barboach" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">339</span>
                             Barboach
@@ -3492,8 +3492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="Whiscash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="View Whiscash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" alt="Whiscash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">340</span>
                             Whiscash
@@ -3502,8 +3502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="Corphish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="View Corphish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" alt="Corphish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">341</span>
                             Corphish
@@ -3512,8 +3512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="Crawdaunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="View Crawdaunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" alt="Crawdaunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">342</span>
                             Crawdaunt
@@ -3522,8 +3522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="Baltoy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="View Baltoy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" alt="Baltoy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">343</span>
                             Baltoy
@@ -3532,8 +3532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="Claydol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="View Claydol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" alt="Claydol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">344</span>
                             Claydol
@@ -3542,8 +3542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="Lileep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="View Lileep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" alt="Lileep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">345</span>
                             Lileep
@@ -3552,8 +3552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="Cradily">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="View Cradily on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" alt="Cradily" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">346</span>
                             Cradily
@@ -3562,8 +3562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="Anorith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="View Anorith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" alt="Anorith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">347</span>
                             Anorith
@@ -3572,8 +3572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="Armaldo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="View Armaldo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" alt="Armaldo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">348</span>
                             Armaldo
@@ -3582,8 +3582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="Feebas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="View Feebas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" alt="Feebas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">349</span>
                             Feebas
@@ -3592,8 +3592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="Milotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="View Milotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" alt="Milotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">350</span>
                             Milotic
@@ -3602,8 +3602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="Castform">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="View Castform on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" alt="Castform" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">351</span>
                             Castform
@@ -3612,8 +3612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="Kecleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="View Kecleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" alt="Kecleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">352</span>
                             Kecleon
@@ -3622,8 +3622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="Shuppet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="View Shuppet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" alt="Shuppet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">353</span>
                             Shuppet
@@ -3632,8 +3632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="Banette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="View Banette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" alt="Banette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">354</span>
                             Banette
@@ -3642,8 +3642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="Duskull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="View Duskull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" alt="Duskull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">355</span>
                             Duskull
@@ -3652,8 +3652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="Dusclops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="View Dusclops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" alt="Dusclops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">356</span>
                             Dusclops
@@ -3662,8 +3662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="Tropius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="View Tropius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" alt="Tropius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">357</span>
                             Tropius
@@ -3672,8 +3672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="Chimecho">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="View Chimecho on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" alt="Chimecho" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">358</span>
                             Chimecho
@@ -3682,8 +3682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="Absol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="View Absol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" alt="Absol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">359</span>
                             Absol
@@ -3692,8 +3692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="Wynaut">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="View Wynaut on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" alt="Wynaut" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">360</span>
                             Wynaut
@@ -3709,8 +3709,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="Snorunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="View Snorunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" alt="Snorunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">361</span>
                             Snorunt
@@ -3719,8 +3719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="Glalie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="View Glalie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" alt="Glalie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">362</span>
                             Glalie
@@ -3729,8 +3729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="Spheal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="View Spheal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" alt="Spheal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">363</span>
                             Spheal
@@ -3739,8 +3739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="Sealeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="View Sealeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" alt="Sealeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">364</span>
                             Sealeo
@@ -3749,8 +3749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="Walrein">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="View Walrein on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" alt="Walrein" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">365</span>
                             Walrein
@@ -3759,8 +3759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="Clamperl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="View Clamperl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" alt="Clamperl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">366</span>
                             Clamperl
@@ -3769,8 +3769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="Huntail">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="View Huntail on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" alt="Huntail" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">367</span>
                             Huntail
@@ -3779,8 +3779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="Gorebyss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="View Gorebyss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" alt="Gorebyss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">368</span>
                             Gorebyss
@@ -3789,8 +3789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="Relicanth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="View Relicanth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" alt="Relicanth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">369</span>
                             Relicanth
@@ -3799,8 +3799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="Luvdisc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="View Luvdisc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" alt="Luvdisc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">370</span>
                             Luvdisc
@@ -3809,8 +3809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="Bagon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="View Bagon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" alt="Bagon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">371</span>
                             Bagon
@@ -3819,8 +3819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="Shelgon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="View Shelgon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" alt="Shelgon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">372</span>
                             Shelgon
@@ -3829,8 +3829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="Salamence">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="View Salamence on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" alt="Salamence" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">373</span>
                             Salamence
@@ -3839,8 +3839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="Beldum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="View Beldum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" alt="Beldum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">374</span>
                             Beldum
@@ -3849,8 +3849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="Metang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="View Metang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" alt="Metang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">375</span>
                             Metang
@@ -3859,8 +3859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="Metagross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="View Metagross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" alt="Metagross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">376</span>
                             Metagross
@@ -3869,8 +3869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="Regirock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="View Regirock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" alt="Regirock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">377</span>
                             Regirock
@@ -3879,8 +3879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="Regice">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="View Regice on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" alt="Regice" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">378</span>
                             Regice
@@ -3889,8 +3889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="Registeel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="View Registeel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" alt="Registeel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">379</span>
                             Registeel
@@ -3899,8 +3899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="Latias">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="View Latias on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" alt="Latias" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">380</span>
                             Latias
@@ -3909,8 +3909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="Latios">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="View Latios on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" alt="Latios" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">381</span>
                             Latios
@@ -3919,8 +3919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="Kyogre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="View Kyogre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" alt="Kyogre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">382</span>
                             Kyogre
@@ -3929,8 +3929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="Groudon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="View Groudon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" alt="Groudon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">383</span>
                             Groudon
@@ -3939,8 +3939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="Rayquaza">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="View Rayquaza on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" alt="Rayquaza" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">384</span>
                             Rayquaza
@@ -3949,8 +3949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="Jirachi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="View Jirachi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" alt="Jirachi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">385</span>
                             Jirachi
@@ -3959,8 +3959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="Deoxys">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="View Deoxys on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" alt="Deoxys" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">386</span>
                             Deoxys
@@ -3969,8 +3969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="Turtwig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="View Turtwig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" alt="Turtwig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">387</span>
                             Turtwig
@@ -3979,8 +3979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="Grotle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="View Grotle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" alt="Grotle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">388</span>
                             Grotle
@@ -3989,8 +3989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="Torterra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="View Torterra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" alt="Torterra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">389</span>
                             Torterra
@@ -3999,8 +3999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="Chimchar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="View Chimchar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" alt="Chimchar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">390</span>
                             Chimchar
@@ -4016,8 +4016,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="Monferno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="View Monferno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" alt="Monferno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">391</span>
                             Monferno
@@ -4026,8 +4026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="Infernape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="View Infernape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" alt="Infernape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">392</span>
                             Infernape
@@ -4036,8 +4036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="Piplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="View Piplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" alt="Piplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">393</span>
                             Piplup
@@ -4046,8 +4046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="Prinplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="View Prinplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" alt="Prinplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">394</span>
                             Prinplup
@@ -4056,8 +4056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="Empoleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="View Empoleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" alt="Empoleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">395</span>
                             Empoleon
@@ -4066,8 +4066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="Starly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="View Starly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" alt="Starly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">396</span>
                             Starly
@@ -4076,8 +4076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="Staravia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="View Staravia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" alt="Staravia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">397</span>
                             Staravia
@@ -4086,8 +4086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="Staraptor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="View Staraptor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" alt="Staraptor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">398</span>
                             Staraptor
@@ -4096,8 +4096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="Bidoof">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="View Bidoof on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" alt="Bidoof" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">399</span>
                             Bidoof
@@ -4106,8 +4106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="Bibarel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="View Bibarel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" alt="Bibarel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">400</span>
                             Bibarel
@@ -4116,8 +4116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="Kricketot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="View Kricketot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" alt="Kricketot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">401</span>
                             Kricketot
@@ -4126,8 +4126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="Kricketune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="View Kricketune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" alt="Kricketune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">402</span>
                             Kricketune
@@ -4136,8 +4136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="Shinx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="View Shinx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" alt="Shinx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">403</span>
                             Shinx
@@ -4146,8 +4146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="Luxio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="View Luxio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" alt="Luxio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">404</span>
                             Luxio
@@ -4156,8 +4156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="Luxray">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="View Luxray on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" alt="Luxray" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">405</span>
                             Luxray
@@ -4166,8 +4166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="Budew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="View Budew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" alt="Budew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">406</span>
                             Budew
@@ -4176,8 +4176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="Roserade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="View Roserade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" alt="Roserade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">407</span>
                             Roserade
@@ -4186,8 +4186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="Cranidos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="View Cranidos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" alt="Cranidos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">408</span>
                             Cranidos
@@ -4196,8 +4196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="Rampardos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="View Rampardos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" alt="Rampardos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">409</span>
                             Rampardos
@@ -4206,8 +4206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="Shieldon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="View Shieldon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" alt="Shieldon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">410</span>
                             Shieldon
@@ -4216,8 +4216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="Bastiodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="View Bastiodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" alt="Bastiodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">411</span>
                             Bastiodon
@@ -4226,8 +4226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="Burmy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="View Burmy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" alt="Burmy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">412</span>
                             Burmy
@@ -4236,8 +4236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="Wormadam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="View Wormadam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" alt="Wormadam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">413</span>
                             Wormadam
@@ -4246,8 +4246,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="Mothim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="View Mothim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" alt="Mothim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">414</span>
                             Mothim
@@ -4256,8 +4256,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="Combee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="View Combee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" alt="Combee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">415</span>
                             Combee
@@ -4266,8 +4266,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="Vespiquen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="View Vespiquen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" alt="Vespiquen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">416</span>
                             Vespiquen
@@ -4276,8 +4276,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="Pachirisu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="View Pachirisu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" alt="Pachirisu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">417</span>
                             Pachirisu
@@ -4286,8 +4286,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="Buizel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="View Buizel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" alt="Buizel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">418</span>
                             Buizel
@@ -4296,8 +4296,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="Floatzel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="View Floatzel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" alt="Floatzel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">419</span>
                             Floatzel
@@ -4306,8 +4306,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="Cherubi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="View Cherubi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" alt="Cherubi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">420</span>
                             Cherubi
@@ -4323,8 +4323,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="Cherrim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="View Cherrim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" alt="Cherrim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">421</span>
                             Cherrim
@@ -4333,8 +4333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="Shellos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="View Shellos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" alt="Shellos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">422</span>
                             Shellos
@@ -4343,8 +4343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="Gastrodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="View Gastrodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" alt="Gastrodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">423</span>
                             Gastrodon
@@ -4353,8 +4353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="Ambipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="View Ambipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" alt="Ambipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">424</span>
                             Ambipom
@@ -4363,8 +4363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="Drifloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="View Drifloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" alt="Drifloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">425</span>
                             Drifloon
@@ -4373,8 +4373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="Drifblim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="View Drifblim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" alt="Drifblim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">426</span>
                             Drifblim
@@ -4383,8 +4383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="Buneary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="View Buneary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" alt="Buneary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">427</span>
                             Buneary
@@ -4393,8 +4393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="Lopunny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="View Lopunny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" alt="Lopunny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">428</span>
                             Lopunny
@@ -4403,8 +4403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="Mismagius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="View Mismagius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" alt="Mismagius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">429</span>
                             Mismagius
@@ -4413,8 +4413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="Honchkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="View Honchkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" alt="Honchkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">430</span>
                             Honchkrow
@@ -4423,8 +4423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="Glameow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="View Glameow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" alt="Glameow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">431</span>
                             Glameow
@@ -4433,8 +4433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="Purugly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="View Purugly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" alt="Purugly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">432</span>
                             Purugly
@@ -4443,8 +4443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="Chingling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="View Chingling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" alt="Chingling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">433</span>
                             Chingling
@@ -4453,8 +4453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="Stunky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="View Stunky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" alt="Stunky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">434</span>
                             Stunky
@@ -4463,8 +4463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="Skuntank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="View Skuntank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" alt="Skuntank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">435</span>
                             Skuntank
@@ -4473,8 +4473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="Bronzor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="View Bronzor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" alt="Bronzor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">436</span>
                             Bronzor
@@ -4483,8 +4483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="Bronzong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="View Bronzong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" alt="Bronzong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">437</span>
                             Bronzong
@@ -4493,8 +4493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="Bonsly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="View Bonsly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" alt="Bonsly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">438</span>
                             Bonsly
@@ -4503,8 +4503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="Mime Jr.">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="View Mime Jr. on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" alt="Mime Jr." loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">439</span>
                             Mime Jr.
@@ -4513,8 +4513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="Happiny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="View Happiny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" alt="Happiny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">440</span>
                             Happiny
@@ -4523,8 +4523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="Chatot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="View Chatot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" alt="Chatot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">441</span>
                             Chatot
@@ -4533,8 +4533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="Spiritomb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="View Spiritomb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" alt="Spiritomb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">442</span>
                             Spiritomb
@@ -4543,8 +4543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="Gible">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="View Gible on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" alt="Gible" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">443</span>
                             Gible
@@ -4553,8 +4553,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="Gabite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="View Gabite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" alt="Gabite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">444</span>
                             Gabite
@@ -4563,8 +4563,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="Garchomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="View Garchomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" alt="Garchomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">445</span>
                             Garchomp
@@ -4573,8 +4573,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="Munchlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="View Munchlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" alt="Munchlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">446</span>
                             Munchlax
@@ -4583,8 +4583,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="Riolu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="View Riolu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" alt="Riolu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">447</span>
                             Riolu
@@ -4593,8 +4593,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="Lucario">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="View Lucario on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" alt="Lucario" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">448</span>
                             Lucario
@@ -4603,8 +4603,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="Hippopotas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="View Hippopotas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" alt="Hippopotas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">449</span>
                             Hippopotas
@@ -4613,8 +4613,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="Hippowdon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="View Hippowdon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" alt="Hippowdon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">450</span>
                             Hippowdon
@@ -4630,8 +4630,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="Skorupi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="View Skorupi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" alt="Skorupi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">451</span>
                             Skorupi
@@ -4640,8 +4640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="Drapion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="View Drapion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" alt="Drapion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">452</span>
                             Drapion
@@ -4650,8 +4650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="Croagunk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="View Croagunk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" alt="Croagunk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">453</span>
                             Croagunk
@@ -4660,8 +4660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="Toxicroak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="View Toxicroak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" alt="Toxicroak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">454</span>
                             Toxicroak
@@ -4670,8 +4670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="Carnivine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="View Carnivine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" alt="Carnivine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">455</span>
                             Carnivine
@@ -4680,8 +4680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="Finneon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="View Finneon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" alt="Finneon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">456</span>
                             Finneon
@@ -4690,8 +4690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="Lumineon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="View Lumineon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" alt="Lumineon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">457</span>
                             Lumineon
@@ -4700,8 +4700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="Mantyke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="View Mantyke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" alt="Mantyke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">458</span>
                             Mantyke
@@ -4710,8 +4710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="Snover">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="View Snover on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" alt="Snover" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">459</span>
                             Snover
@@ -4720,8 +4720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="Abomasnow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="View Abomasnow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" alt="Abomasnow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">460</span>
                             Abomasnow
@@ -4730,8 +4730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="Weavile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="View Weavile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" alt="Weavile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">461</span>
                             Weavile
@@ -4740,8 +4740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="Magnezone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="View Magnezone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" alt="Magnezone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">462</span>
                             Magnezone
@@ -4750,8 +4750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="Lickilicky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="View Lickilicky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" alt="Lickilicky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">463</span>
                             Lickilicky
@@ -4760,8 +4760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="Rhyperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="View Rhyperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" alt="Rhyperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">464</span>
                             Rhyperior
@@ -4770,8 +4770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="Tangrowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="View Tangrowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" alt="Tangrowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">465</span>
                             Tangrowth
@@ -4780,8 +4780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="Electivire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="View Electivire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" alt="Electivire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">466</span>
                             Electivire
@@ -4790,8 +4790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="Magmortar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="View Magmortar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" alt="Magmortar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">467</span>
                             Magmortar
@@ -4800,8 +4800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="Togekiss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="View Togekiss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" alt="Togekiss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">468</span>
                             Togekiss
@@ -4810,8 +4810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="Yanmega">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="View Yanmega on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" alt="Yanmega" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">469</span>
                             Yanmega
@@ -4820,8 +4820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="Leafeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="View Leafeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" alt="Leafeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">470</span>
                             Leafeon
@@ -4830,8 +4830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="Glaceon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="View Glaceon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" alt="Glaceon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">471</span>
                             Glaceon
@@ -4840,8 +4840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="Gliscor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="View Gliscor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" alt="Gliscor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">472</span>
                             Gliscor
@@ -4850,8 +4850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="Mamoswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="View Mamoswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" alt="Mamoswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">473</span>
                             Mamoswine
@@ -4860,8 +4860,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="Porygon-Z">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="View Porygon-Z on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" alt="Porygon-Z" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">474</span>
                             Porygon-Z
@@ -4870,8 +4870,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="Gallade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="View Gallade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" alt="Gallade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">475</span>
                             Gallade
@@ -4880,8 +4880,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="Probopass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="View Probopass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" alt="Probopass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">476</span>
                             Probopass
@@ -4890,8 +4890,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="Dusknoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="View Dusknoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" alt="Dusknoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">477</span>
                             Dusknoir
@@ -4900,8 +4900,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="Froslass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="View Froslass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" alt="Froslass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">478</span>
                             Froslass
@@ -4910,8 +4910,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="Rotom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="View Rotom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" alt="Rotom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">479</span>
                             Rotom
@@ -4920,8 +4920,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="Uxie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="View Uxie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" alt="Uxie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">480</span>
                             Uxie
@@ -4937,8 +4937,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="Mesprit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="View Mesprit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" alt="Mesprit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">481</span>
                             Mesprit
@@ -4947,8 +4947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="Azelf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="View Azelf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" alt="Azelf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">482</span>
                             Azelf
@@ -4957,8 +4957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="Dialga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="View Dialga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" alt="Dialga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">483</span>
                             Dialga
@@ -4967,8 +4967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="Palkia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="View Palkia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" alt="Palkia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">484</span>
                             Palkia
@@ -4977,8 +4977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="Heatran">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="View Heatran on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" alt="Heatran" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">485</span>
                             Heatran
@@ -4987,8 +4987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="Regigigas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="View Regigigas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" alt="Regigigas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">486</span>
                             Regigigas
@@ -4997,8 +4997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="Giratina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="View Giratina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" alt="Giratina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">487</span>
                             Giratina
@@ -5007,8 +5007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="Cresselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="View Cresselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" alt="Cresselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">488</span>
                             Cresselia
@@ -5017,8 +5017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="Phione">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="View Phione on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" alt="Phione" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">489</span>
                             Phione
@@ -5027,8 +5027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="Manaphy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="View Manaphy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" alt="Manaphy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">490</span>
                             Manaphy
@@ -5037,8 +5037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darkrai/" title="Darkrai">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/491.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darkrai/" title="View Darkrai on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/491.png" alt="Darkrai" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">491</span>
                             Darkrai
@@ -5047,8 +5047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shaymin/" title="Shaymin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/492.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shaymin/" title="View Shaymin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/492.png" alt="Shaymin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">492</span>
                             Shaymin
@@ -5057,8 +5057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arceus/" title="Arceus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/493.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arceus/" title="View Arceus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/493.png" alt="Arceus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">493</span>
                             Arceus
@@ -5067,8 +5067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victini/" title="Victini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/494.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victini/" title="View Victini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/494.png" alt="Victini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">494</span>
                             Victini
@@ -5077,8 +5077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snivy/" title="Snivy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/495.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snivy/" title="View Snivy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/495.png" alt="Snivy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">495</span>
                             Snivy
@@ -5087,8 +5087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/servine/" title="Servine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/496.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/servine/" title="View Servine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/496.png" alt="Servine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">496</span>
                             Servine
@@ -5097,8 +5097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/serperior/" title="Serperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/497.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/serperior/" title="View Serperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/497.png" alt="Serperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">497</span>
                             Serperior
@@ -5107,8 +5107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tepig/" title="Tepig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/498.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tepig/" title="View Tepig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/498.png" alt="Tepig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">498</span>
                             Tepig
@@ -5117,8 +5117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pignite/" title="Pignite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/499.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pignite/" title="View Pignite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/499.png" alt="Pignite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">499</span>
                             Pignite
@@ -5127,8 +5127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/emboar/" title="Emboar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/500.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/emboar/" title="View Emboar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/500.png" alt="Emboar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">500</span>
                             Emboar
@@ -5137,8 +5137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oshawott/" title="Oshawott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/501.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oshawott/" title="View Oshawott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/501.png" alt="Oshawott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">501</span>
                             Oshawott
@@ -5147,8 +5147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewott/" title="Dewott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/502.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewott/" title="View Dewott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/502.png" alt="Dewott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">502</span>
                             Dewott
@@ -5157,8 +5157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/samurott/" title="Samurott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/503.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/samurott/" title="View Samurott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/503.png" alt="Samurott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">503</span>
                             Samurott
@@ -5167,8 +5167,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/patrat/" title="Patrat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/504.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/patrat/" title="View Patrat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/504.png" alt="Patrat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">504</span>
                             Patrat
@@ -5177,8 +5177,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/watchog/" title="Watchog">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/505.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/watchog/" title="View Watchog on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/505.png" alt="Watchog" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">505</span>
                             Watchog
@@ -5187,8 +5187,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="Lillipup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="View Lillipup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" alt="Lillipup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">506</span>
                             Lillipup
@@ -5197,8 +5197,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="Herdier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="View Herdier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" alt="Herdier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">507</span>
                             Herdier
@@ -5207,8 +5207,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="Stoutland">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="View Stoutland on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" alt="Stoutland" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">508</span>
                             Stoutland
@@ -5217,8 +5217,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="Purrloin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="View Purrloin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" alt="Purrloin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">509</span>
                             Purrloin
@@ -5227,8 +5227,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="Liepard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="View Liepard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" alt="Liepard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">510</span>
                             Liepard
@@ -5244,8 +5244,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pansage/" title="Pansage">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/511.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pansage/" title="View Pansage on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/511.png" alt="Pansage" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">511</span>
                             Pansage
@@ -5254,8 +5254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simisage/" title="Simisage">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/512.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simisage/" title="View Simisage on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/512.png" alt="Simisage" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">512</span>
                             Simisage
@@ -5264,8 +5264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pansear/" title="Pansear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/513.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pansear/" title="View Pansear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/513.png" alt="Pansear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">513</span>
                             Pansear
@@ -5274,8 +5274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simisear/" title="Simisear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/514.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simisear/" title="View Simisear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/514.png" alt="Simisear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">514</span>
                             Simisear
@@ -5284,8 +5284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/panpour/" title="Panpour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/515.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/panpour/" title="View Panpour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/515.png" alt="Panpour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">515</span>
                             Panpour
@@ -5294,8 +5294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simipour/" title="Simipour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/516.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simipour/" title="View Simipour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/516.png" alt="Simipour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">516</span>
                             Simipour
@@ -5304,8 +5304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="Munna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="View Munna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" alt="Munna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">517</span>
                             Munna
@@ -5314,8 +5314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="Musharna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="View Musharna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" alt="Musharna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">518</span>
                             Musharna
@@ -5324,8 +5324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="Pidove">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="View Pidove on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" alt="Pidove" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">519</span>
                             Pidove
@@ -5334,8 +5334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="Tranquill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="View Tranquill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" alt="Tranquill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">520</span>
                             Tranquill
@@ -5344,8 +5344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="Unfezant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="View Unfezant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" alt="Unfezant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">521</span>
                             Unfezant
@@ -5354,8 +5354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blitzle/" title="Blitzle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/522.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blitzle/" title="View Blitzle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/522.png" alt="Blitzle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">522</span>
                             Blitzle
@@ -5364,8 +5364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zebstrika/" title="Zebstrika">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/523.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zebstrika/" title="View Zebstrika on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/523.png" alt="Zebstrika" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">523</span>
                             Zebstrika
@@ -5374,8 +5374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="Roggenrola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="View Roggenrola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" alt="Roggenrola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">524</span>
                             Roggenrola
@@ -5384,8 +5384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="Boldore">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="View Boldore on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" alt="Boldore" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">525</span>
                             Boldore
@@ -5394,8 +5394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="Gigalith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="View Gigalith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" alt="Gigalith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">526</span>
                             Gigalith
@@ -5404,8 +5404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="Woobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="View Woobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" alt="Woobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">527</span>
                             Woobat
@@ -5414,8 +5414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="Swoobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="View Swoobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" alt="Swoobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">528</span>
                             Swoobat
@@ -5424,8 +5424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="Drilbur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="View Drilbur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" alt="Drilbur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">529</span>
                             Drilbur
@@ -5434,8 +5434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="Excadrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="View Excadrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" alt="Excadrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">530</span>
                             Excadrill
@@ -5444,8 +5444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/audino/" title="Audino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/531.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/audino/" title="View Audino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/531.png" alt="Audino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">531</span>
                             Audino
@@ -5454,8 +5454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="Timburr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="View Timburr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" alt="Timburr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">532</span>
                             Timburr
@@ -5464,8 +5464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="Gurdurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="View Gurdurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" alt="Gurdurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">533</span>
                             Gurdurr
@@ -5474,8 +5474,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="Conkeldurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="View Conkeldurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" alt="Conkeldurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">534</span>
                             Conkeldurr
@@ -5484,8 +5484,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="Tympole">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="View Tympole on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" alt="Tympole" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">535</span>
                             Tympole
@@ -5494,8 +5494,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="Palpitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="View Palpitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" alt="Palpitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">536</span>
                             Palpitoad
@@ -5504,8 +5504,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="Seismitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="View Seismitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" alt="Seismitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">537</span>
                             Seismitoad
@@ -5514,8 +5514,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="Throh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="View Throh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" alt="Throh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">538</span>
                             Throh
@@ -5524,8 +5524,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="Sawk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="View Sawk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" alt="Sawk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">539</span>
                             Sawk
@@ -5534,8 +5534,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sewaddle/" title="Sewaddle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/540.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sewaddle/" title="View Sewaddle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/540.png" alt="Sewaddle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">540</span>
                             Sewaddle
@@ -5551,8 +5551,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swadloon/" title="Swadloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/541.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swadloon/" title="View Swadloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/541.png" alt="Swadloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">541</span>
                             Swadloon
@@ -5561,8 +5561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leavanny/" title="Leavanny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/542.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leavanny/" title="View Leavanny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/542.png" alt="Leavanny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">542</span>
                             Leavanny
@@ -5571,8 +5571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="Venipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="View Venipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" alt="Venipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">543</span>
                             Venipede
@@ -5581,8 +5581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="Whirlipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="View Whirlipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" alt="Whirlipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">544</span>
                             Whirlipede
@@ -5591,8 +5591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="Scolipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="View Scolipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" alt="Scolipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">545</span>
                             Scolipede
@@ -5601,8 +5601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="Cottonee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="View Cottonee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" alt="Cottonee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">546</span>
                             Cottonee
@@ -5611,8 +5611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="Whimsicott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="View Whimsicott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" alt="Whimsicott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">547</span>
                             Whimsicott
@@ -5621,8 +5621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="Petilil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="View Petilil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" alt="Petilil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">548</span>
                             Petilil
@@ -5631,8 +5631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="Lilligant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="View Lilligant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" alt="Lilligant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">549</span>
                             Lilligant
@@ -5641,8 +5641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="Basculin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="View Basculin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" alt="Basculin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">550</span>
                             Basculin
@@ -5651,8 +5651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="Sandile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="View Sandile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" alt="Sandile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">551</span>
                             Sandile
@@ -5661,8 +5661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="Krokorok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="View Krokorok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" alt="Krokorok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">552</span>
                             Krokorok
@@ -5671,8 +5671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="Krookodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="View Krookodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" alt="Krookodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">553</span>
                             Krookodile
@@ -5681,8 +5681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="Darumaka">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="View Darumaka on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" alt="Darumaka" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">554</span>
                             Darumaka
@@ -5691,8 +5691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="Darmanitan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="View Darmanitan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" alt="Darmanitan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">555</span>
                             Darmanitan
@@ -5701,8 +5701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="Maractus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="View Maractus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" alt="Maractus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">556</span>
                             Maractus
@@ -5711,8 +5711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="Dwebble">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="View Dwebble on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" alt="Dwebble" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">557</span>
                             Dwebble
@@ -5721,8 +5721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="Crustle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="View Crustle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" alt="Crustle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">558</span>
                             Crustle
@@ -5731,8 +5731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="Scraggy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="View Scraggy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" alt="Scraggy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">559</span>
                             Scraggy
@@ -5741,8 +5741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="Scrafty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="View Scrafty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" alt="Scrafty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">560</span>
                             Scrafty
@@ -5751,8 +5751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="Sigilyph">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="View Sigilyph on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" alt="Sigilyph" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">561</span>
                             Sigilyph
@@ -5761,8 +5761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="Yamask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="View Yamask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" alt="Yamask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">562</span>
                             Yamask
@@ -5771,8 +5771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="Cofagrigus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="View Cofagrigus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" alt="Cofagrigus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">563</span>
                             Cofagrigus
@@ -5781,8 +5781,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tirtouga/" title="Tirtouga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/564.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tirtouga/" title="View Tirtouga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/564.png" alt="Tirtouga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">564</span>
                             Tirtouga
@@ -5791,8 +5791,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carracosta/" title="Carracosta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/565.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carracosta/" title="View Carracosta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/565.png" alt="Carracosta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">565</span>
                             Carracosta
@@ -5801,8 +5801,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/archen/" title="Archen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/566.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/archen/" title="View Archen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/566.png" alt="Archen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">566</span>
                             Archen
@@ -5811,8 +5811,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/archeops/" title="Archeops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/567.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/archeops/" title="View Archeops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/567.png" alt="Archeops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">567</span>
                             Archeops
@@ -5821,8 +5821,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="Trubbish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="View Trubbish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" alt="Trubbish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">568</span>
                             Trubbish
@@ -5831,8 +5831,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="Garbodor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="View Garbodor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" alt="Garbodor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">569</span>
                             Garbodor
@@ -5841,8 +5841,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="Zorua">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="View Zorua on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" alt="Zorua" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">570</span>
                             Zorua
@@ -5858,8 +5858,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="Zoroark">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="View Zoroark on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" alt="Zoroark" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">571</span>
                             Zoroark
@@ -5868,8 +5868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="Minccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="View Minccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" alt="Minccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">572</span>
                             Minccino
@@ -5878,8 +5878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="Cinccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="View Cinccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" alt="Cinccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">573</span>
                             Cinccino
@@ -5888,8 +5888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="Gothita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="View Gothita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" alt="Gothita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">574</span>
                             Gothita
@@ -5898,8 +5898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="Gothorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="View Gothorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" alt="Gothorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">575</span>
                             Gothorita
@@ -5908,8 +5908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="Gothitelle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="View Gothitelle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" alt="Gothitelle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">576</span>
                             Gothitelle
@@ -5918,8 +5918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="Solosis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="View Solosis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" alt="Solosis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">577</span>
                             Solosis
@@ -5928,8 +5928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="Duosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="View Duosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" alt="Duosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">578</span>
                             Duosion
@@ -5938,8 +5938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="Reuniclus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="View Reuniclus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" alt="Reuniclus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">579</span>
                             Reuniclus
@@ -5948,8 +5948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ducklett/" title="Ducklett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/580.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ducklett/" title="View Ducklett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/580.png" alt="Ducklett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">580</span>
                             Ducklett
@@ -5958,8 +5958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swanna/" title="Swanna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/581.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swanna/" title="View Swanna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/581.png" alt="Swanna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">581</span>
                             Swanna
@@ -5968,8 +5968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="Vanillite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="View Vanillite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" alt="Vanillite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">582</span>
                             Vanillite
@@ -5978,8 +5978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="Vanillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="View Vanillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" alt="Vanillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">583</span>
                             Vanillish
@@ -5988,8 +5988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="Vanilluxe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="View Vanilluxe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" alt="Vanilluxe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">584</span>
                             Vanilluxe
@@ -5998,8 +5998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deerling/" title="Deerling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/585.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deerling/" title="View Deerling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/585.png" alt="Deerling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">585</span>
                             Deerling
@@ -6008,8 +6008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sawsbuck/" title="Sawsbuck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/586.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sawsbuck/" title="View Sawsbuck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/586.png" alt="Sawsbuck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">586</span>
                             Sawsbuck
@@ -6018,8 +6018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="Emolga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="View Emolga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" alt="Emolga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">587</span>
                             Emolga
@@ -6028,8 +6028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="Karrablast">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="View Karrablast on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" alt="Karrablast" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">588</span>
                             Karrablast
@@ -6038,8 +6038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="Escavalier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="View Escavalier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" alt="Escavalier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">589</span>
                             Escavalier
@@ -6048,8 +6048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="Foongus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="View Foongus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" alt="Foongus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">590</span>
                             Foongus
@@ -6058,8 +6058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="Amoonguss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="View Amoonguss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" alt="Amoonguss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">591</span>
                             Amoonguss
@@ -6068,8 +6068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="Frillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="View Frillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" alt="Frillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">592</span>
                             Frillish
@@ -6078,8 +6078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="Jellicent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="View Jellicent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" alt="Jellicent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">593</span>
                             Jellicent
@@ -6088,8 +6088,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alomomola/" title="Alomomola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/594.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alomomola/" title="View Alomomola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/594.png" alt="Alomomola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">594</span>
                             Alomomola
@@ -6098,8 +6098,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="Joltik">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="View Joltik on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" alt="Joltik" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">595</span>
                             Joltik
@@ -6108,8 +6108,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="Galvantula">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="View Galvantula on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" alt="Galvantula" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">596</span>
                             Galvantula
@@ -6118,8 +6118,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="Ferroseed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="View Ferroseed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" alt="Ferroseed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">597</span>
                             Ferroseed
@@ -6128,8 +6128,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="Ferrothorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="View Ferrothorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" alt="Ferrothorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">598</span>
                             Ferrothorn
@@ -6138,8 +6138,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="Klink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="View Klink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" alt="Klink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">599</span>
                             Klink
@@ -6148,8 +6148,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="Klang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="View Klang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" alt="Klang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">600</span>
                             Klang
@@ -6165,8 +6165,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="Klinklang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="View Klinklang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" alt="Klinklang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">601</span>
                             Klinklang
@@ -6175,8 +6175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tynamo/" title="Tynamo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/602.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tynamo/" title="View Tynamo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/602.png" alt="Tynamo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">602</span>
                             Tynamo
@@ -6185,8 +6185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eelektrik/" title="Eelektrik">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/603.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eelektrik/" title="View Eelektrik on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/603.png" alt="Eelektrik" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">603</span>
                             Eelektrik
@@ -6195,8 +6195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eelektross/" title="Eelektross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/604.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eelektross/" title="View Eelektross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/604.png" alt="Eelektross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">604</span>
                             Eelektross
@@ -6205,8 +6205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="Elgyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="View Elgyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" alt="Elgyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">605</span>
                             Elgyem
@@ -6215,8 +6215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="Beheeyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="View Beheeyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" alt="Beheeyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">606</span>
                             Beheeyem
@@ -6225,8 +6225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="Litwick">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="View Litwick on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" alt="Litwick" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">607</span>
                             Litwick
@@ -6235,8 +6235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="Lampent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="View Lampent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" alt="Lampent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">608</span>
                             Lampent
@@ -6245,8 +6245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="Chandelure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="View Chandelure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" alt="Chandelure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">609</span>
                             Chandelure
@@ -6255,8 +6255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="Axew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="View Axew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" alt="Axew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">610</span>
                             Axew
@@ -6265,8 +6265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="Fraxure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="View Fraxure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" alt="Fraxure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">611</span>
                             Fraxure
@@ -6275,8 +6275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="Haxorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="View Haxorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" alt="Haxorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">612</span>
                             Haxorus
@@ -6285,8 +6285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="Cubchoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="View Cubchoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" alt="Cubchoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">613</span>
                             Cubchoo
@@ -6295,8 +6295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="Beartic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="View Beartic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" alt="Beartic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">614</span>
                             Beartic
@@ -6305,8 +6305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cryogonal/" title="Cryogonal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/615.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cryogonal/" title="View Cryogonal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/615.png" alt="Cryogonal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">615</span>
                             Cryogonal
@@ -6315,8 +6315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="Shelmet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="View Shelmet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" alt="Shelmet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">616</span>
                             Shelmet
@@ -6325,8 +6325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="Accelgor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="View Accelgor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" alt="Accelgor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">617</span>
                             Accelgor
@@ -6335,8 +6335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="Stunfisk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="View Stunfisk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" alt="Stunfisk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">618</span>
                             Stunfisk
@@ -6345,8 +6345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="Mienfoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="View Mienfoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" alt="Mienfoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">619</span>
                             Mienfoo
@@ -6355,8 +6355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="Mienshao">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="View Mienshao on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" alt="Mienshao" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">620</span>
                             Mienshao
@@ -6365,8 +6365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="Druddigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="View Druddigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" alt="Druddigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">621</span>
                             Druddigon
@@ -6375,8 +6375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="Golett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="View Golett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" alt="Golett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">622</span>
                             Golett
@@ -6385,8 +6385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="Golurk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="View Golurk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" alt="Golurk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">623</span>
                             Golurk
@@ -6395,8 +6395,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="Pawniard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="View Pawniard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" alt="Pawniard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">624</span>
                             Pawniard
@@ -6405,8 +6405,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="Bisharp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="View Bisharp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" alt="Bisharp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">625</span>
                             Bisharp
@@ -6415,8 +6415,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="Bouffalant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="View Bouffalant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" alt="Bouffalant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">626</span>
                             Bouffalant
@@ -6425,8 +6425,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="Rufflet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="View Rufflet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" alt="Rufflet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">627</span>
                             Rufflet
@@ -6435,8 +6435,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="Braviary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="View Braviary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" alt="Braviary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">628</span>
                             Braviary
@@ -6445,8 +6445,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="Vullaby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="View Vullaby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" alt="Vullaby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">629</span>
                             Vullaby
@@ -6455,8 +6455,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="Mandibuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="View Mandibuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" alt="Mandibuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">630</span>
                             Mandibuzz
@@ -6472,8 +6472,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="Heatmor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="View Heatmor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" alt="Heatmor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">631</span>
                             Heatmor
@@ -6482,8 +6482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="Durant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="View Durant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" alt="Durant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">632</span>
                             Durant
@@ -6492,8 +6492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="Deino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="View Deino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" alt="Deino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">633</span>
                             Deino
@@ -6502,8 +6502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="Zweilous">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="View Zweilous on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" alt="Zweilous" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">634</span>
                             Zweilous
@@ -6512,8 +6512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="Hydreigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="View Hydreigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" alt="Hydreigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">635</span>
                             Hydreigon
@@ -6522,8 +6522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="Larvesta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="View Larvesta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" alt="Larvesta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">636</span>
                             Larvesta
@@ -6532,8 +6532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="Volcarona">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="View Volcarona on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" alt="Volcarona" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">637</span>
                             Volcarona
@@ -6542,8 +6542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cobalion/" title="Cobalion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/638.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cobalion/" title="View Cobalion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/638.png" alt="Cobalion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">638</span>
                             Cobalion
@@ -6552,8 +6552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/terrakion/" title="Terrakion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/639.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/terrakion/" title="View Terrakion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/639.png" alt="Terrakion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">639</span>
                             Terrakion
@@ -6562,8 +6562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/virizion/" title="Virizion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/640.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/virizion/" title="View Virizion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/640.png" alt="Virizion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">640</span>
                             Virizion
@@ -6572,8 +6572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tornadus/" title="Tornadus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/641.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tornadus/" title="View Tornadus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/641.png" alt="Tornadus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">641</span>
                             Tornadus
@@ -6582,8 +6582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/thundurus/" title="Thundurus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/642.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/thundurus/" title="View Thundurus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/642.png" alt="Thundurus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">642</span>
                             Thundurus
@@ -6592,8 +6592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/reshiram/" title="Reshiram">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/643.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/reshiram/" title="View Reshiram on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/643.png" alt="Reshiram" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">643</span>
                             Reshiram
@@ -6602,8 +6602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zekrom/" title="Zekrom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/644.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zekrom/" title="View Zekrom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/644.png" alt="Zekrom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">644</span>
                             Zekrom
@@ -6612,8 +6612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/landorus/" title="Landorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/645.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/landorus/" title="View Landorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/645.png" alt="Landorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">645</span>
                             Landorus
@@ -6622,8 +6622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyurem/" title="Kyurem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/646.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyurem/" title="View Kyurem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/646.png" alt="Kyurem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">646</span>
                             Kyurem
@@ -6632,8 +6632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/keldeo/" title="Keldeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/647.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/keldeo/" title="View Keldeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/647.png" alt="Keldeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">647</span>
                             Keldeo
@@ -6642,8 +6642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meloetta/" title="Meloetta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/648.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meloetta/" title="View Meloetta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/648.png" alt="Meloetta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">648</span>
                             Meloetta
@@ -6652,8 +6652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/genesect/" title="Genesect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/649.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/genesect/" title="View Genesect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/649.png" alt="Genesect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">649</span>
                             Genesect
@@ -6662,8 +6662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chespin/" title="Chespin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/650.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chespin/" title="View Chespin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/650.png" alt="Chespin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">650</span>
                             Chespin
@@ -6672,8 +6672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilladin/" title="Quilladin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/651.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilladin/" title="View Quilladin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/651.png" alt="Quilladin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">651</span>
                             Quilladin
@@ -6682,8 +6682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chesnaught/" title="Chesnaught">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/652.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chesnaught/" title="View Chesnaught on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/652.png" alt="Chesnaught" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">652</span>
                             Chesnaught
@@ -6692,8 +6692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fennekin/" title="Fennekin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/653.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fennekin/" title="View Fennekin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/653.png" alt="Fennekin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">653</span>
                             Fennekin
@@ -6702,8 +6702,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/braixen/" title="Braixen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/654.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/braixen/" title="View Braixen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/654.png" alt="Braixen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">654</span>
                             Braixen
@@ -6712,8 +6712,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delphox/" title="Delphox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/655.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delphox/" title="View Delphox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/655.png" alt="Delphox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">655</span>
                             Delphox
@@ -6722,8 +6722,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froakie/" title="Froakie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/656.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froakie/" title="View Froakie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/656.png" alt="Froakie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">656</span>
                             Froakie
@@ -6732,8 +6732,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frogadier/" title="Frogadier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/657.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frogadier/" title="View Frogadier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/657.png" alt="Frogadier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">657</span>
                             Frogadier
@@ -6742,8 +6742,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/greninja/" title="Greninja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/658.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/greninja/" title="View Greninja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/658.png" alt="Greninja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">658</span>
                             Greninja
@@ -6752,8 +6752,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bunnelby/" title="Bunnelby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/659.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bunnelby/" title="View Bunnelby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/659.png" alt="Bunnelby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">659</span>
                             Bunnelby
@@ -6762,8 +6762,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diggersby/" title="Diggersby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/660.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diggersby/" title="View Diggersby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/660.png" alt="Diggersby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">660</span>
                             Diggersby
@@ -6779,8 +6779,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fletchling/" title="Fletchling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/661.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fletchling/" title="View Fletchling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/661.png" alt="Fletchling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">661</span>
                             Fletchling
@@ -6789,8 +6789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fletchinder/" title="Fletchinder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/662.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fletchinder/" title="View Fletchinder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/662.png" alt="Fletchinder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">662</span>
                             Fletchinder
@@ -6799,8 +6799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/talonflame/" title="Talonflame">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/663.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/talonflame/" title="View Talonflame on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/663.png" alt="Talonflame" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">663</span>
                             Talonflame
@@ -6809,8 +6809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scatterbug/" title="Scatterbug">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/664.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scatterbug/" title="View Scatterbug on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/664.png" alt="Scatterbug" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">664</span>
                             Scatterbug
@@ -6819,8 +6819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spewpa/" title="Spewpa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/665.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spewpa/" title="View Spewpa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/665.png" alt="Spewpa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">665</span>
                             Spewpa
@@ -6829,8 +6829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vivillon/" title="Vivillon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/666.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vivillon/" title="View Vivillon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/666.png" alt="Vivillon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">666</span>
                             Vivillon
@@ -6839,8 +6839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litleo/" title="Litleo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/667.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litleo/" title="View Litleo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/667.png" alt="Litleo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">667</span>
                             Litleo
@@ -6849,8 +6849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pyroar/" title="Pyroar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/668.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pyroar/" title="View Pyroar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/668.png" alt="Pyroar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">668</span>
                             Pyroar
@@ -6859,8 +6859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flabebe/" title="Flabébé">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/669.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flabebe/" title="View Flabébé on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/669.png" alt="Flabébé" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">669</span>
                             Flabébé
@@ -6869,8 +6869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/floette/" title="Floette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/670.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/floette/" title="View Floette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/670.png" alt="Floette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">670</span>
                             Floette
@@ -6879,8 +6879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/florges/" title="Florges">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/671.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/florges/" title="View Florges on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/671.png" alt="Florges" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">671</span>
                             Florges
@@ -6889,8 +6889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiddo/" title="Skiddo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/672.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiddo/" title="View Skiddo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/672.png" alt="Skiddo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">672</span>
                             Skiddo
@@ -6899,8 +6899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gogoat/" title="Gogoat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/673.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gogoat/" title="View Gogoat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/673.png" alt="Gogoat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">673</span>
                             Gogoat
@@ -6909,8 +6909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pancham/" title="Pancham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/674.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pancham/" title="View Pancham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/674.png" alt="Pancham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">674</span>
                             Pancham
@@ -6919,8 +6919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pangoro/" title="Pangoro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/675.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pangoro/" title="View Pangoro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/675.png" alt="Pangoro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">675</span>
                             Pangoro
@@ -6929,8 +6929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furfrou/" title="Furfrou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/676.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furfrou/" title="View Furfrou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/676.png" alt="Furfrou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">676</span>
                             Furfrou
@@ -6939,8 +6939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espurr/" title="Espurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/677.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espurr/" title="View Espurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/677.png" alt="Espurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">677</span>
                             Espurr
@@ -6949,8 +6949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowstic/" title="Meowstic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/678.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowstic/" title="View Meowstic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/678.png" alt="Meowstic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">678</span>
                             Meowstic
@@ -6959,8 +6959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honedge/" title="Honedge">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/679.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honedge/" title="View Honedge on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/679.png" alt="Honedge" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">679</span>
                             Honedge
@@ -6969,8 +6969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doublade/" title="Doublade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/680.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doublade/" title="View Doublade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/680.png" alt="Doublade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">680</span>
                             Doublade
@@ -6979,8 +6979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aegislash/" title="Aegislash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/681.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aegislash/" title="View Aegislash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/681.png" alt="Aegislash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">681</span>
                             Aegislash
@@ -6989,8 +6989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spritzee/" title="Spritzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/682.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spritzee/" title="View Spritzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/682.png" alt="Spritzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">682</span>
                             Spritzee
@@ -6999,8 +6999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aromatisse/" title="Aromatisse">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/683.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aromatisse/" title="View Aromatisse on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/683.png" alt="Aromatisse" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">683</span>
                             Aromatisse
@@ -7009,8 +7009,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swirlix/" title="Swirlix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/684.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swirlix/" title="View Swirlix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/684.png" alt="Swirlix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">684</span>
                             Swirlix
@@ -7019,8 +7019,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slurpuff/" title="Slurpuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/685.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slurpuff/" title="View Slurpuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/685.png" alt="Slurpuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">685</span>
                             Slurpuff
@@ -7029,8 +7029,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="Inkay">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="View Inkay on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" alt="Inkay" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">686</span>
                             Inkay
@@ -7039,8 +7039,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="Malamar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="View Malamar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" alt="Malamar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">687</span>
                             Malamar
@@ -7049,8 +7049,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/binacle/" title="Binacle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/688.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/binacle/" title="View Binacle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/688.png" alt="Binacle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">688</span>
                             Binacle
@@ -7059,8 +7059,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barbaracle/" title="Barbaracle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/689.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barbaracle/" title="View Barbaracle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/689.png" alt="Barbaracle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">689</span>
                             Barbaracle
@@ -7069,8 +7069,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skrelp/" title="Skrelp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/690.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skrelp/" title="View Skrelp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/690.png" alt="Skrelp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">690</span>
                             Skrelp
@@ -7086,8 +7086,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragalge/" title="Dragalge">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/691.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragalge/" title="View Dragalge on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/691.png" alt="Dragalge" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">691</span>
                             Dragalge
@@ -7096,8 +7096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clauncher/" title="Clauncher">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/692.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clauncher/" title="View Clauncher on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/692.png" alt="Clauncher" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">692</span>
                             Clauncher
@@ -7106,8 +7106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clawitzer/" title="Clawitzer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/693.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clawitzer/" title="View Clawitzer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/693.png" alt="Clawitzer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">693</span>
                             Clawitzer
@@ -7116,8 +7116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/helioptile/" title="Helioptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/694.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/helioptile/" title="View Helioptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/694.png" alt="Helioptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">694</span>
                             Helioptile
@@ -7126,8 +7126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heliolisk/" title="Heliolisk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/695.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heliolisk/" title="View Heliolisk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/695.png" alt="Heliolisk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">695</span>
                             Heliolisk
@@ -7136,8 +7136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrunt/" title="Tyrunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/696.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrunt/" title="View Tyrunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/696.png" alt="Tyrunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">696</span>
                             Tyrunt
@@ -7146,8 +7146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrantrum/" title="Tyrantrum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/697.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrantrum/" title="View Tyrantrum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/697.png" alt="Tyrantrum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">697</span>
                             Tyrantrum
@@ -7156,8 +7156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/amaura/" title="Amaura">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/698.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/amaura/" title="View Amaura on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/698.png" alt="Amaura" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">698</span>
                             Amaura
@@ -7166,8 +7166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aurorus/" title="Aurorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/699.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aurorus/" title="View Aurorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/699.png" alt="Aurorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">699</span>
                             Aurorus
@@ -7176,8 +7176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sylveon/" title="Sylveon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/700.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sylveon/" title="View Sylveon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/700.png" alt="Sylveon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">700</span>
                             Sylveon
@@ -7186,8 +7186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hawlucha/" title="Hawlucha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/701.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hawlucha/" title="View Hawlucha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/701.png" alt="Hawlucha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">701</span>
                             Hawlucha
@@ -7196,8 +7196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dedenne/" title="Dedenne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/702.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dedenne/" title="View Dedenne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/702.png" alt="Dedenne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">702</span>
                             Dedenne
@@ -7206,8 +7206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carbink/" title="Carbink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/703.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carbink/" title="View Carbink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/703.png" alt="Carbink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">703</span>
                             Carbink
@@ -7216,8 +7216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="Goomy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="View Goomy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" alt="Goomy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">704</span>
                             Goomy
@@ -7226,8 +7226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="Sliggoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="View Sliggoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" alt="Sliggoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">705</span>
                             Sliggoo
@@ -7236,8 +7236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="Goodra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="View Goodra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" alt="Goodra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">706</span>
                             Goodra
@@ -7246,8 +7246,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klefki/" title="Klefki">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/707.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klefki/" title="View Klefki on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/707.png" alt="Klefki" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">707</span>
                             Klefki
@@ -7256,8 +7256,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phantump/" title="Phantump">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/708.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phantump/" title="View Phantump on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/708.png" alt="Phantump" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">708</span>
                             Phantump
@@ -7266,8 +7266,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trevenant/" title="Trevenant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/709.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trevenant/" title="View Trevenant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/709.png" alt="Trevenant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">709</span>
                             Trevenant
@@ -7276,8 +7276,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pumpkaboo/" title="Pumpkaboo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/710.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pumpkaboo/" title="View Pumpkaboo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/710.png" alt="Pumpkaboo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">710</span>
                             Pumpkaboo
@@ -7286,8 +7286,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gourgeist/" title="Gourgeist">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/711.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gourgeist/" title="View Gourgeist on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/711.png" alt="Gourgeist" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">711</span>
                             Gourgeist
@@ -7296,8 +7296,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bergmite/" title="Bergmite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/712.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bergmite/" title="View Bergmite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/712.png" alt="Bergmite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">712</span>
                             Bergmite
@@ -7306,8 +7306,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/avalugg/" title="Avalugg">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/713.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/avalugg/" title="View Avalugg on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/713.png" alt="Avalugg" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">713</span>
                             Avalugg
@@ -7316,8 +7316,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noibat/" title="Noibat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/714.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noibat/" title="View Noibat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/714.png" alt="Noibat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">714</span>
                             Noibat
@@ -7326,8 +7326,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noivern/" title="Noivern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/715.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noivern/" title="View Noivern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/715.png" alt="Noivern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">715</span>
                             Noivern
@@ -7336,8 +7336,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xerneas/" title="Xerneas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/716.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xerneas/" title="View Xerneas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/716.png" alt="Xerneas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">716</span>
                             Xerneas
@@ -7346,8 +7346,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yveltal/" title="Yveltal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/717.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yveltal/" title="View Yveltal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/717.png" alt="Yveltal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">717</span>
                             Yveltal
@@ -7356,8 +7356,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zygarde/" title="Zygarde">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/718.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zygarde/" title="View Zygarde on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/718.png" alt="Zygarde" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">718</span>
                             Zygarde
@@ -7366,8 +7366,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diancie/" title="Diancie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/719.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diancie/" title="View Diancie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/719.png" alt="Diancie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">719</span>
                             Diancie
@@ -7376,8 +7376,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoopa/" title="Hoopa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/720.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoopa/" title="View Hoopa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/720.png" alt="Hoopa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">720</span>
                             Hoopa
@@ -7393,8 +7393,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volcanion/" title="Volcanion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/721.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volcanion/" title="View Volcanion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/721.png" alt="Volcanion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">721</span>
                             Volcanion
@@ -7403,8 +7403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rowlet/" title="Rowlet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/722.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rowlet/" title="View Rowlet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/722.png" alt="Rowlet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">722</span>
                             Rowlet
@@ -7413,8 +7413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dartrix/" title="Dartrix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/723.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dartrix/" title="View Dartrix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/723.png" alt="Dartrix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">723</span>
                             Dartrix
@@ -7423,8 +7423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/decidueye/" title="Decidueye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/724.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/decidueye/" title="View Decidueye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/724.png" alt="Decidueye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">724</span>
                             Decidueye
@@ -7433,8 +7433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litten/" title="Litten">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/725.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litten/" title="View Litten on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/725.png" alt="Litten" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">725</span>
                             Litten
@@ -7443,8 +7443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torracat/" title="Torracat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/726.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torracat/" title="View Torracat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/726.png" alt="Torracat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">726</span>
                             Torracat
@@ -7453,8 +7453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/incineroar/" title="Incineroar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/727.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/incineroar/" title="View Incineroar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/727.png" alt="Incineroar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">727</span>
                             Incineroar
@@ -7463,8 +7463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/popplio/" title="Popplio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/728.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/popplio/" title="View Popplio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/728.png" alt="Popplio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">728</span>
                             Popplio
@@ -7473,8 +7473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/brionne/" title="Brionne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/729.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/brionne/" title="View Brionne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/729.png" alt="Brionne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">729</span>
                             Brionne
@@ -7483,8 +7483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primarina/" title="Primarina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/730.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primarina/" title="View Primarina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/730.png" alt="Primarina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">730</span>
                             Primarina
@@ -7493,8 +7493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikipek/" title="Pikipek">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/731.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikipek/" title="View Pikipek on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/731.png" alt="Pikipek" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">731</span>
                             Pikipek
@@ -7503,8 +7503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trumbeak/" title="Trumbeak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/732.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trumbeak/" title="View Trumbeak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/732.png" alt="Trumbeak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">732</span>
                             Trumbeak
@@ -7513,8 +7513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toucannon/" title="Toucannon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/733.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toucannon/" title="View Toucannon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/733.png" alt="Toucannon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">733</span>
                             Toucannon
@@ -7523,8 +7523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yungoos/" title="Yungoos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/734.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yungoos/" title="View Yungoos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/734.png" alt="Yungoos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">734</span>
                             Yungoos
@@ -7533,8 +7533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gumshoos/" title="Gumshoos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/735.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gumshoos/" title="View Gumshoos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/735.png" alt="Gumshoos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">735</span>
                             Gumshoos
@@ -7543,8 +7543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grubbin/" title="Grubbin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/736.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grubbin/" title="View Grubbin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/736.png" alt="Grubbin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">736</span>
                             Grubbin
@@ -7553,8 +7553,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charjabug/" title="Charjabug">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/737.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charjabug/" title="View Charjabug on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/737.png" alt="Charjabug" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">737</span>
                             Charjabug
@@ -7563,8 +7563,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vikavolt/" title="Vikavolt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/738.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vikavolt/" title="View Vikavolt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/738.png" alt="Vikavolt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">738</span>
                             Vikavolt
@@ -7573,8 +7573,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crabrawler/" title="Crabrawler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/739.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crabrawler/" title="View Crabrawler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/739.png" alt="Crabrawler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">739</span>
                             Crabrawler
@@ -7583,8 +7583,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crabominable/" title="Crabominable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/740.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crabominable/" title="View Crabominable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/740.png" alt="Crabominable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">740</span>
                             Crabominable
@@ -7593,8 +7593,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oricorio/" title="Oricorio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/741.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oricorio/" title="View Oricorio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/741.png" alt="Oricorio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">741</span>
                             Oricorio
@@ -7603,8 +7603,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cutiefly/" title="Cutiefly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/742.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cutiefly/" title="View Cutiefly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/742.png" alt="Cutiefly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">742</span>
                             Cutiefly
@@ -7613,8 +7613,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ribombee/" title="Ribombee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/743.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ribombee/" title="View Ribombee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/743.png" alt="Ribombee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">743</span>
                             Ribombee
@@ -7623,8 +7623,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rockruff/" title="Rockruff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/744.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rockruff/" title="View Rockruff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/744.png" alt="Rockruff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">744</span>
                             Rockruff
@@ -7633,8 +7633,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lycanroc/" title="Lycanroc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/745.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lycanroc/" title="View Lycanroc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/745.png" alt="Lycanroc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">745</span>
                             Lycanroc
@@ -7643,8 +7643,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wishiwashi/" title="Wishiwashi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/746.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wishiwashi/" title="View Wishiwashi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/746.png" alt="Wishiwashi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">746</span>
                             Wishiwashi
@@ -7653,8 +7653,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareanie/" title="Mareanie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/747.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareanie/" title="View Mareanie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/747.png" alt="Mareanie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">747</span>
                             Mareanie
@@ -7663,8 +7663,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxapex/" title="Toxapex">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/748.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxapex/" title="View Toxapex on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/748.png" alt="Toxapex" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">748</span>
                             Toxapex
@@ -7673,8 +7673,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudbray/" title="Mudbray">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/749.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudbray/" title="View Mudbray on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/749.png" alt="Mudbray" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">749</span>
                             Mudbray
@@ -7683,8 +7683,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudsdale/" title="Mudsdale">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/750.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudsdale/" title="View Mudsdale on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/750.png" alt="Mudsdale" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">750</span>
                             Mudsdale
@@ -7700,8 +7700,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewpider/" title="Dewpider">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/751.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewpider/" title="View Dewpider on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/751.png" alt="Dewpider" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">751</span>
                             Dewpider
@@ -7710,8 +7710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/araquanid/" title="Araquanid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/752.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/araquanid/" title="View Araquanid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/752.png" alt="Araquanid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">752</span>
                             Araquanid
@@ -7720,8 +7720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fomantis/" title="Fomantis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/753.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fomantis/" title="View Fomantis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/753.png" alt="Fomantis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">753</span>
                             Fomantis
@@ -7730,8 +7730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lurantis/" title="Lurantis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/754.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lurantis/" title="View Lurantis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/754.png" alt="Lurantis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">754</span>
                             Lurantis
@@ -7740,8 +7740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/morelull/" title="Morelull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/755.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/morelull/" title="View Morelull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/755.png" alt="Morelull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">755</span>
                             Morelull
@@ -7750,8 +7750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiinotic/" title="Shiinotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/756.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiinotic/" title="View Shiinotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/756.png" alt="Shiinotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">756</span>
                             Shiinotic
@@ -7760,8 +7760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salandit/" title="Salandit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/757.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salandit/" title="View Salandit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/757.png" alt="Salandit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">757</span>
                             Salandit
@@ -7770,8 +7770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salazzle/" title="Salazzle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/758.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salazzle/" title="View Salazzle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/758.png" alt="Salazzle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">758</span>
                             Salazzle
@@ -7780,8 +7780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stufful/" title="Stufful">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/759.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stufful/" title="View Stufful on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/759.png" alt="Stufful" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">759</span>
                             Stufful
@@ -7790,8 +7790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bewear/" title="Bewear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/760.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bewear/" title="View Bewear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/760.png" alt="Bewear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">760</span>
                             Bewear
@@ -7800,8 +7800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bounsweet/" title="Bounsweet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/761.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bounsweet/" title="View Bounsweet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/761.png" alt="Bounsweet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">761</span>
                             Bounsweet
@@ -7810,8 +7810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steenee/" title="Steenee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/762.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steenee/" title="View Steenee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/762.png" alt="Steenee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">762</span>
                             Steenee
@@ -7820,8 +7820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tsareena/" title="Tsareena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/763.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tsareena/" title="View Tsareena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/763.png" alt="Tsareena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">763</span>
                             Tsareena
@@ -7830,8 +7830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/comfey/" title="Comfey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/764.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/comfey/" title="View Comfey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/764.png" alt="Comfey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">764</span>
                             Comfey
@@ -7840,8 +7840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oranguru/" title="Oranguru">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/765.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oranguru/" title="View Oranguru on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/765.png" alt="Oranguru" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">765</span>
                             Oranguru
@@ -7850,8 +7850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/passimian/" title="Passimian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/766.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/passimian/" title="View Passimian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/766.png" alt="Passimian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">766</span>
                             Passimian
@@ -7860,8 +7860,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wimpod/" title="Wimpod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/767.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wimpod/" title="View Wimpod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/767.png" alt="Wimpod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">767</span>
                             Wimpod
@@ -7870,8 +7870,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golisopod/" title="Golisopod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/768.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golisopod/" title="View Golisopod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/768.png" alt="Golisopod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">768</span>
                             Golisopod
@@ -7880,8 +7880,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandygast/" title="Sandygast">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/769.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandygast/" title="View Sandygast on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/769.png" alt="Sandygast" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">769</span>
                             Sandygast
@@ -7890,8 +7890,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palossand/" title="Palossand">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/770.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palossand/" title="View Palossand on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/770.png" alt="Palossand" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">770</span>
                             Palossand
@@ -7900,8 +7900,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pyukumuku/" title="Pyukumuku">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/771.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pyukumuku/" title="View Pyukumuku on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/771.png" alt="Pyukumuku" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">771</span>
                             Pyukumuku
@@ -7910,8 +7910,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/type-null/" title="Type: Null">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/772.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/type-null/" title="View Type: Null on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/772.png" alt="Type: Null" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">772</span>
                             Type: Null
@@ -7920,8 +7920,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silvally/" title="Silvally">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/773.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silvally/" title="View Silvally on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/773.png" alt="Silvally" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">773</span>
                             Silvally
@@ -7930,8 +7930,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minior/" title="Minior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/774.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minior/" title="View Minior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/774.png" alt="Minior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">774</span>
                             Minior
@@ -7940,8 +7940,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/komala/" title="Komala">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/775.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/komala/" title="View Komala on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/775.png" alt="Komala" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">775</span>
                             Komala
@@ -7950,8 +7950,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/turtonator/" title="Turtonator">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/776.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/turtonator/" title="View Turtonator on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/776.png" alt="Turtonator" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">776</span>
                             Turtonator
@@ -7960,8 +7960,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togedemaru/" title="Togedemaru">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/777.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togedemaru/" title="View Togedemaru on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/777.png" alt="Togedemaru" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">777</span>
                             Togedemaru
@@ -7970,8 +7970,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mimikyu/" title="Mimikyu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/778.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mimikyu/" title="View Mimikyu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/778.png" alt="Mimikyu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">778</span>
                             Mimikyu
@@ -7980,8 +7980,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bruxish/" title="Bruxish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/779.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bruxish/" title="View Bruxish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/779.png" alt="Bruxish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">779</span>
                             Bruxish
@@ -7990,8 +7990,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drampa/" title="Drampa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/780.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drampa/" title="View Drampa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/780.png" alt="Drampa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">780</span>
                             Drampa
@@ -8007,8 +8007,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dhelmise/" title="Dhelmise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/781.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dhelmise/" title="View Dhelmise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/781.png" alt="Dhelmise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">781</span>
                             Dhelmise
@@ -8017,8 +8017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jangmo-o/" title="Jangmo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/782.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jangmo-o/" title="View Jangmo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/782.png" alt="Jangmo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">782</span>
                             Jangmo-o
@@ -8027,8 +8027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hakamo-o/" title="Hakamo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/783.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hakamo-o/" title="View Hakamo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/783.png" alt="Hakamo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">783</span>
                             Hakamo-o
@@ -8037,8 +8037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kommo-o/" title="Kommo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/784.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kommo-o/" title="View Kommo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/784.png" alt="Kommo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">784</span>
                             Kommo-o
@@ -8047,8 +8047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tapu-koko/" title="Tapu Koko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/785.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tapu-koko/" title="View Tapu Koko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/785.png" alt="Tapu Koko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">785</span>
                             Tapu Koko
@@ -8057,8 +8057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tapu-lele/" title="Tapu Lele">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/786.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tapu-lele/" title="View Tapu Lele on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/786.png" alt="Tapu Lele" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">786</span>
                             Tapu Lele
@@ -8067,8 +8067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tapu-bulu/" title="Tapu Bulu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/787.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tapu-bulu/" title="View Tapu Bulu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/787.png" alt="Tapu Bulu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">787</span>
                             Tapu Bulu
@@ -8077,8 +8077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tapu-fini/" title="Tapu Fini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/788.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tapu-fini/" title="View Tapu Fini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/788.png" alt="Tapu Fini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">788</span>
                             Tapu Fini
@@ -8087,8 +8087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cosmog/" title="Cosmog">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/789.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cosmog/" title="View Cosmog on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/789.png" alt="Cosmog" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">789</span>
                             Cosmog
@@ -8097,8 +8097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cosmoem/" title="Cosmoem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/790.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cosmoem/" title="View Cosmoem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/790.png" alt="Cosmoem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">790</span>
                             Cosmoem
@@ -8107,8 +8107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solgaleo/" title="Solgaleo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/791.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solgaleo/" title="View Solgaleo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/791.png" alt="Solgaleo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">791</span>
                             Solgaleo
@@ -8117,8 +8117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunala/" title="Lunala">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/792.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunala/" title="View Lunala on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/792.png" alt="Lunala" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">792</span>
                             Lunala
@@ -8127,8 +8127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nihilego/" title="Nihilego">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/793.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nihilego/" title="View Nihilego on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/793.png" alt="Nihilego" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">793</span>
                             Nihilego
@@ -8137,8 +8137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buzzwole/" title="Buzzwole">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/794.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buzzwole/" title="View Buzzwole on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/794.png" alt="Buzzwole" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">794</span>
                             Buzzwole
@@ -8147,8 +8147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pheromosa/" title="Pheromosa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/795.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pheromosa/" title="View Pheromosa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/795.png" alt="Pheromosa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">795</span>
                             Pheromosa
@@ -8157,8 +8157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xurkitree/" title="Xurkitree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/796.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xurkitree/" title="View Xurkitree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/796.png" alt="Xurkitree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">796</span>
                             Xurkitree
@@ -8167,8 +8167,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celesteela/" title="Celesteela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/797.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celesteela/" title="View Celesteela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/797.png" alt="Celesteela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">797</span>
                             Celesteela
@@ -8177,8 +8177,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kartana/" title="Kartana">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/798.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kartana/" title="View Kartana on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/798.png" alt="Kartana" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">798</span>
                             Kartana
@@ -8187,8 +8187,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/guzzlord/" title="Guzzlord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/799.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/guzzlord/" title="View Guzzlord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/799.png" alt="Guzzlord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">799</span>
                             Guzzlord
@@ -8197,8 +8197,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/necrozma/" title="Necrozma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/800.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/necrozma/" title="View Necrozma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/800.png" alt="Necrozma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">800</span>
                             Necrozma
@@ -8207,8 +8207,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magearna/" title="Magearna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/801.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magearna/" title="View Magearna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/801.png" alt="Magearna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">801</span>
                             Magearna
@@ -8217,8 +8217,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marshadow/" title="Marshadow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/802.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marshadow/" title="View Marshadow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/802.png" alt="Marshadow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">802</span>
                             Marshadow
@@ -8232,8 +8232,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/sword-shield-galar.html
+++ b/docs/sword-shield-galar.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grookey/" title="Grookey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/810.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grookey/" title="View Grookey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/810.png" alt="Grookey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Grookey
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/thwackey/" title="Thwackey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/811.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/thwackey/" title="View Thwackey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/811.png" alt="Thwackey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Thwackey
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rillaboom/" title="Rillaboom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/812.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rillaboom/" title="View Rillaboom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/812.png" alt="Rillaboom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Rillaboom
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scorbunny/" title="Scorbunny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/813.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scorbunny/" title="View Scorbunny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/813.png" alt="Scorbunny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Scorbunny
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raboot/" title="Raboot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/814.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raboot/" title="View Raboot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/814.png" alt="Raboot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Raboot
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cinderace/" title="Cinderace">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/815.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cinderace/" title="View Cinderace on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/815.png" alt="Cinderace" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Cinderace
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sobble/" title="Sobble">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/816.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sobble/" title="View Sobble on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/816.png" alt="Sobble" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Sobble
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drizzile/" title="Drizzile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/817.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drizzile/" title="View Drizzile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/817.png" alt="Drizzile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Drizzile
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/inteleon/" title="Inteleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/818.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/inteleon/" title="View Inteleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/818.png" alt="Inteleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Inteleon
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blipbug/" title="Blipbug">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/824.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blipbug/" title="View Blipbug on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/824.png" alt="Blipbug" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Blipbug
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dottler/" title="Dottler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/825.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dottler/" title="View Dottler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/825.png" alt="Dottler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Dottler
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/orbeetle/" title="Orbeetle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/826.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/orbeetle/" title="View Orbeetle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/826.png" alt="Orbeetle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Orbeetle
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Caterpie
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Metapod
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Butterfree
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grubbin/" title="Grubbin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/736.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grubbin/" title="View Grubbin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/736.png" alt="Grubbin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Grubbin
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charjabug/" title="Charjabug">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/737.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charjabug/" title="View Charjabug on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/737.png" alt="Charjabug" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Charjabug
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vikavolt/" title="Vikavolt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/738.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vikavolt/" title="View Vikavolt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/738.png" alt="Vikavolt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Vikavolt
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="Hoothoot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="View Hoothoot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" alt="Hoothoot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Hoothoot
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="Noctowl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="View Noctowl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" alt="Noctowl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Noctowl
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rookidee/" title="Rookidee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/821.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rookidee/" title="View Rookidee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/821.png" alt="Rookidee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Rookidee
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corvisquire/" title="Corvisquire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/822.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corvisquire/" title="View Corvisquire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/822.png" alt="Corvisquire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Corvisquire
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corviknight/" title="Corviknight">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/823.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corviknight/" title="View Corviknight on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/823.png" alt="Corviknight" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Corviknight
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skwovet/" title="Skwovet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/819.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skwovet/" title="View Skwovet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/819.png" alt="Skwovet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Skwovet
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/greedent/" title="Greedent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/820.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/greedent/" title="View Greedent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/820.png" alt="Greedent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Greedent
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="Pidove">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="View Pidove on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" alt="Pidove" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Pidove
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="Tranquill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="View Tranquill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" alt="Tranquill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Tranquill
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="Unfezant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="View Unfezant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" alt="Unfezant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Unfezant
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nickit/" title="Nickit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/827.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nickit/" title="View Nickit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/827.png" alt="Nickit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nickit
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/thievul/" title="Thievul">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/828.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/thievul/" title="View Thievul on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/828.png" alt="Thievul" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Thievul
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="Zigzagoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="View Zigzagoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" alt="Zigzagoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Zigzagoon
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="Linoone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="View Linoone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" alt="Linoone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Linoone
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/obstagoon/" title="Obstagoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/862.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/obstagoon/" title="View Obstagoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/862.png" alt="Obstagoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Obstagoon
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooloo/" title="Wooloo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/831.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooloo/" title="View Wooloo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/831.png" alt="Wooloo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Wooloo
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dubwool/" title="Dubwool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/832.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dubwool/" title="View Dubwool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/832.png" alt="Dubwool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Dubwool
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="Lotad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="View Lotad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" alt="Lotad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Lotad
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="Lombre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="View Lombre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" alt="Lombre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Lombre
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="Ludicolo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="View Ludicolo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" alt="Ludicolo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ludicolo
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="Seedot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="View Seedot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" alt="Seedot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Seedot
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="Nuzleaf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="View Nuzleaf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" alt="Nuzleaf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Nuzleaf
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="Shiftry">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="View Shiftry on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" alt="Shiftry" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Shiftry
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chewtle/" title="Chewtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/833.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chewtle/" title="View Chewtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/833.png" alt="Chewtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Chewtle
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drednaw/" title="Drednaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/834.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drednaw/" title="View Drednaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/834.png" alt="Drednaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Drednaw
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="Purrloin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="View Purrloin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" alt="Purrloin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Purrloin
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="Liepard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="View Liepard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" alt="Liepard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Liepard
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yamper/" title="Yamper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/835.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yamper/" title="View Yamper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/835.png" alt="Yamper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Yamper
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/boltund/" title="Boltund">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/836.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/boltund/" title="View Boltund on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/836.png" alt="Boltund" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Boltund
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bunnelby/" title="Bunnelby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/659.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bunnelby/" title="View Bunnelby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/659.png" alt="Bunnelby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Bunnelby
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diggersby/" title="Diggersby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/660.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diggersby/" title="View Diggersby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/660.png" alt="Diggersby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Diggersby
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="Minccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="View Minccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" alt="Minccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Minccino
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="Cinccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="View Cinccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" alt="Cinccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Cinccino
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bounsweet/" title="Bounsweet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/761.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bounsweet/" title="View Bounsweet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/761.png" alt="Bounsweet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Bounsweet
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steenee/" title="Steenee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/762.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steenee/" title="View Steenee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/762.png" alt="Steenee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Steenee
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tsareena/" title="Tsareena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/763.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tsareena/" title="View Tsareena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/763.png" alt="Tsareena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Tsareena
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Oddish
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Gloom
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Vileplume
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="Bellossom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="View Bellossom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" alt="Bellossom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Bellossom
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="Budew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="View Budew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" alt="Budew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Budew
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="Roselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="View Roselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" alt="Roselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Roselia
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="Roserade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="View Roserade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" alt="Roserade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Roserade
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="Wingull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="View Wingull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" alt="Wingull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Wingull
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="Pelipper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="View Pelipper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" alt="Pelipper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Pelipper
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="Joltik">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="View Joltik on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" alt="Joltik" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Joltik
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="Galvantula">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="View Galvantula on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" alt="Galvantula" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Galvantula
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="Electrike">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="View Electrike on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" alt="Electrike" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Electrike
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="Manectric">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="View Manectric on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" alt="Manectric" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Manectric
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Vulpix
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Ninetales
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Growlithe
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Arcanine
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="Vanillite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="View Vanillite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" alt="Vanillite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Vanillite
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="Vanillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="View Vanillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" alt="Vanillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Vanillish
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="Vanilluxe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="View Vanilluxe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" alt="Vanilluxe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Vanilluxe
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="Swinub">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="View Swinub on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" alt="Swinub" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Swinub
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="Piloswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="View Piloswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" alt="Piloswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Piloswine
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="Mamoswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="View Mamoswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" alt="Mamoswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Mamoswine
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="Delibird">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="View Delibird on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" alt="Delibird" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Delibird
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="Snorunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="View Snorunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" alt="Snorunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Snorunt
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="Glalie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="View Glalie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" alt="Glalie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Glalie
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="Froslass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="View Froslass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" alt="Froslass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Froslass
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="Baltoy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="View Baltoy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" alt="Baltoy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Baltoy
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="Claydol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="View Claydol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" alt="Claydol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Claydol
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudbray/" title="Mudbray">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/749.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudbray/" title="View Mudbray on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/749.png" alt="Mudbray" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Mudbray
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudsdale/" title="Mudsdale">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/750.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudsdale/" title="View Mudsdale on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/750.png" alt="Mudsdale" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Mudsdale
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="Dwebble">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="View Dwebble on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" alt="Dwebble" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Dwebble
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="Crustle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="View Crustle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" alt="Crustle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Crustle
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="Golett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="View Golett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" alt="Golett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Golett
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="Golurk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="View Golurk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" alt="Golurk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Golurk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="Munna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="View Munna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" alt="Munna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Munna
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="Musharna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="View Musharna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" alt="Musharna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Musharna
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="Natu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="View Natu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" alt="Natu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Natu
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="Xatu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="View Xatu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" alt="Xatu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Xatu
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stufful/" title="Stufful">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/759.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stufful/" title="View Stufful on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/759.png" alt="Stufful" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Stufful
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bewear/" title="Bewear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/760.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bewear/" title="View Bewear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/760.png" alt="Bewear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Bewear
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="Snover">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="View Snover on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" alt="Snover" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Snover
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="Abomasnow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="View Abomasnow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" alt="Abomasnow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Abomasnow
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Wooper
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Quagsire
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="Corphish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="View Corphish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" alt="Corphish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Corphish
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="Crawdaunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="View Crawdaunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" alt="Crawdaunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Crawdaunt
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="Nincada">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="View Nincada on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" alt="Nincada" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Nincada
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="Ninjask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="View Ninjask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" alt="Ninjask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Ninjask
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="Shedinja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="View Shedinja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" alt="Shedinja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Shedinja
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="Tyrogue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="View Tyrogue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" alt="Tyrogue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Tyrogue
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Hitmonlee
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Hitmonchan
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="Hitmontop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="View Hitmontop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" alt="Hitmontop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Hitmontop
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pancham/" title="Pancham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/674.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pancham/" title="View Pancham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/674.png" alt="Pancham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Pancham
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pangoro/" title="Pangoro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/675.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pangoro/" title="View Pangoro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/675.png" alt="Pangoro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Pangoro
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="Klink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="View Klink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" alt="Klink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Klink
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="Klang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="View Klang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" alt="Klang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Klang
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="Klinklang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="View Klinklang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" alt="Klinklang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Klinklang
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="Combee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="View Combee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" alt="Combee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Combee
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="Vespiquen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="View Vespiquen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" alt="Vespiquen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Vespiquen
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="Bronzor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="View Bronzor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" alt="Bronzor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Bronzor
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="Bronzong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="View Bronzong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" alt="Bronzong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Bronzong
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="Ralts">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="View Ralts on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" alt="Ralts" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Ralts
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="Kirlia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="View Kirlia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" alt="Kirlia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Kirlia
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="Gardevoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="View Gardevoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" alt="Gardevoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Gardevoir
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="Gallade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="View Gallade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" alt="Gallade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Gallade
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="Drifloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="View Drifloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" alt="Drifloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Drifloon
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="Drifblim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="View Drifblim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" alt="Drifblim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Drifblim
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gossifleur/" title="Gossifleur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/829.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gossifleur/" title="View Gossifleur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/829.png" alt="Gossifleur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Gossifleur
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eldegoss/" title="Eldegoss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/830.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eldegoss/" title="View Eldegoss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/830.png" alt="Eldegoss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Eldegoss
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="Cherubi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="View Cherubi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" alt="Cherubi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Cherubi
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="Cherrim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="View Cherrim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" alt="Cherrim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Cherrim
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="Stunky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="View Stunky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" alt="Stunky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Stunky
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="Skuntank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="View Skuntank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" alt="Skuntank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Skuntank
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="Tympole">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="View Tympole on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" alt="Tympole" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Tympole
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="Palpitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="View Palpitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" alt="Palpitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Palpitoad
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="Seismitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="View Seismitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" alt="Seismitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Seismitoad
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="Duskull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="View Duskull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" alt="Duskull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Duskull
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="Dusclops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="View Dusclops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" alt="Dusclops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Dusclops
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="Dusknoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="View Dusknoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" alt="Dusknoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Dusknoir
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Machop
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Machoke
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Machamp
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Gastly
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Haunter
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Gengar
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Magikarp
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Gyarados
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Goldeen
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Seaking
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Remoraid
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Octillery
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Shellder
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Cloyster
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="Feebas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="View Feebas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" alt="Feebas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Feebas
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="Milotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="View Milotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" alt="Milotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Milotic
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="Basculin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="View Basculin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" alt="Basculin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Basculin
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wishiwashi/" title="Wishiwashi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/746.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wishiwashi/" title="View Wishiwashi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/746.png" alt="Wishiwashi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Wishiwashi
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pyukumuku/" title="Pyukumuku">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/771.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pyukumuku/" title="View Pyukumuku on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/771.png" alt="Pyukumuku" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Pyukumuku
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="Trubbish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="View Trubbish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" alt="Trubbish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Trubbish
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="Garbodor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="View Garbodor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" alt="Garbodor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Garbodor
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sizzlipede/" title="Sizzlipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/850.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sizzlipede/" title="View Sizzlipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/850.png" alt="Sizzlipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Sizzlipede
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/centiskorch/" title="Centiskorch">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/851.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/centiskorch/" title="View Centiskorch on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/851.png" alt="Centiskorch" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Centiskorch
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rolycoly/" title="Rolycoly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/837.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rolycoly/" title="View Rolycoly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/837.png" alt="Rolycoly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Rolycoly
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carkol/" title="Carkol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/838.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carkol/" title="View Carkol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/838.png" alt="Carkol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Carkol
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/coalossal/" title="Coalossal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/839.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/coalossal/" title="View Coalossal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/839.png" alt="Coalossal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Coalossal
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Diglett
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Dugtrio
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="Drilbur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="View Drilbur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" alt="Drilbur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Drilbur
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="Excadrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="View Excadrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" alt="Excadrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Excadrill
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="Roggenrola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="View Roggenrola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" alt="Roggenrola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Roggenrola
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="Boldore">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="View Boldore on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" alt="Boldore" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Boldore
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="Gigalith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="View Gigalith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" alt="Gigalith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Gigalith
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="Timburr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="View Timburr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" alt="Timburr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Timburr
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="Gurdurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="View Gurdurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" alt="Gurdurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Gurdurr
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="Conkeldurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="View Conkeldurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" alt="Conkeldurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Conkeldurr
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="Woobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="View Woobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" alt="Woobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Woobat
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="Swoobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="View Swoobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" alt="Swoobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Swoobat
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noibat/" title="Noibat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/714.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noibat/" title="View Noibat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/714.png" alt="Noibat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Noibat
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noivern/" title="Noivern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/715.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noivern/" title="View Noivern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/715.png" alt="Noivern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Noivern
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Onix
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="Steelix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="View Steelix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" alt="Steelix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Steelix
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arrokuda/" title="Arrokuda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/846.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arrokuda/" title="View Arrokuda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/846.png" alt="Arrokuda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Arrokuda
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barraskewda/" title="Barraskewda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/847.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barraskewda/" title="View Barraskewda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/847.png" alt="Barraskewda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Barraskewda
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Meowth
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/perrserker/" title="Perrserker">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/863.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/perrserker/" title="View Perrserker on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/863.png" alt="Perrserker" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Perrserker
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Persian
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/milcery/" title="Milcery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/868.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/milcery/" title="View Milcery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/868.png" alt="Milcery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Milcery
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alcremie/" title="Alcremie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/869.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alcremie/" title="View Alcremie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/869.png" alt="Alcremie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Alcremie
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cutiefly/" title="Cutiefly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/742.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cutiefly/" title="View Cutiefly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/742.png" alt="Cutiefly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Cutiefly
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ribombee/" title="Ribombee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/743.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ribombee/" title="View Ribombee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/743.png" alt="Ribombee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Ribombee
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="Ferroseed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="View Ferroseed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" alt="Ferroseed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Ferroseed
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="Ferrothorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="View Ferrothorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" alt="Ferrothorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Ferrothorn
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pumpkaboo/" title="Pumpkaboo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/710.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pumpkaboo/" title="View Pumpkaboo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/710.png" alt="Pumpkaboo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Pumpkaboo
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gourgeist/" title="Gourgeist">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/711.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gourgeist/" title="View Gourgeist on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/711.png" alt="Gourgeist" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Gourgeist
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Pichu
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Pikachu
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Raichu
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Eevee
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Vaporeon
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Jolteon
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Flareon
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="Espeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="View Espeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" alt="Espeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Espeon
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="Umbreon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="View Umbreon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" alt="Umbreon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Umbreon
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="Leafeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="View Leafeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" alt="Leafeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Leafeon
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="Glaceon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="View Glaceon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" alt="Glaceon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Glaceon
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sylveon/" title="Sylveon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/700.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sylveon/" title="View Sylveon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/700.png" alt="Sylveon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Sylveon
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/applin/" title="Applin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/840.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/applin/" title="View Applin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/840.png" alt="Applin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Applin
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flapple/" title="Flapple">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/841.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flapple/" title="View Flapple on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/841.png" alt="Flapple" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Flapple
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/appletun/" title="Appletun">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/842.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/appletun/" title="View Appletun on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/842.png" alt="Appletun" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Appletun
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espurr/" title="Espurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/677.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espurr/" title="View Espurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/677.png" alt="Espurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Espurr
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowstic/" title="Meowstic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/678.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowstic/" title="View Meowstic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/678.png" alt="Meowstic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Meowstic
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swirlix/" title="Swirlix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/684.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swirlix/" title="View Swirlix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/684.png" alt="Swirlix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Swirlix
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slurpuff/" title="Slurpuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/685.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slurpuff/" title="View Slurpuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/685.png" alt="Slurpuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Slurpuff
@@ -2184,8 +2184,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spritzee/" title="Spritzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/682.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spritzee/" title="View Spritzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/682.png" alt="Spritzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">212</span>
                             Spritzee
@@ -2194,8 +2194,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aromatisse/" title="Aromatisse">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/683.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aromatisse/" title="View Aromatisse on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/683.png" alt="Aromatisse" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">213</span>
                             Aromatisse
@@ -2204,8 +2204,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewpider/" title="Dewpider">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/751.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewpider/" title="View Dewpider on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/751.png" alt="Dewpider" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">214</span>
                             Dewpider
@@ -2214,8 +2214,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/araquanid/" title="Araquanid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/752.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/araquanid/" title="View Araquanid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/752.png" alt="Araquanid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">215</span>
                             Araquanid
@@ -2224,8 +2224,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="Wynaut">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="View Wynaut on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" alt="Wynaut" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">216</span>
                             Wynaut
@@ -2234,8 +2234,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="Wobbuffet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="View Wobbuffet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" alt="Wobbuffet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">217</span>
                             Wobbuffet
@@ -2244,8 +2244,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetch%27d/" title="Farfetch&#39;d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetch%27d/" title="View Farfetch&#39;d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch&#39;d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">218</span>
                             Farfetch&#39;d
@@ -2254,8 +2254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sirfetch%27d/" title="Sirfetch&#39;d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/865.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sirfetch%27d/" title="View Sirfetch&#39;d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/865.png" alt="Sirfetch&#39;d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">219</span>
                             Sirfetch&#39;d
@@ -2264,8 +2264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">220</span>
                             Chinchou
@@ -2274,8 +2274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">221</span>
                             Lanturn
@@ -2284,8 +2284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="Croagunk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="View Croagunk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" alt="Croagunk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">222</span>
                             Croagunk
@@ -2294,8 +2294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="Toxicroak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="View Toxicroak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" alt="Toxicroak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">223</span>
                             Toxicroak
@@ -2304,8 +2304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="Scraggy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="View Scraggy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" alt="Scraggy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">224</span>
                             Scraggy
@@ -2314,8 +2314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="Scrafty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="View Scrafty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" alt="Scrafty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">225</span>
                             Scrafty
@@ -2324,8 +2324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="Stunfisk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="View Stunfisk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" alt="Stunfisk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">226</span>
                             Stunfisk
@@ -2334,8 +2334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="Shuckle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="View Shuckle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" alt="Shuckle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">227</span>
                             Shuckle
@@ -2344,8 +2344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="Barboach">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="View Barboach on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" alt="Barboach" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">228</span>
                             Barboach
@@ -2354,8 +2354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="Whiscash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="View Whiscash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" alt="Whiscash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">229</span>
                             Whiscash
@@ -2364,8 +2364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="Shellos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="View Shellos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" alt="Shellos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">230</span>
                             Shellos
@@ -2374,8 +2374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="Gastrodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="View Gastrodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" alt="Gastrodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">231</span>
                             Gastrodon
@@ -2384,8 +2384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wimpod/" title="Wimpod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/767.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wimpod/" title="View Wimpod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/767.png" alt="Wimpod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">232</span>
                             Wimpod
@@ -2394,8 +2394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golisopod/" title="Golisopod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/768.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golisopod/" title="View Golisopod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/768.png" alt="Golisopod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">233</span>
                             Golisopod
@@ -2404,8 +2404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/binacle/" title="Binacle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/688.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/binacle/" title="View Binacle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/688.png" alt="Binacle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">234</span>
                             Binacle
@@ -2414,8 +2414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barbaracle/" title="Barbaracle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/689.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barbaracle/" title="View Barbaracle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/689.png" alt="Barbaracle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">235</span>
                             Barbaracle
@@ -2424,8 +2424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="Corsola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="View Corsola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" alt="Corsola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">236</span>
                             Corsola
@@ -2434,8 +2434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cursola/" title="Cursola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/864.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cursola/" title="View Cursola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/864.png" alt="Cursola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">237</span>
                             Cursola
@@ -2444,8 +2444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/impidimp/" title="Impidimp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/859.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/impidimp/" title="View Impidimp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/859.png" alt="Impidimp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">238</span>
                             Impidimp
@@ -2454,8 +2454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/morgrem/" title="Morgrem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/860.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/morgrem/" title="View Morgrem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/860.png" alt="Morgrem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">239</span>
                             Morgrem
@@ -2464,8 +2464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimmsnarl/" title="Grimmsnarl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/861.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimmsnarl/" title="View Grimmsnarl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/861.png" alt="Grimmsnarl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">240</span>
                             Grimmsnarl
@@ -2481,8 +2481,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hatenna/" title="Hatenna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/856.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hatenna/" title="View Hatenna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/856.png" alt="Hatenna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">241</span>
                             Hatenna
@@ -2491,8 +2491,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hattrem/" title="Hattrem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/857.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hattrem/" title="View Hattrem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/857.png" alt="Hattrem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">242</span>
                             Hattrem
@@ -2501,8 +2501,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hatterene/" title="Hatterene">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/858.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hatterene/" title="View Hatterene on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/858.png" alt="Hatterene" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">243</span>
                             Hatterene
@@ -2511,8 +2511,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salandit/" title="Salandit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/757.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salandit/" title="View Salandit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/757.png" alt="Salandit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">244</span>
                             Salandit
@@ -2521,8 +2521,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salazzle/" title="Salazzle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/758.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salazzle/" title="View Salazzle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/758.png" alt="Salazzle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">245</span>
                             Salazzle
@@ -2531,8 +2531,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="Pawniard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="View Pawniard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" alt="Pawniard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">246</span>
                             Pawniard
@@ -2541,8 +2541,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="Bisharp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="View Bisharp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" alt="Bisharp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">247</span>
                             Bisharp
@@ -2551,8 +2551,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="Throh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="View Throh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" alt="Throh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">248</span>
                             Throh
@@ -2561,8 +2561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="Sawk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="View Sawk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" alt="Sawk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">249</span>
                             Sawk
@@ -2571,8 +2571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">250</span>
                             Koffing
@@ -2581,8 +2581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">251</span>
                             Weezing
@@ -2591,8 +2591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="Bonsly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="View Bonsly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" alt="Bonsly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">252</span>
                             Bonsly
@@ -2601,8 +2601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="Sudowoodo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="View Sudowoodo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" alt="Sudowoodo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">253</span>
                             Sudowoodo
@@ -2611,8 +2611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="Cleffa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="View Cleffa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" alt="Cleffa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">254</span>
                             Cleffa
@@ -2621,8 +2621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">255</span>
                             Clefairy
@@ -2631,8 +2631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">256</span>
                             Clefable
@@ -2641,8 +2641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="Togepi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="View Togepi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" alt="Togepi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">257</span>
                             Togepi
@@ -2651,8 +2651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="Togetic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="View Togetic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" alt="Togetic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">258</span>
                             Togetic
@@ -2661,8 +2661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="Togekiss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="View Togekiss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" alt="Togekiss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">259</span>
                             Togekiss
@@ -2671,8 +2671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="Munchlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="View Munchlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" alt="Munchlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">260</span>
                             Munchlax
@@ -2681,8 +2681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">261</span>
                             Snorlax
@@ -2691,8 +2691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="Cottonee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="View Cottonee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" alt="Cottonee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">262</span>
                             Cottonee
@@ -2701,8 +2701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="Whimsicott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="View Whimsicott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" alt="Whimsicott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">263</span>
                             Whimsicott
@@ -2711,8 +2711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">264</span>
                             Rhyhorn
@@ -2721,8 +2721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">265</span>
                             Rhydon
@@ -2731,8 +2731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="Rhyperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="View Rhyperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" alt="Rhyperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">266</span>
                             Rhyperior
@@ -2741,8 +2741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="Gothita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="View Gothita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" alt="Gothita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">267</span>
                             Gothita
@@ -2751,8 +2751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="Gothorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="View Gothorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" alt="Gothorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">268</span>
                             Gothorita
@@ -2761,8 +2761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="Gothitelle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="View Gothitelle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" alt="Gothitelle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">269</span>
                             Gothitelle
@@ -2771,8 +2771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="Solosis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="View Solosis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" alt="Solosis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">270</span>
                             Solosis
@@ -2788,8 +2788,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="Duosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="View Duosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" alt="Duosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">271</span>
                             Duosion
@@ -2798,8 +2798,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="Reuniclus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="View Reuniclus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" alt="Reuniclus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">272</span>
                             Reuniclus
@@ -2808,8 +2808,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="Karrablast">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="View Karrablast on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" alt="Karrablast" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">273</span>
                             Karrablast
@@ -2818,8 +2818,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="Escavalier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="View Escavalier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" alt="Escavalier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">274</span>
                             Escavalier
@@ -2828,8 +2828,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="Shelmet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="View Shelmet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" alt="Shelmet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">275</span>
                             Shelmet
@@ -2838,8 +2838,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="Accelgor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="View Accelgor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" alt="Accelgor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">276</span>
                             Accelgor
@@ -2848,8 +2848,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="Elgyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="View Elgyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" alt="Elgyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">277</span>
                             Elgyem
@@ -2858,8 +2858,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="Beheeyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="View Beheeyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" alt="Beheeyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">278</span>
                             Beheeyem
@@ -2868,8 +2868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="Cubchoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="View Cubchoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" alt="Cubchoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">279</span>
                             Cubchoo
@@ -2878,8 +2878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="Beartic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="View Beartic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" alt="Beartic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">280</span>
                             Beartic
@@ -2888,8 +2888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="Rufflet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="View Rufflet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" alt="Rufflet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">281</span>
                             Rufflet
@@ -2898,8 +2898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="Braviary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="View Braviary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" alt="Braviary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">282</span>
                             Braviary
@@ -2908,8 +2908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="Vullaby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="View Vullaby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" alt="Vullaby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">283</span>
                             Vullaby
@@ -2918,8 +2918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="Mandibuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="View Mandibuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" alt="Mandibuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">284</span>
                             Mandibuzz
@@ -2928,8 +2928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="Skorupi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="View Skorupi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" alt="Skorupi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">285</span>
                             Skorupi
@@ -2938,8 +2938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="Drapion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="View Drapion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" alt="Drapion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">286</span>
                             Drapion
@@ -2948,8 +2948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="Litwick">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="View Litwick on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" alt="Litwick" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">287</span>
                             Litwick
@@ -2958,8 +2958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="Lampent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="View Lampent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" alt="Lampent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">288</span>
                             Lampent
@@ -2968,8 +2968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="Chandelure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="View Chandelure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" alt="Chandelure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">289</span>
                             Chandelure
@@ -2978,8 +2978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="Inkay">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="View Inkay on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" alt="Inkay" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">290</span>
                             Inkay
@@ -2988,8 +2988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="Malamar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="View Malamar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" alt="Malamar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">291</span>
                             Malamar
@@ -2998,8 +2998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="Sneasel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="View Sneasel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" alt="Sneasel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">292</span>
                             Sneasel
@@ -3008,8 +3008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="Weavile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="View Weavile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" alt="Weavile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">293</span>
                             Weavile
@@ -3018,8 +3018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="Sableye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="View Sableye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" alt="Sableye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">294</span>
                             Sableye
@@ -3028,8 +3028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="Mawile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="View Mawile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" alt="Mawile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">295</span>
                             Mawile
@@ -3038,8 +3038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="Maractus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="View Maractus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" alt="Maractus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">296</span>
                             Maractus
@@ -3048,8 +3048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="Sigilyph">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="View Sigilyph on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" alt="Sigilyph" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">297</span>
                             Sigilyph
@@ -3058,8 +3058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="Riolu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="View Riolu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" alt="Riolu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">298</span>
                             Riolu
@@ -3068,8 +3068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="Lucario">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="View Lucario on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" alt="Lucario" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">299</span>
                             Lucario
@@ -3078,8 +3078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="Torkoal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="View Torkoal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" alt="Torkoal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">300</span>
                             Torkoal
@@ -3095,8 +3095,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mimikyu/" title="Mimikyu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/778.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mimikyu/" title="View Mimikyu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/778.png" alt="Mimikyu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">301</span>
                             Mimikyu
@@ -3105,8 +3105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cufant/" title="Cufant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/878.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cufant/" title="View Cufant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/878.png" alt="Cufant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">302</span>
                             Cufant
@@ -3115,8 +3115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/copperajah/" title="Copperajah">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/879.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/copperajah/" title="View Copperajah on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/879.png" alt="Copperajah" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">303</span>
                             Copperajah
@@ -3125,8 +3125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="Qwilfish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="View Qwilfish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" alt="Qwilfish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">304</span>
                             Qwilfish
@@ -3135,8 +3135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="Frillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="View Frillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" alt="Frillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">305</span>
                             Frillish
@@ -3145,8 +3145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="Jellicent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="View Jellicent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" alt="Jellicent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">306</span>
                             Jellicent
@@ -3155,8 +3155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareanie/" title="Mareanie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/747.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareanie/" title="View Mareanie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/747.png" alt="Mareanie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">307</span>
                             Mareanie
@@ -3165,8 +3165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxapex/" title="Toxapex">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/748.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxapex/" title="View Toxapex on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/748.png" alt="Toxapex" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">308</span>
                             Toxapex
@@ -3175,8 +3175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cramorant/" title="Cramorant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/845.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cramorant/" title="View Cramorant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/845.png" alt="Cramorant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">309</span>
                             Cramorant
@@ -3185,8 +3185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxel/" title="Toxel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/848.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxel/" title="View Toxel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/848.png" alt="Toxel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">310</span>
                             Toxel
@@ -3195,8 +3195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxtricity/" title="Toxtricity">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/849.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxtricity/" title="View Toxtricity on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/849.png" alt="Toxtricity" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">311</span>
                             Toxtricity
@@ -3205,8 +3205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silicobra/" title="Silicobra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/843.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silicobra/" title="View Silicobra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/843.png" alt="Silicobra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">312</span>
                             Silicobra
@@ -3215,8 +3215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandaconda/" title="Sandaconda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/844.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandaconda/" title="View Sandaconda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/844.png" alt="Sandaconda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">313</span>
                             Sandaconda
@@ -3225,8 +3225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="Hippopotas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="View Hippopotas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" alt="Hippopotas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">314</span>
                             Hippopotas
@@ -3235,8 +3235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="Hippowdon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="View Hippowdon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" alt="Hippowdon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">315</span>
                             Hippowdon
@@ -3245,8 +3245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="Durant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="View Durant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" alt="Durant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">316</span>
                             Durant
@@ -3255,8 +3255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="Heatmor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="View Heatmor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" alt="Heatmor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">317</span>
                             Heatmor
@@ -3265,8 +3265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/helioptile/" title="Helioptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/694.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/helioptile/" title="View Helioptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/694.png" alt="Helioptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">318</span>
                             Helioptile
@@ -3275,8 +3275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heliolisk/" title="Heliolisk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/695.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heliolisk/" title="View Heliolisk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/695.png" alt="Heliolisk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">319</span>
                             Heliolisk
@@ -3285,8 +3285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hawlucha/" title="Hawlucha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/701.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hawlucha/" title="View Hawlucha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/701.png" alt="Hawlucha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">320</span>
                             Hawlucha
@@ -3295,8 +3295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="Trapinch">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="View Trapinch on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" alt="Trapinch" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">321</span>
                             Trapinch
@@ -3305,8 +3305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="Vibrava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="View Vibrava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" alt="Vibrava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">322</span>
                             Vibrava
@@ -3315,8 +3315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="Flygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="View Flygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" alt="Flygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">323</span>
                             Flygon
@@ -3325,8 +3325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="Axew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="View Axew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" alt="Axew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">324</span>
                             Axew
@@ -3335,8 +3335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="Fraxure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="View Fraxure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" alt="Fraxure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">325</span>
                             Fraxure
@@ -3345,8 +3345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="Haxorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="View Haxorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" alt="Haxorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">326</span>
                             Haxorus
@@ -3355,8 +3355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="Yamask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="View Yamask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" alt="Yamask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">327</span>
                             Yamask
@@ -3365,8 +3365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/runerigus/" title="Runerigus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/867.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/runerigus/" title="View Runerigus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/867.png" alt="Runerigus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">328</span>
                             Runerigus
@@ -3375,8 +3375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="Cofagrigus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="View Cofagrigus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" alt="Cofagrigus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">329</span>
                             Cofagrigus
@@ -3385,8 +3385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honedge/" title="Honedge">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/679.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honedge/" title="View Honedge on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/679.png" alt="Honedge" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">330</span>
                             Honedge
@@ -3402,8 +3402,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doublade/" title="Doublade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/680.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doublade/" title="View Doublade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/680.png" alt="Doublade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">331</span>
                             Doublade
@@ -3412,8 +3412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aegislash/" title="Aegislash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/681.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aegislash/" title="View Aegislash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/681.png" alt="Aegislash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">332</span>
                             Aegislash
@@ -3422,8 +3422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">333</span>
                             Ponyta
@@ -3432,8 +3432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">334</span>
                             Rapidash
@@ -3442,8 +3442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sinistea/" title="Sinistea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/854.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sinistea/" title="View Sinistea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/854.png" alt="Sinistea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">335</span>
                             Sinistea
@@ -3452,8 +3452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/polteageist/" title="Polteageist">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/855.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/polteageist/" title="View Polteageist on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/855.png" alt="Polteageist" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">336</span>
                             Polteageist
@@ -3462,8 +3462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/indeedee/" title="Indeedee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/876.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/indeedee/" title="View Indeedee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/876.png" alt="Indeedee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">337</span>
                             Indeedee
@@ -3472,8 +3472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phantump/" title="Phantump">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/708.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phantump/" title="View Phantump on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/708.png" alt="Phantump" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">338</span>
                             Phantump
@@ -3482,8 +3482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trevenant/" title="Trevenant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/709.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trevenant/" title="View Trevenant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/709.png" alt="Trevenant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">339</span>
                             Trevenant
@@ -3492,8 +3492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/morelull/" title="Morelull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/755.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/morelull/" title="View Morelull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/755.png" alt="Morelull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">340</span>
                             Morelull
@@ -3502,8 +3502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiinotic/" title="Shiinotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/756.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiinotic/" title="View Shiinotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/756.png" alt="Shiinotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">341</span>
                             Shiinotic
@@ -3512,8 +3512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oranguru/" title="Oranguru">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/765.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oranguru/" title="View Oranguru on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/765.png" alt="Oranguru" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">342</span>
                             Oranguru
@@ -3522,8 +3522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/passimian/" title="Passimian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/766.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/passimian/" title="View Passimian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/766.png" alt="Passimian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">343</span>
                             Passimian
@@ -3532,8 +3532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/morpeko/" title="Morpeko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/877.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/morpeko/" title="View Morpeko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/877.png" alt="Morpeko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">344</span>
                             Morpeko
@@ -3542,8 +3542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/falinks/" title="Falinks">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/870.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/falinks/" title="View Falinks on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/870.png" alt="Falinks" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">345</span>
                             Falinks
@@ -3552,8 +3552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drampa/" title="Drampa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/780.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drampa/" title="View Drampa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/780.png" alt="Drampa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">346</span>
                             Drampa
@@ -3562,8 +3562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/turtonator/" title="Turtonator">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/776.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/turtonator/" title="View Turtonator on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/776.png" alt="Turtonator" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">347</span>
                             Turtonator
@@ -3572,8 +3572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togedemaru/" title="Togedemaru">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/777.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togedemaru/" title="View Togedemaru on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/777.png" alt="Togedemaru" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">348</span>
                             Togedemaru
@@ -3582,8 +3582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snom/" title="Snom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/872.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snom/" title="View Snom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/872.png" alt="Snom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">349</span>
                             Snom
@@ -3592,8 +3592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frosmoth/" title="Frosmoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/873.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frosmoth/" title="View Frosmoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/873.png" alt="Frosmoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">350</span>
                             Frosmoth
@@ -3602,8 +3602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clobbopus/" title="Clobbopus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/852.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clobbopus/" title="View Clobbopus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/852.png" alt="Clobbopus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">351</span>
                             Clobbopus
@@ -3612,8 +3612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grapploct/" title="Grapploct">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/853.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grapploct/" title="View Grapploct on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/853.png" alt="Grapploct" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">352</span>
                             Grapploct
@@ -3622,8 +3622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pincurchin/" title="Pincurchin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/871.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pincurchin/" title="View Pincurchin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/871.png" alt="Pincurchin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">353</span>
                             Pincurchin
@@ -3632,8 +3632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="Mantyke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="View Mantyke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" alt="Mantyke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">354</span>
                             Mantyke
@@ -3642,8 +3642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">355</span>
                             Mantine
@@ -3652,8 +3652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="Wailmer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="View Wailmer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" alt="Wailmer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">356</span>
                             Wailmer
@@ -3662,8 +3662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="Wailord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="View Wailord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" alt="Wailord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">357</span>
                             Wailord
@@ -3672,8 +3672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bergmite/" title="Bergmite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/712.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bergmite/" title="View Bergmite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/712.png" alt="Bergmite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">358</span>
                             Bergmite
@@ -3682,8 +3682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/avalugg/" title="Avalugg">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/713.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/avalugg/" title="View Avalugg on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/713.png" alt="Avalugg" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">359</span>
                             Avalugg
@@ -3692,8 +3692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dhelmise/" title="Dhelmise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/781.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dhelmise/" title="View Dhelmise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/781.png" alt="Dhelmise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">360</span>
                             Dhelmise
@@ -3709,8 +3709,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">361</span>
                             Lapras
@@ -3719,8 +3719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="Lunatone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="View Lunatone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" alt="Lunatone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">362</span>
                             Lunatone
@@ -3729,8 +3729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="Solrock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="View Solrock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" alt="Solrock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">363</span>
                             Solrock
@@ -3739,8 +3739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mimejr./" title="Mime Jr.">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mimejr./" title="View Mime Jr. on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" alt="Mime Jr." loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">364</span>
                             Mime Jr.
@@ -3749,8 +3749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr.mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr.mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">365</span>
                             Mr. Mime
@@ -3759,8 +3759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr.rime/" title="Mr. Rime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/866.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr.rime/" title="View Mr. Rime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/866.png" alt="Mr. Rime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">366</span>
                             Mr. Rime
@@ -3769,8 +3769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="Darumaka">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="View Darumaka on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" alt="Darumaka" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">367</span>
                             Darumaka
@@ -3779,8 +3779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="Darmanitan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="View Darmanitan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" alt="Darmanitan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">368</span>
                             Darmanitan
@@ -3789,8 +3789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stonjourner/" title="Stonjourner">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/874.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stonjourner/" title="View Stonjourner on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/874.png" alt="Stonjourner" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">369</span>
                             Stonjourner
@@ -3799,8 +3799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eiscue/" title="Eiscue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/875.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eiscue/" title="View Eiscue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/875.png" alt="Eiscue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">370</span>
                             Eiscue
@@ -3809,8 +3809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duraludon/" title="Duraludon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/884.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duraludon/" title="View Duraludon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/884.png" alt="Duraludon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">371</span>
                             Duraludon
@@ -3819,8 +3819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="Rotom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="View Rotom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" alt="Rotom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">372</span>
                             Rotom
@@ -3829,8 +3829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">373</span>
                             Ditto
@@ -3839,8 +3839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dracozolt/" title="Dracozolt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/880.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dracozolt/" title="View Dracozolt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/880.png" alt="Dracozolt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">374</span>
                             Dracozolt
@@ -3849,8 +3849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arctozolt/" title="Arctozolt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/881.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arctozolt/" title="View Arctozolt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/881.png" alt="Arctozolt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">375</span>
                             Arctozolt
@@ -3859,8 +3859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dracovish/" title="Dracovish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/882.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dracovish/" title="View Dracovish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/882.png" alt="Dracovish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">376</span>
                             Dracovish
@@ -3869,8 +3869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arctovish/" title="Arctovish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/883.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arctovish/" title="View Arctovish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/883.png" alt="Arctovish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">377</span>
                             Arctovish
@@ -3879,8 +3879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">378</span>
                             Charmander
@@ -3889,8 +3889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">379</span>
                             Charmeleon
@@ -3899,8 +3899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">380</span>
                             Charizard
@@ -3909,8 +3909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/type:null/" title="Type: Null">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/772.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/type:null/" title="View Type: Null on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/772.png" alt="Type: Null" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">381</span>
                             Type: Null
@@ -3919,8 +3919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silvally/" title="Silvally">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/773.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silvally/" title="View Silvally on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/773.png" alt="Silvally" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">382</span>
                             Silvally
@@ -3929,8 +3929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="Larvitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="View Larvitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" alt="Larvitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">383</span>
                             Larvitar
@@ -3939,8 +3939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="Pupitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="View Pupitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" alt="Pupitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">384</span>
                             Pupitar
@@ -3949,8 +3949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="Tyranitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="View Tyranitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" alt="Tyranitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">385</span>
                             Tyranitar
@@ -3959,8 +3959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="Deino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="View Deino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" alt="Deino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">386</span>
                             Deino
@@ -3969,8 +3969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="Zweilous">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="View Zweilous on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" alt="Zweilous" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">387</span>
                             Zweilous
@@ -3979,8 +3979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="Hydreigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="View Hydreigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" alt="Hydreigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">388</span>
                             Hydreigon
@@ -3989,8 +3989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="Goomy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="View Goomy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" alt="Goomy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">389</span>
                             Goomy
@@ -3999,8 +3999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="Sliggoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="View Sliggoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" alt="Sliggoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">390</span>
                             Sliggoo
@@ -4016,8 +4016,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="Goodra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="View Goodra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" alt="Goodra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">391</span>
                             Goodra
@@ -4026,8 +4026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jangmo-o/" title="Jangmo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/782.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jangmo-o/" title="View Jangmo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/782.png" alt="Jangmo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">392</span>
                             Jangmo-o
@@ -4036,8 +4036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hakamo-o/" title="Hakamo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/783.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hakamo-o/" title="View Hakamo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/783.png" alt="Hakamo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">393</span>
                             Hakamo-o
@@ -4046,8 +4046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kommo-o/" title="Kommo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/784.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kommo-o/" title="View Kommo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/784.png" alt="Kommo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">394</span>
                             Kommo-o
@@ -4056,8 +4056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dreepy/" title="Dreepy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/885.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dreepy/" title="View Dreepy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/885.png" alt="Dreepy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">395</span>
                             Dreepy
@@ -4066,8 +4066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drakloak/" title="Drakloak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/886.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drakloak/" title="View Drakloak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/886.png" alt="Drakloak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">396</span>
                             Drakloak
@@ -4076,8 +4076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragapult/" title="Dragapult">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/887.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragapult/" title="View Dragapult on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/887.png" alt="Dragapult" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">397</span>
                             Dragapult
@@ -4086,8 +4086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zacian/" title="Zacian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/888.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zacian/" title="View Zacian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/888.png" alt="Zacian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">398</span>
                             Zacian
@@ -4096,8 +4096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zamazenta/" title="Zamazenta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/889.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zamazenta/" title="View Zamazenta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/889.png" alt="Zamazenta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">399</span>
                             Zamazenta
@@ -4106,8 +4106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eternatus/" title="Eternatus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/890.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eternatus/" title="View Eternatus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/890.png" alt="Eternatus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">400</span>
                             Eternatus
@@ -4121,8 +4121,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/sword-shield-isle-of-armor.html
+++ b/docs/sword-shield-isle-of-armor.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Slowpoke
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Slowbro
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="Slowking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="View Slowking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" alt="Slowking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Slowking
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="Buneary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="View Buneary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" alt="Buneary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Buneary
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="Lopunny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="View Lopunny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" alt="Lopunny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Lopunny
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="Happiny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="View Happiny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" alt="Happiny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Happiny
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Chansey
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="Blissey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="View Blissey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" alt="Blissey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Blissey
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skwovet/" title="Skwovet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/819.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skwovet/" title="View Skwovet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/819.png" alt="Skwovet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Skwovet
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/greedent/" title="Greedent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/820.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/greedent/" title="View Greedent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/820.png" alt="Greedent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Greedent
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="Igglybuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="View Igglybuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" alt="Igglybuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Igglybuff
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Jigglypuff
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Wigglytuff
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blipbug/" title="Blipbug">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/824.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blipbug/" title="View Blipbug on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/824.png" alt="Blipbug" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Blipbug
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dottler/" title="Dottler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/825.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dottler/" title="View Dottler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/825.png" alt="Dottler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Dottler
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/orbeetle/" title="Orbeetle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/826.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/orbeetle/" title="View Orbeetle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/826.png" alt="Orbeetle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Orbeetle
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fomantis/" title="Fomantis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/753.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fomantis/" title="View Fomantis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/753.png" alt="Fomantis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Fomantis
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lurantis/" title="Lurantis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/754.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lurantis/" title="View Lurantis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/754.png" alt="Lurantis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Lurantis
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/applin/" title="Applin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/840.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/applin/" title="View Applin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/840.png" alt="Applin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Applin
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flapple/" title="Flapple">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/841.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flapple/" title="View Flapple on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/841.png" alt="Flapple" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Flapple
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/appletun/" title="Appletun">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/842.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/appletun/" title="View Appletun on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/842.png" alt="Appletun" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Appletun
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fletchling/" title="Fletchling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/661.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fletchling/" title="View Fletchling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/661.png" alt="Fletchling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fletchling
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fletchinder/" title="Fletchinder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/662.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fletchinder/" title="View Fletchinder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/662.png" alt="Fletchinder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Fletchinder
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/talonflame/" title="Talonflame">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/663.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/talonflame/" title="View Talonflame on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/663.png" alt="Talonflame" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Talonflame
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="Shinx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="View Shinx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" alt="Shinx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Shinx
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="Luxio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="View Luxio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" alt="Luxio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Luxio
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="Luxray">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="View Luxray on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" alt="Luxray" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Luxray
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klefki/" title="Klefki">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/707.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klefki/" title="View Klefki on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/707.png" alt="Klefki" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Klefki
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="Pawniard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="View Pawniard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" alt="Pawniard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Pawniard
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="Bisharp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="View Bisharp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" alt="Bisharp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Bisharp
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Abra
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Kadabra
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Alakazam
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="Ralts">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="View Ralts on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" alt="Ralts" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Ralts
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="Kirlia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="View Kirlia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" alt="Kirlia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Kirlia
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="Gardevoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="View Gardevoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" alt="Gardevoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Gardevoir
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="Gallade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="View Gallade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" alt="Gallade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Gallade
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Krabby
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Kingler
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Tentacool
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Tentacruel
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Magikarp
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Gyarados
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Remoraid
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Octillery
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="Mantyke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="View Mantyke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" alt="Mantyke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Mantyke
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Mantine
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="Wingull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="View Wingull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" alt="Wingull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Wingull
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="Pelipper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="View Pelipper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" alt="Pelipper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Pelipper
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="Skorupi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="View Skorupi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" alt="Skorupi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Skorupi
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="Drapion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="View Drapion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" alt="Drapion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Drapion
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="Dunsparce">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="View Dunsparce on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" alt="Dunsparce" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Dunsparce
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="Bouffalant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="View Bouffalant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" alt="Bouffalant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Bouffalant
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Lickitung
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="Lickilicky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="View Lickilicky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" alt="Lickilicky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Lickilicky
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chewtle/" title="Chewtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/833.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chewtle/" title="View Chewtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/833.png" alt="Chewtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Chewtle
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drednaw/" title="Drednaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/834.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drednaw/" title="View Drednaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/834.png" alt="Drednaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Drednaw
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Wooper
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Quagsire
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="Goomy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="View Goomy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" alt="Goomy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Goomy
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="Sliggoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="View Sliggoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" alt="Sliggoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Sliggoo
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="Goodra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="View Goodra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" alt="Goodra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Goodra
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="Druddigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="View Druddigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" alt="Druddigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Druddigon
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="Shelmet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="View Shelmet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" alt="Shelmet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Shelmet
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="Accelgor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="View Accelgor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" alt="Accelgor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Accelgor
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="Karrablast">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="View Karrablast on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" alt="Karrablast" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Karrablast
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="Escavalier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="View Escavalier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" alt="Escavalier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Escavalier
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Bulbasaur
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Ivysaur
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Venusaur
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Squirtle
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Wartortle
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Blastoise
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="Venipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="View Venipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" alt="Venipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Venipede
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="Whirlipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="View Whirlipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" alt="Whirlipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Whirlipede
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="Scolipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="View Scolipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" alt="Scolipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Scolipede
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="Foongus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="View Foongus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" alt="Foongus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Foongus
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="Amoonguss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="View Amoonguss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" alt="Amoonguss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Amoonguss
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/comfey/" title="Comfey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/764.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/comfey/" title="View Comfey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/764.png" alt="Comfey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Comfey
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Tangela
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="Tangrowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="View Tangrowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" alt="Tangrowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Tangrowth
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="Croagunk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="View Croagunk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" alt="Croagunk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Croagunk
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="Toxicroak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="View Toxicroak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" alt="Toxicroak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Toxicroak
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Pichu
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Pikachu
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Raichu
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="Zorua">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="View Zorua on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" alt="Zorua" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Zorua
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="Zoroark">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="View Zoroark on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" alt="Zoroark" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Zoroark
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oranguru/" title="Oranguru">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/765.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oranguru/" title="View Oranguru on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/765.png" alt="Oranguru" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Oranguru
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/passimian/" title="Passimian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/766.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/passimian/" title="View Passimian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/766.png" alt="Passimian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Passimian
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="Corphish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="View Corphish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" alt="Corphish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Corphish
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="Crawdaunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="View Crawdaunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" alt="Crawdaunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Crawdaunt
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cramorant/" title="Cramorant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/845.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cramorant/" title="View Cramorant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/845.png" alt="Cramorant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Cramorant
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Goldeen
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Seaking
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arrokuda/" title="Arrokuda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/846.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arrokuda/" title="View Arrokuda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/846.png" alt="Arrokuda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Arrokuda
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barraskewda/" title="Barraskewda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/847.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barraskewda/" title="View Barraskewda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/847.png" alt="Barraskewda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Barraskewda
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Staryu
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Starmie
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kubfu/" title="Kubfu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/891.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kubfu/" title="View Kubfu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/891.png" alt="Kubfu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Kubfu
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/urshifu/" title="Urshifu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/892.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/urshifu/" title="View Urshifu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/892.png" alt="Urshifu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Urshifu
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="Emolga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="View Emolga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" alt="Emolga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Emolga
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dedenne/" title="Dedenne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/702.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dedenne/" title="View Dedenne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/702.png" alt="Dedenne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Dedenne
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/morpeko/" title="Morpeko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/877.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/morpeko/" title="View Morpeko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/877.png" alt="Morpeko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Morpeko
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Magnemite
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Magneton
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="Magnezone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="View Magnezone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" alt="Magnezone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Magnezone
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="Inkay">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="View Inkay on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" alt="Inkay" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Inkay
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="Malamar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="View Malamar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" alt="Malamar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Malamar
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wishiwashi/" title="Wishiwashi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/746.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wishiwashi/" title="View Wishiwashi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/746.png" alt="Wishiwashi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Wishiwashi
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="Carvanha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="View Carvanha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" alt="Carvanha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Carvanha
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="Sharpedo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="View Sharpedo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" alt="Sharpedo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Sharpedo
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="Lillipup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="View Lillipup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" alt="Lillipup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Lillipup
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="Herdier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="View Herdier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" alt="Herdier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Herdier
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="Stoutland">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="View Stoutland on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" alt="Stoutland" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Stoutland
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Tauros
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="Miltank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="View Miltank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" alt="Miltank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Miltank
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Scyther
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="Scizor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="View Scizor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" alt="Scizor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Scizor
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Pinsir
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="Heracross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="View Heracross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" alt="Heracross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Heracross
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="Dwebble">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="View Dwebble on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" alt="Dwebble" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Dwebble
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="Crustle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="View Crustle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" alt="Crustle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Crustle
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wimpod/" title="Wimpod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/767.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wimpod/" title="View Wimpod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/767.png" alt="Wimpod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Wimpod
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golisopod/" title="Golisopod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/768.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golisopod/" title="View Golisopod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/768.png" alt="Golisopod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Golisopod
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pincurchin/" title="Pincurchin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/871.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pincurchin/" title="View Pincurchin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/871.png" alt="Pincurchin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Pincurchin
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareanie/" title="Mareanie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/747.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareanie/" title="View Mareanie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/747.png" alt="Mareanie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Mareanie
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxapex/" title="Toxapex">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/748.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxapex/" title="View Toxapex on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/748.png" alt="Toxapex" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Toxapex
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clobbopus/" title="Clobbopus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/852.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clobbopus/" title="View Clobbopus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/852.png" alt="Clobbopus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Clobbopus
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grapploct/" title="Grapploct">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/853.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grapploct/" title="View Grapploct on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/853.png" alt="Grapploct" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Grapploct
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Shellder
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Cloyster
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandygast/" title="Sandygast">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/769.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandygast/" title="View Sandygast on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/769.png" alt="Sandygast" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Sandygast
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palossand/" title="Palossand">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/770.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palossand/" title="View Palossand on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/770.png" alt="Palossand" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Palossand
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="Drifloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="View Drifloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" alt="Drifloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Drifloon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="Drifblim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="View Drifblim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" alt="Drifblim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Drifblim
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="Barboach">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="View Barboach on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" alt="Barboach" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Barboach
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="Whiscash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="View Whiscash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" alt="Whiscash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Whiscash
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="Azurill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="View Azurill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" alt="Azurill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Azurill
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="Marill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="View Marill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" alt="Marill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Marill
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="Azumarill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="View Azumarill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" alt="Azumarill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Azumarill
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Poliwag
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Poliwhirl
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Poliwrath
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="Politoed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="View Politoed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" alt="Politoed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Politoed
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Psyduck
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Golduck
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="Whismur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="View Whismur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" alt="Whismur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Whismur
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="Loudred">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="View Loudred on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" alt="Loudred" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Loudred
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="Exploud">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="View Exploud on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" alt="Exploud" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Exploud
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="Woobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="View Woobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" alt="Woobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Woobat
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="Swoobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="View Swoobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" alt="Swoobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Swoobat
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="Skarmory">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="View Skarmory on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" alt="Skarmory" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Skarmory
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="Roggenrola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="View Roggenrola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" alt="Roggenrola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Roggenrola
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="Boldore">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="View Boldore on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" alt="Boldore" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Boldore
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="Gigalith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="View Gigalith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" alt="Gigalith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Gigalith
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rockruff/" title="Rockruff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/744.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rockruff/" title="View Rockruff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/744.png" alt="Rockruff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Rockruff
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lycanroc/" title="Lycanroc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/745.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lycanroc/" title="View Lycanroc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/745.png" alt="Lycanroc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Lycanroc
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salandit/" title="Salandit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/757.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salandit/" title="View Salandit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/757.png" alt="Salandit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Salandit
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salazzle/" title="Salazzle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/758.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salazzle/" title="View Salazzle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/758.png" alt="Salazzle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Salazzle
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="Scraggy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="View Scraggy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" alt="Scraggy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Scraggy
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="Scrafty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="View Scrafty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" alt="Scrafty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Scrafty
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="Mienfoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="View Mienfoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" alt="Mienfoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Mienfoo
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="Mienshao">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="View Mienshao on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" alt="Mienshao" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Mienshao
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jangmo-o/" title="Jangmo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/782.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jangmo-o/" title="View Jangmo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/782.png" alt="Jangmo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Jangmo-o
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hakamo-o/" title="Hakamo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/783.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hakamo-o/" title="View Hakamo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/783.png" alt="Hakamo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Hakamo-o
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kommo-o/" title="Kommo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/784.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kommo-o/" title="View Kommo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/784.png" alt="Kommo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Kommo-o
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Sandshrew
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Sandslash
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Cubone
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Marowak
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Kangaskhan
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="Torkoal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="View Torkoal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" alt="Torkoal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Torkoal
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silicobra/" title="Silicobra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/843.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silicobra/" title="View Silicobra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/843.png" alt="Silicobra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Silicobra
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandaconda/" title="Sandaconda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/844.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandaconda/" title="View Sandaconda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/844.png" alt="Sandaconda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Sandaconda
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="Sandile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="View Sandile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" alt="Sandile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Sandile
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="Krokorok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="View Krokorok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" alt="Krokorok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Krokorok
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="Krookodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="View Krookodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" alt="Krookodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Krookodile
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="Rufflet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="View Rufflet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" alt="Rufflet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Rufflet
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="Braviary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="View Braviary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" alt="Braviary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Braviary
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="Vullaby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="View Vullaby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" alt="Vullaby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Vullaby
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="Mandibuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="View Mandibuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" alt="Mandibuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Mandibuzz
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Rhyhorn
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Rhydon
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="Rhyperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="View Rhyperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" alt="Rhyperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Rhyperior
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="Larvesta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="View Larvesta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" alt="Larvesta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Larvesta
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="Volcarona">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="View Volcarona on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" alt="Volcarona" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Volcarona
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Chinchou
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Lanturn
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="Wailmer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="View Wailmer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" alt="Wailmer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Wailmer
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="Wailord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="View Wailord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" alt="Wailord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Wailord
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="Frillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="View Frillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" alt="Frillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Frillish
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="Jellicent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="View Jellicent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" alt="Jellicent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Jellicent
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skrelp/" title="Skrelp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/690.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skrelp/" title="View Skrelp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/690.png" alt="Skrelp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Skrelp
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragalge/" title="Dragalge">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/691.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragalge/" title="View Dragalge on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/691.png" alt="Dragalge" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Dragalge
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clauncher/" title="Clauncher">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/692.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clauncher/" title="View Clauncher on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/692.png" alt="Clauncher" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Clauncher
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clawitzer/" title="Clawitzer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/693.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clawitzer/" title="View Clawitzer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/693.png" alt="Clawitzer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Clawitzer
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Horsea
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Seadra
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="Kingdra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="View Kingdra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" alt="Kingdra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Kingdra
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="Petilil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="View Petilil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" alt="Petilil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Petilil
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="Lilligant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="View Lilligant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" alt="Lilligant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Lilligant
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="Combee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="View Combee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" alt="Combee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Combee
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="Vespiquen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="View Vespiquen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" alt="Vespiquen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Vespiquen
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Exeggcute
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Exeggutor
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Ditto
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Porygon
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="Porygon2">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="View Porygon2 on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" alt="Porygon2" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Porygon2
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="Porygon-Z">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="View Porygon-Z on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" alt="Porygon-Z" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Porygon-Z
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zarude/" title="Zarude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/893.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zarude/" title="View Zarude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/893.png" alt="Zarude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Zarude
@@ -2189,8 +2189,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/ultra-sun-ultra-moon.html
+++ b/docs/ultra-sun-ultra-moon.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Bulbasaur
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Ivysaur
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Venusaur
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Charmander
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Charmeleon
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Charizard
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Squirtle
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Wartortle
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Blastoise
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Caterpie
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Metapod
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Butterfree
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="Weedle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="View Weedle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" alt="Weedle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Weedle
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="Kakuna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="View Kakuna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" alt="Kakuna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Kakuna
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="Beedrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="View Beedrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" alt="Beedrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Beedrill
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="Pidgey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="View Pidgey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" alt="Pidgey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Pidgey
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="Pidgeotto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="View Pidgeotto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" alt="Pidgeotto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Pidgeotto
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="Pidgeot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="View Pidgeot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" alt="Pidgeot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Pidgeot
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="Rattata">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="View Rattata on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" alt="Rattata" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Rattata
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="Raticate">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="View Raticate on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" alt="Raticate" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Raticate
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="Spearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="View Spearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" alt="Spearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Spearow
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="Fearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="View Fearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" alt="Fearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fearow
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="Ekans">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="View Ekans on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" alt="Ekans" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Ekans
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="Arbok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="View Arbok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" alt="Arbok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Arbok
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Pikachu
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Raichu
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Sandshrew
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Sandslash
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="Nidoran♀">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="View Nidoran♀ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" alt="Nidoran♀" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nidoran♀
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="Nidorina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="View Nidorina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" alt="Nidorina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Nidorina
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="Nidoqueen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="View Nidoqueen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" alt="Nidoqueen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Nidoqueen
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="Nidoran♂">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="View Nidoran♂ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" alt="Nidoran♂" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Nidoran♂
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="Nidorino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="View Nidorino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" alt="Nidorino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Nidorino
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="Nidoking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="View Nidoking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" alt="Nidoking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Nidoking
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Clefairy
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Clefable
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Vulpix
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ninetales
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Jigglypuff
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Wigglytuff
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="Zubat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="View Zubat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" alt="Zubat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Zubat
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="Golbat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="View Golbat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" alt="Golbat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Golbat
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Oddish
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Gloom
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Vileplume
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="Paras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="View Paras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" alt="Paras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Paras
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="Parasect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="View Parasect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" alt="Parasect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Parasect
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="Venonat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="View Venonat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" alt="Venonat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Venonat
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="Venomoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="View Venomoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" alt="Venomoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Venomoth
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Diglett
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Dugtrio
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Meowth
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Persian
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Psyduck
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Golduck
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="Mankey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="View Mankey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" alt="Mankey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Mankey
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="Primeape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="View Primeape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" alt="Primeape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Primeape
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Growlithe
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Arcanine
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Poliwag
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Poliwhirl
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Poliwrath
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Abra
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Kadabra
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Alakazam
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Machop
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Machoke
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Machamp
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="Bellsprout">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="View Bellsprout on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" alt="Bellsprout" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Bellsprout
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="Weepinbell">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="View Weepinbell on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" alt="Weepinbell" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Weepinbell
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="Victreebel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="View Victreebel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" alt="Victreebel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Victreebel
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Tentacool
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Tentacruel
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="Geodude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="View Geodude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" alt="Geodude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Geodude
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="Graveler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="View Graveler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" alt="Graveler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Graveler
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="Golem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="View Golem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" alt="Golem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Golem
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Ponyta
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Rapidash
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Slowpoke
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Slowbro
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Magnemite
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Magneton
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="Farfetch’d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="View Farfetch’d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch’d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Farfetch’d
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="Doduo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="View Doduo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" alt="Doduo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Doduo
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="Dodrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="View Dodrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" alt="Dodrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Dodrio
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="Seel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="View Seel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" alt="Seel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Seel
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="Dewgong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="View Dewgong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" alt="Dewgong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Dewgong
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="Grimer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="View Grimer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" alt="Grimer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Grimer
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="Muk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="View Muk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" alt="Muk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Muk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Shellder
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Cloyster
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Gastly
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Haunter
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Gengar
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Onix
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="Drowzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="View Drowzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" alt="Drowzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Drowzee
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="Hypno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="View Hypno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" alt="Hypno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Hypno
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="Voltorb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="View Voltorb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" alt="Voltorb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Voltorb
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="Electrode">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="View Electrode on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" alt="Electrode" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Electrode
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Exeggcute
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Exeggutor
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Cubone
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Marowak
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Hitmonlee
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Hitmonchan
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Lickitung
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Koffing
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Weezing
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Rhyhorn
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Rhydon
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Chansey
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Tangela
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Kangaskhan
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Horsea
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Seadra
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Goldeen
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Seaking
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Staryu
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Starmie
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Mr. Mime
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Scyther
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="Jynx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="View Jynx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" alt="Jynx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Jynx
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="Electabuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="View Electabuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" alt="Electabuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Electabuzz
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="Magmar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="View Magmar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" alt="Magmar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Magmar
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Pinsir
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Tauros
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Magikarp
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Gyarados
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Lapras
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Ditto
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Eevee
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Vaporeon
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Jolteon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Flareon
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Porygon
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="Omanyte">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="View Omanyte on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" alt="Omanyte" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Omanyte
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="Omastar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="View Omastar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" alt="Omastar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Omastar
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="Kabuto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="View Kabuto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" alt="Kabuto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Kabuto
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="Kabutops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="View Kabutops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" alt="Kabutops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Kabutops
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="Aerodactyl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="View Aerodactyl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" alt="Aerodactyl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Aerodactyl
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Snorlax
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="Articuno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="View Articuno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" alt="Articuno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Articuno
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="Zapdos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="View Zapdos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" alt="Zapdos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Zapdos
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="Moltres">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="View Moltres on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" alt="Moltres" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Moltres
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="Dratini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="View Dratini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" alt="Dratini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Dratini
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="Dragonair">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="View Dragonair on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" alt="Dragonair" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Dragonair
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="Dragonite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="View Dragonite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" alt="Dragonite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Dragonite
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="Mewtwo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="View Mewtwo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" alt="Mewtwo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Mewtwo
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="Mew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="View Mew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" alt="Mew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Mew
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="Chikorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="View Chikorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" alt="Chikorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Chikorita
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="Bayleef">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="View Bayleef on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" alt="Bayleef" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Bayleef
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="Meganium">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="View Meganium on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" alt="Meganium" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Meganium
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="Cyndaquil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="View Cyndaquil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" alt="Cyndaquil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Cyndaquil
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="Quilava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="View Quilava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" alt="Quilava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Quilava
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="Typhlosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="View Typhlosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" alt="Typhlosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Typhlosion
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="Totodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="View Totodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" alt="Totodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Totodile
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="Croconaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="View Croconaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" alt="Croconaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Croconaw
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="Feraligatr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="View Feraligatr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" alt="Feraligatr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Feraligatr
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="Sentret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="View Sentret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" alt="Sentret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Sentret
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="Furret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="View Furret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" alt="Furret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Furret
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="Hoothoot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="View Hoothoot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" alt="Hoothoot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Hoothoot
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="Noctowl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="View Noctowl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" alt="Noctowl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Noctowl
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="Ledyba">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="View Ledyba on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" alt="Ledyba" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Ledyba
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="Ledian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="View Ledian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" alt="Ledian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Ledian
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="Spinarak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="View Spinarak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" alt="Spinarak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Spinarak
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="Ariados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="View Ariados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" alt="Ariados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Ariados
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="Crobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="View Crobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" alt="Crobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Crobat
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Chinchou
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Lanturn
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Pichu
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="Cleffa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="View Cleffa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" alt="Cleffa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Cleffa
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="Igglybuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="View Igglybuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" alt="Igglybuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Igglybuff
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="Togepi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="View Togepi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" alt="Togepi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Togepi
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="Togetic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="View Togetic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" alt="Togetic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Togetic
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="Natu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="View Natu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" alt="Natu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Natu
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="Xatu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="View Xatu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" alt="Xatu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Xatu
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="Mareep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="View Mareep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" alt="Mareep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Mareep
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="Flaaffy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="View Flaaffy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" alt="Flaaffy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Flaaffy
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="Ampharos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="View Ampharos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" alt="Ampharos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Ampharos
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="Bellossom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="View Bellossom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" alt="Bellossom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Bellossom
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="Marill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="View Marill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" alt="Marill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Marill
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="Azumarill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="View Azumarill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" alt="Azumarill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Azumarill
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="Sudowoodo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="View Sudowoodo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" alt="Sudowoodo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Sudowoodo
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="Politoed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="View Politoed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" alt="Politoed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Politoed
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="Hoppip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="View Hoppip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" alt="Hoppip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Hoppip
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="Skiploom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="View Skiploom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" alt="Skiploom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Skiploom
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="Jumpluff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="View Jumpluff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" alt="Jumpluff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Jumpluff
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="Aipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="View Aipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" alt="Aipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Aipom
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="Sunkern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="View Sunkern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" alt="Sunkern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Sunkern
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="Sunflora">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="View Sunflora on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" alt="Sunflora" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Sunflora
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="Yanma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="View Yanma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" alt="Yanma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Yanma
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Wooper
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Quagsire
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="Espeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="View Espeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" alt="Espeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Espeon
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="Umbreon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="View Umbreon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" alt="Umbreon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Umbreon
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="Murkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="View Murkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" alt="Murkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Murkrow
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="Slowking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="View Slowking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" alt="Slowking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Slowking
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="Misdreavus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="View Misdreavus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" alt="Misdreavus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Misdreavus
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="Unown">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="View Unown on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" alt="Unown" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Unown
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="Wobbuffet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="View Wobbuffet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" alt="Wobbuffet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Wobbuffet
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="Girafarig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="View Girafarig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" alt="Girafarig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Girafarig
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="Pineco">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="View Pineco on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" alt="Pineco" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Pineco
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="Forretress">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="View Forretress on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" alt="Forretress" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Forretress
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="Dunsparce">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="View Dunsparce on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" alt="Dunsparce" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Dunsparce
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="Gligar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="View Gligar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" alt="Gligar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Gligar
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="Steelix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="View Steelix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" alt="Steelix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Steelix
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="Snubbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="View Snubbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" alt="Snubbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Snubbull
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="Granbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="View Granbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" alt="Granbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Granbull
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="Qwilfish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="View Qwilfish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" alt="Qwilfish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Qwilfish
@@ -2184,8 +2184,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="Scizor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="View Scizor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" alt="Scizor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">212</span>
                             Scizor
@@ -2194,8 +2194,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="Shuckle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="View Shuckle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" alt="Shuckle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">213</span>
                             Shuckle
@@ -2204,8 +2204,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="Heracross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="View Heracross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" alt="Heracross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">214</span>
                             Heracross
@@ -2214,8 +2214,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="Sneasel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="View Sneasel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" alt="Sneasel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">215</span>
                             Sneasel
@@ -2224,8 +2224,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="Teddiursa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="View Teddiursa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" alt="Teddiursa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">216</span>
                             Teddiursa
@@ -2234,8 +2234,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="Ursaring">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="View Ursaring on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" alt="Ursaring" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">217</span>
                             Ursaring
@@ -2244,8 +2244,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="Slugma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="View Slugma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" alt="Slugma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">218</span>
                             Slugma
@@ -2254,8 +2254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="Magcargo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="View Magcargo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" alt="Magcargo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">219</span>
                             Magcargo
@@ -2264,8 +2264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="Swinub">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="View Swinub on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" alt="Swinub" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">220</span>
                             Swinub
@@ -2274,8 +2274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="Piloswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="View Piloswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" alt="Piloswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">221</span>
                             Piloswine
@@ -2284,8 +2284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="Corsola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="View Corsola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" alt="Corsola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">222</span>
                             Corsola
@@ -2294,8 +2294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">223</span>
                             Remoraid
@@ -2304,8 +2304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">224</span>
                             Octillery
@@ -2314,8 +2314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="Delibird">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="View Delibird on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" alt="Delibird" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">225</span>
                             Delibird
@@ -2324,8 +2324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">226</span>
                             Mantine
@@ -2334,8 +2334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="Skarmory">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="View Skarmory on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" alt="Skarmory" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">227</span>
                             Skarmory
@@ -2344,8 +2344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="Houndour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="View Houndour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" alt="Houndour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">228</span>
                             Houndour
@@ -2354,8 +2354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="Houndoom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="View Houndoom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" alt="Houndoom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">229</span>
                             Houndoom
@@ -2364,8 +2364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="Kingdra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="View Kingdra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" alt="Kingdra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">230</span>
                             Kingdra
@@ -2374,8 +2374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="Phanpy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="View Phanpy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" alt="Phanpy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">231</span>
                             Phanpy
@@ -2384,8 +2384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="Donphan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="View Donphan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" alt="Donphan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">232</span>
                             Donphan
@@ -2394,8 +2394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="Porygon2">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="View Porygon2 on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" alt="Porygon2" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">233</span>
                             Porygon2
@@ -2404,8 +2404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="Stantler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="View Stantler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" alt="Stantler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">234</span>
                             Stantler
@@ -2414,8 +2414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="Smeargle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="View Smeargle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" alt="Smeargle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">235</span>
                             Smeargle
@@ -2424,8 +2424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="Tyrogue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="View Tyrogue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" alt="Tyrogue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">236</span>
                             Tyrogue
@@ -2434,8 +2434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="Hitmontop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="View Hitmontop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" alt="Hitmontop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">237</span>
                             Hitmontop
@@ -2444,8 +2444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="Smoochum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="View Smoochum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" alt="Smoochum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">238</span>
                             Smoochum
@@ -2454,8 +2454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="Elekid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="View Elekid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" alt="Elekid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">239</span>
                             Elekid
@@ -2464,8 +2464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="Magby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="View Magby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" alt="Magby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">240</span>
                             Magby
@@ -2481,8 +2481,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="Miltank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="View Miltank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" alt="Miltank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">241</span>
                             Miltank
@@ -2491,8 +2491,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="Blissey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="View Blissey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" alt="Blissey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">242</span>
                             Blissey
@@ -2501,8 +2501,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="Raikou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="View Raikou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" alt="Raikou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">243</span>
                             Raikou
@@ -2511,8 +2511,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="Entei">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="View Entei on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" alt="Entei" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">244</span>
                             Entei
@@ -2521,8 +2521,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="Suicune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="View Suicune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" alt="Suicune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">245</span>
                             Suicune
@@ -2531,8 +2531,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="Larvitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="View Larvitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" alt="Larvitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">246</span>
                             Larvitar
@@ -2541,8 +2541,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="Pupitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="View Pupitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" alt="Pupitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">247</span>
                             Pupitar
@@ -2551,8 +2551,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="Tyranitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="View Tyranitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" alt="Tyranitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">248</span>
                             Tyranitar
@@ -2561,8 +2561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="Lugia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="View Lugia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" alt="Lugia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">249</span>
                             Lugia
@@ -2571,8 +2571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="Ho-Oh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="View Ho-Oh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" alt="Ho-Oh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">250</span>
                             Ho-Oh
@@ -2581,8 +2581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="Celebi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="View Celebi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" alt="Celebi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">251</span>
                             Celebi
@@ -2591,8 +2591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="Treecko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="View Treecko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" alt="Treecko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">252</span>
                             Treecko
@@ -2601,8 +2601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="Grovyle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="View Grovyle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" alt="Grovyle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">253</span>
                             Grovyle
@@ -2611,8 +2611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="Sceptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="View Sceptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" alt="Sceptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">254</span>
                             Sceptile
@@ -2621,8 +2621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="Torchic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="View Torchic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" alt="Torchic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">255</span>
                             Torchic
@@ -2631,8 +2631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="Combusken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="View Combusken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" alt="Combusken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">256</span>
                             Combusken
@@ -2641,8 +2641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="Blaziken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="View Blaziken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" alt="Blaziken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">257</span>
                             Blaziken
@@ -2651,8 +2651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="Mudkip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="View Mudkip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" alt="Mudkip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">258</span>
                             Mudkip
@@ -2661,8 +2661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="Marshtomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="View Marshtomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" alt="Marshtomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">259</span>
                             Marshtomp
@@ -2671,8 +2671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="Swampert">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="View Swampert on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" alt="Swampert" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">260</span>
                             Swampert
@@ -2681,8 +2681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="Poochyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="View Poochyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" alt="Poochyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">261</span>
                             Poochyena
@@ -2691,8 +2691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="Mightyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="View Mightyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" alt="Mightyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">262</span>
                             Mightyena
@@ -2701,8 +2701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="Zigzagoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="View Zigzagoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" alt="Zigzagoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">263</span>
                             Zigzagoon
@@ -2711,8 +2711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="Linoone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="View Linoone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" alt="Linoone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">264</span>
                             Linoone
@@ -2721,8 +2721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="Wurmple">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="View Wurmple on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" alt="Wurmple" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">265</span>
                             Wurmple
@@ -2731,8 +2731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="Silcoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="View Silcoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" alt="Silcoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">266</span>
                             Silcoon
@@ -2741,8 +2741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="Beautifly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="View Beautifly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" alt="Beautifly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">267</span>
                             Beautifly
@@ -2751,8 +2751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="Cascoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="View Cascoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" alt="Cascoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">268</span>
                             Cascoon
@@ -2761,8 +2761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="Dustox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="View Dustox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" alt="Dustox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">269</span>
                             Dustox
@@ -2771,8 +2771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="Lotad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="View Lotad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" alt="Lotad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">270</span>
                             Lotad
@@ -2788,8 +2788,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="Lombre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="View Lombre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" alt="Lombre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">271</span>
                             Lombre
@@ -2798,8 +2798,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="Ludicolo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="View Ludicolo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" alt="Ludicolo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">272</span>
                             Ludicolo
@@ -2808,8 +2808,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="Seedot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="View Seedot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" alt="Seedot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">273</span>
                             Seedot
@@ -2818,8 +2818,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="Nuzleaf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="View Nuzleaf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" alt="Nuzleaf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">274</span>
                             Nuzleaf
@@ -2828,8 +2828,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="Shiftry">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="View Shiftry on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" alt="Shiftry" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">275</span>
                             Shiftry
@@ -2838,8 +2838,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="Taillow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="View Taillow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" alt="Taillow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">276</span>
                             Taillow
@@ -2848,8 +2848,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="Swellow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="View Swellow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" alt="Swellow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">277</span>
                             Swellow
@@ -2858,8 +2858,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="Wingull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="View Wingull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" alt="Wingull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">278</span>
                             Wingull
@@ -2868,8 +2868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="Pelipper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="View Pelipper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" alt="Pelipper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">279</span>
                             Pelipper
@@ -2878,8 +2878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="Ralts">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="View Ralts on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" alt="Ralts" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">280</span>
                             Ralts
@@ -2888,8 +2888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="Kirlia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="View Kirlia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" alt="Kirlia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">281</span>
                             Kirlia
@@ -2898,8 +2898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="Gardevoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="View Gardevoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" alt="Gardevoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">282</span>
                             Gardevoir
@@ -2908,8 +2908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="Surskit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="View Surskit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" alt="Surskit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">283</span>
                             Surskit
@@ -2918,8 +2918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="Masquerain">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="View Masquerain on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" alt="Masquerain" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">284</span>
                             Masquerain
@@ -2928,8 +2928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="Shroomish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="View Shroomish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" alt="Shroomish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">285</span>
                             Shroomish
@@ -2938,8 +2938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="Breloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="View Breloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" alt="Breloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">286</span>
                             Breloom
@@ -2948,8 +2948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="Slakoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="View Slakoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" alt="Slakoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">287</span>
                             Slakoth
@@ -2958,8 +2958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="Vigoroth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="View Vigoroth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" alt="Vigoroth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">288</span>
                             Vigoroth
@@ -2968,8 +2968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="Slaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="View Slaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" alt="Slaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">289</span>
                             Slaking
@@ -2978,8 +2978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="Nincada">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="View Nincada on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" alt="Nincada" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">290</span>
                             Nincada
@@ -2988,8 +2988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="Ninjask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="View Ninjask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" alt="Ninjask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">291</span>
                             Ninjask
@@ -2998,8 +2998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="Shedinja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="View Shedinja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" alt="Shedinja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">292</span>
                             Shedinja
@@ -3008,8 +3008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="Whismur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="View Whismur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" alt="Whismur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">293</span>
                             Whismur
@@ -3018,8 +3018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="Loudred">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="View Loudred on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" alt="Loudred" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">294</span>
                             Loudred
@@ -3028,8 +3028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="Exploud">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="View Exploud on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" alt="Exploud" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">295</span>
                             Exploud
@@ -3038,8 +3038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="Makuhita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="View Makuhita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" alt="Makuhita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">296</span>
                             Makuhita
@@ -3048,8 +3048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="Hariyama">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="View Hariyama on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" alt="Hariyama" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">297</span>
                             Hariyama
@@ -3058,8 +3058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="Azurill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="View Azurill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" alt="Azurill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">298</span>
                             Azurill
@@ -3068,8 +3068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="Nosepass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="View Nosepass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" alt="Nosepass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">299</span>
                             Nosepass
@@ -3078,8 +3078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="Skitty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="View Skitty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" alt="Skitty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">300</span>
                             Skitty
@@ -3095,8 +3095,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="Delcatty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="View Delcatty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" alt="Delcatty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">301</span>
                             Delcatty
@@ -3105,8 +3105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="Sableye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="View Sableye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" alt="Sableye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">302</span>
                             Sableye
@@ -3115,8 +3115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="Mawile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="View Mawile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" alt="Mawile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">303</span>
                             Mawile
@@ -3125,8 +3125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="Aron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="View Aron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" alt="Aron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">304</span>
                             Aron
@@ -3135,8 +3135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="Lairon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="View Lairon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" alt="Lairon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">305</span>
                             Lairon
@@ -3145,8 +3145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="Aggron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="View Aggron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" alt="Aggron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">306</span>
                             Aggron
@@ -3155,8 +3155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="Meditite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="View Meditite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" alt="Meditite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">307</span>
                             Meditite
@@ -3165,8 +3165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="Medicham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="View Medicham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" alt="Medicham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">308</span>
                             Medicham
@@ -3175,8 +3175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="Electrike">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="View Electrike on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" alt="Electrike" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">309</span>
                             Electrike
@@ -3185,8 +3185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="Manectric">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="View Manectric on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" alt="Manectric" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">310</span>
                             Manectric
@@ -3195,8 +3195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="Plusle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="View Plusle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" alt="Plusle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">311</span>
                             Plusle
@@ -3205,8 +3205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="Minun">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="View Minun on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" alt="Minun" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">312</span>
                             Minun
@@ -3215,8 +3215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="Volbeat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="View Volbeat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" alt="Volbeat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">313</span>
                             Volbeat
@@ -3225,8 +3225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="Illumise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="View Illumise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" alt="Illumise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">314</span>
                             Illumise
@@ -3235,8 +3235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="Roselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="View Roselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" alt="Roselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">315</span>
                             Roselia
@@ -3245,8 +3245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="Gulpin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="View Gulpin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" alt="Gulpin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">316</span>
                             Gulpin
@@ -3255,8 +3255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="Swalot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="View Swalot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" alt="Swalot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">317</span>
                             Swalot
@@ -3265,8 +3265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="Carvanha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="View Carvanha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" alt="Carvanha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">318</span>
                             Carvanha
@@ -3275,8 +3275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="Sharpedo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="View Sharpedo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" alt="Sharpedo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">319</span>
                             Sharpedo
@@ -3285,8 +3285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="Wailmer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="View Wailmer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" alt="Wailmer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">320</span>
                             Wailmer
@@ -3295,8 +3295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="Wailord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="View Wailord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" alt="Wailord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">321</span>
                             Wailord
@@ -3305,8 +3305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="Numel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="View Numel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" alt="Numel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">322</span>
                             Numel
@@ -3315,8 +3315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="Camerupt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="View Camerupt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" alt="Camerupt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">323</span>
                             Camerupt
@@ -3325,8 +3325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="Torkoal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="View Torkoal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" alt="Torkoal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">324</span>
                             Torkoal
@@ -3335,8 +3335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="Spoink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="View Spoink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" alt="Spoink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">325</span>
                             Spoink
@@ -3345,8 +3345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="Grumpig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="View Grumpig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" alt="Grumpig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">326</span>
                             Grumpig
@@ -3355,8 +3355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="Spinda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="View Spinda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" alt="Spinda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">327</span>
                             Spinda
@@ -3365,8 +3365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="Trapinch">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="View Trapinch on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" alt="Trapinch" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">328</span>
                             Trapinch
@@ -3375,8 +3375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="Vibrava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="View Vibrava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" alt="Vibrava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">329</span>
                             Vibrava
@@ -3385,8 +3385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="Flygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="View Flygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" alt="Flygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">330</span>
                             Flygon
@@ -3402,8 +3402,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="Cacnea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="View Cacnea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" alt="Cacnea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">331</span>
                             Cacnea
@@ -3412,8 +3412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="Cacturne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="View Cacturne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" alt="Cacturne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">332</span>
                             Cacturne
@@ -3422,8 +3422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="Swablu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="View Swablu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" alt="Swablu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">333</span>
                             Swablu
@@ -3432,8 +3432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="Altaria">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="View Altaria on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" alt="Altaria" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">334</span>
                             Altaria
@@ -3442,8 +3442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="Zangoose">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="View Zangoose on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" alt="Zangoose" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">335</span>
                             Zangoose
@@ -3452,8 +3452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="Seviper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="View Seviper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" alt="Seviper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">336</span>
                             Seviper
@@ -3462,8 +3462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="Lunatone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="View Lunatone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" alt="Lunatone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">337</span>
                             Lunatone
@@ -3472,8 +3472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="Solrock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="View Solrock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" alt="Solrock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">338</span>
                             Solrock
@@ -3482,8 +3482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="Barboach">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="View Barboach on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" alt="Barboach" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">339</span>
                             Barboach
@@ -3492,8 +3492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="Whiscash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="View Whiscash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" alt="Whiscash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">340</span>
                             Whiscash
@@ -3502,8 +3502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="Corphish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="View Corphish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" alt="Corphish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">341</span>
                             Corphish
@@ -3512,8 +3512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="Crawdaunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="View Crawdaunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" alt="Crawdaunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">342</span>
                             Crawdaunt
@@ -3522,8 +3522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="Baltoy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="View Baltoy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" alt="Baltoy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">343</span>
                             Baltoy
@@ -3532,8 +3532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="Claydol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="View Claydol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" alt="Claydol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">344</span>
                             Claydol
@@ -3542,8 +3542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="Lileep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="View Lileep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" alt="Lileep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">345</span>
                             Lileep
@@ -3552,8 +3552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="Cradily">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="View Cradily on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" alt="Cradily" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">346</span>
                             Cradily
@@ -3562,8 +3562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="Anorith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="View Anorith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" alt="Anorith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">347</span>
                             Anorith
@@ -3572,8 +3572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="Armaldo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="View Armaldo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" alt="Armaldo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">348</span>
                             Armaldo
@@ -3582,8 +3582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="Feebas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="View Feebas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" alt="Feebas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">349</span>
                             Feebas
@@ -3592,8 +3592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="Milotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="View Milotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" alt="Milotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">350</span>
                             Milotic
@@ -3602,8 +3602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="Castform">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="View Castform on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" alt="Castform" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">351</span>
                             Castform
@@ -3612,8 +3612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="Kecleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="View Kecleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" alt="Kecleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">352</span>
                             Kecleon
@@ -3622,8 +3622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="Shuppet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="View Shuppet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" alt="Shuppet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">353</span>
                             Shuppet
@@ -3632,8 +3632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="Banette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="View Banette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" alt="Banette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">354</span>
                             Banette
@@ -3642,8 +3642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="Duskull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="View Duskull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" alt="Duskull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">355</span>
                             Duskull
@@ -3652,8 +3652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="Dusclops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="View Dusclops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" alt="Dusclops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">356</span>
                             Dusclops
@@ -3662,8 +3662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="Tropius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="View Tropius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" alt="Tropius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">357</span>
                             Tropius
@@ -3672,8 +3672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="Chimecho">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="View Chimecho on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" alt="Chimecho" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">358</span>
                             Chimecho
@@ -3682,8 +3682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="Absol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="View Absol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" alt="Absol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">359</span>
                             Absol
@@ -3692,8 +3692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="Wynaut">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="View Wynaut on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" alt="Wynaut" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">360</span>
                             Wynaut
@@ -3709,8 +3709,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="Snorunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="View Snorunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" alt="Snorunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">361</span>
                             Snorunt
@@ -3719,8 +3719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="Glalie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="View Glalie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" alt="Glalie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">362</span>
                             Glalie
@@ -3729,8 +3729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="Spheal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="View Spheal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" alt="Spheal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">363</span>
                             Spheal
@@ -3739,8 +3739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="Sealeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="View Sealeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" alt="Sealeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">364</span>
                             Sealeo
@@ -3749,8 +3749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="Walrein">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="View Walrein on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" alt="Walrein" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">365</span>
                             Walrein
@@ -3759,8 +3759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="Clamperl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="View Clamperl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" alt="Clamperl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">366</span>
                             Clamperl
@@ -3769,8 +3769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="Huntail">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="View Huntail on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" alt="Huntail" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">367</span>
                             Huntail
@@ -3779,8 +3779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="Gorebyss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="View Gorebyss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" alt="Gorebyss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">368</span>
                             Gorebyss
@@ -3789,8 +3789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="Relicanth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="View Relicanth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" alt="Relicanth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">369</span>
                             Relicanth
@@ -3799,8 +3799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="Luvdisc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="View Luvdisc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" alt="Luvdisc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">370</span>
                             Luvdisc
@@ -3809,8 +3809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="Bagon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="View Bagon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" alt="Bagon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">371</span>
                             Bagon
@@ -3819,8 +3819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="Shelgon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="View Shelgon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" alt="Shelgon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">372</span>
                             Shelgon
@@ -3829,8 +3829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="Salamence">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="View Salamence on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" alt="Salamence" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">373</span>
                             Salamence
@@ -3839,8 +3839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="Beldum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="View Beldum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" alt="Beldum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">374</span>
                             Beldum
@@ -3849,8 +3849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="Metang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="View Metang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" alt="Metang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">375</span>
                             Metang
@@ -3859,8 +3859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="Metagross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="View Metagross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" alt="Metagross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">376</span>
                             Metagross
@@ -3869,8 +3869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="Regirock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="View Regirock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" alt="Regirock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">377</span>
                             Regirock
@@ -3879,8 +3879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="Regice">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="View Regice on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" alt="Regice" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">378</span>
                             Regice
@@ -3889,8 +3889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="Registeel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="View Registeel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" alt="Registeel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">379</span>
                             Registeel
@@ -3899,8 +3899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="Latias">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="View Latias on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" alt="Latias" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">380</span>
                             Latias
@@ -3909,8 +3909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="Latios">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="View Latios on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" alt="Latios" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">381</span>
                             Latios
@@ -3919,8 +3919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="Kyogre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="View Kyogre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" alt="Kyogre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">382</span>
                             Kyogre
@@ -3929,8 +3929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="Groudon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="View Groudon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" alt="Groudon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">383</span>
                             Groudon
@@ -3939,8 +3939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="Rayquaza">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="View Rayquaza on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" alt="Rayquaza" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">384</span>
                             Rayquaza
@@ -3949,8 +3949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="Jirachi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="View Jirachi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" alt="Jirachi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">385</span>
                             Jirachi
@@ -3959,8 +3959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="Deoxys">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="View Deoxys on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" alt="Deoxys" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">386</span>
                             Deoxys
@@ -3969,8 +3969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="Turtwig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="View Turtwig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" alt="Turtwig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">387</span>
                             Turtwig
@@ -3979,8 +3979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="Grotle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="View Grotle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" alt="Grotle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">388</span>
                             Grotle
@@ -3989,8 +3989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="Torterra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="View Torterra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" alt="Torterra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">389</span>
                             Torterra
@@ -3999,8 +3999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="Chimchar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="View Chimchar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" alt="Chimchar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">390</span>
                             Chimchar
@@ -4016,8 +4016,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="Monferno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="View Monferno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" alt="Monferno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">391</span>
                             Monferno
@@ -4026,8 +4026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="Infernape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="View Infernape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" alt="Infernape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">392</span>
                             Infernape
@@ -4036,8 +4036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="Piplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="View Piplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" alt="Piplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">393</span>
                             Piplup
@@ -4046,8 +4046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="Prinplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="View Prinplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" alt="Prinplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">394</span>
                             Prinplup
@@ -4056,8 +4056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="Empoleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="View Empoleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" alt="Empoleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">395</span>
                             Empoleon
@@ -4066,8 +4066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="Starly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="View Starly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" alt="Starly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">396</span>
                             Starly
@@ -4076,8 +4076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="Staravia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="View Staravia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" alt="Staravia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">397</span>
                             Staravia
@@ -4086,8 +4086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="Staraptor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="View Staraptor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" alt="Staraptor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">398</span>
                             Staraptor
@@ -4096,8 +4096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="Bidoof">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="View Bidoof on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" alt="Bidoof" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">399</span>
                             Bidoof
@@ -4106,8 +4106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="Bibarel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="View Bibarel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" alt="Bibarel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">400</span>
                             Bibarel
@@ -4116,8 +4116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="Kricketot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="View Kricketot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" alt="Kricketot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">401</span>
                             Kricketot
@@ -4126,8 +4126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="Kricketune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="View Kricketune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" alt="Kricketune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">402</span>
                             Kricketune
@@ -4136,8 +4136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="Shinx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="View Shinx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" alt="Shinx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">403</span>
                             Shinx
@@ -4146,8 +4146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="Luxio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="View Luxio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" alt="Luxio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">404</span>
                             Luxio
@@ -4156,8 +4156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="Luxray">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="View Luxray on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" alt="Luxray" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">405</span>
                             Luxray
@@ -4166,8 +4166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="Budew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="View Budew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" alt="Budew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">406</span>
                             Budew
@@ -4176,8 +4176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="Roserade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="View Roserade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" alt="Roserade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">407</span>
                             Roserade
@@ -4186,8 +4186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="Cranidos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="View Cranidos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" alt="Cranidos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">408</span>
                             Cranidos
@@ -4196,8 +4196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="Rampardos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="View Rampardos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" alt="Rampardos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">409</span>
                             Rampardos
@@ -4206,8 +4206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="Shieldon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="View Shieldon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" alt="Shieldon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">410</span>
                             Shieldon
@@ -4216,8 +4216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="Bastiodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="View Bastiodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" alt="Bastiodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">411</span>
                             Bastiodon
@@ -4226,8 +4226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="Burmy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="View Burmy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" alt="Burmy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">412</span>
                             Burmy
@@ -4236,8 +4236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="Wormadam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="View Wormadam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" alt="Wormadam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">413</span>
                             Wormadam
@@ -4246,8 +4246,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="Mothim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="View Mothim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" alt="Mothim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">414</span>
                             Mothim
@@ -4256,8 +4256,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="Combee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="View Combee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" alt="Combee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">415</span>
                             Combee
@@ -4266,8 +4266,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="Vespiquen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="View Vespiquen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" alt="Vespiquen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">416</span>
                             Vespiquen
@@ -4276,8 +4276,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="Pachirisu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="View Pachirisu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" alt="Pachirisu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">417</span>
                             Pachirisu
@@ -4286,8 +4286,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="Buizel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="View Buizel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" alt="Buizel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">418</span>
                             Buizel
@@ -4296,8 +4296,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="Floatzel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="View Floatzel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" alt="Floatzel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">419</span>
                             Floatzel
@@ -4306,8 +4306,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="Cherubi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="View Cherubi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" alt="Cherubi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">420</span>
                             Cherubi
@@ -4323,8 +4323,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="Cherrim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="View Cherrim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" alt="Cherrim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">421</span>
                             Cherrim
@@ -4333,8 +4333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="Shellos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="View Shellos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" alt="Shellos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">422</span>
                             Shellos
@@ -4343,8 +4343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="Gastrodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="View Gastrodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" alt="Gastrodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">423</span>
                             Gastrodon
@@ -4353,8 +4353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="Ambipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="View Ambipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" alt="Ambipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">424</span>
                             Ambipom
@@ -4363,8 +4363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="Drifloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="View Drifloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" alt="Drifloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">425</span>
                             Drifloon
@@ -4373,8 +4373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="Drifblim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="View Drifblim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" alt="Drifblim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">426</span>
                             Drifblim
@@ -4383,8 +4383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="Buneary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="View Buneary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" alt="Buneary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">427</span>
                             Buneary
@@ -4393,8 +4393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="Lopunny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="View Lopunny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" alt="Lopunny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">428</span>
                             Lopunny
@@ -4403,8 +4403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="Mismagius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="View Mismagius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" alt="Mismagius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">429</span>
                             Mismagius
@@ -4413,8 +4413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="Honchkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="View Honchkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" alt="Honchkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">430</span>
                             Honchkrow
@@ -4423,8 +4423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="Glameow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="View Glameow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" alt="Glameow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">431</span>
                             Glameow
@@ -4433,8 +4433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="Purugly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="View Purugly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" alt="Purugly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">432</span>
                             Purugly
@@ -4443,8 +4443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="Chingling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="View Chingling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" alt="Chingling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">433</span>
                             Chingling
@@ -4453,8 +4453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="Stunky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="View Stunky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" alt="Stunky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">434</span>
                             Stunky
@@ -4463,8 +4463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="Skuntank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="View Skuntank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" alt="Skuntank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">435</span>
                             Skuntank
@@ -4473,8 +4473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="Bronzor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="View Bronzor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" alt="Bronzor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">436</span>
                             Bronzor
@@ -4483,8 +4483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="Bronzong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="View Bronzong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" alt="Bronzong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">437</span>
                             Bronzong
@@ -4493,8 +4493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="Bonsly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="View Bonsly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" alt="Bonsly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">438</span>
                             Bonsly
@@ -4503,8 +4503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="Mime Jr.">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="View Mime Jr. on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" alt="Mime Jr." loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">439</span>
                             Mime Jr.
@@ -4513,8 +4513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="Happiny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="View Happiny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" alt="Happiny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">440</span>
                             Happiny
@@ -4523,8 +4523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="Chatot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="View Chatot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" alt="Chatot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">441</span>
                             Chatot
@@ -4533,8 +4533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="Spiritomb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="View Spiritomb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" alt="Spiritomb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">442</span>
                             Spiritomb
@@ -4543,8 +4543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="Gible">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="View Gible on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" alt="Gible" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">443</span>
                             Gible
@@ -4553,8 +4553,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="Gabite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="View Gabite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" alt="Gabite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">444</span>
                             Gabite
@@ -4563,8 +4563,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="Garchomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="View Garchomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" alt="Garchomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">445</span>
                             Garchomp
@@ -4573,8 +4573,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="Munchlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="View Munchlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" alt="Munchlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">446</span>
                             Munchlax
@@ -4583,8 +4583,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="Riolu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="View Riolu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" alt="Riolu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">447</span>
                             Riolu
@@ -4593,8 +4593,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="Lucario">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="View Lucario on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" alt="Lucario" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">448</span>
                             Lucario
@@ -4603,8 +4603,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="Hippopotas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="View Hippopotas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" alt="Hippopotas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">449</span>
                             Hippopotas
@@ -4613,8 +4613,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="Hippowdon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="View Hippowdon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" alt="Hippowdon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">450</span>
                             Hippowdon
@@ -4630,8 +4630,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="Skorupi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="View Skorupi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" alt="Skorupi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">451</span>
                             Skorupi
@@ -4640,8 +4640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="Drapion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="View Drapion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" alt="Drapion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">452</span>
                             Drapion
@@ -4650,8 +4650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="Croagunk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="View Croagunk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" alt="Croagunk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">453</span>
                             Croagunk
@@ -4660,8 +4660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="Toxicroak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="View Toxicroak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" alt="Toxicroak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">454</span>
                             Toxicroak
@@ -4670,8 +4670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="Carnivine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="View Carnivine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" alt="Carnivine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">455</span>
                             Carnivine
@@ -4680,8 +4680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="Finneon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="View Finneon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" alt="Finneon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">456</span>
                             Finneon
@@ -4690,8 +4690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="Lumineon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="View Lumineon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" alt="Lumineon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">457</span>
                             Lumineon
@@ -4700,8 +4700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="Mantyke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="View Mantyke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" alt="Mantyke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">458</span>
                             Mantyke
@@ -4710,8 +4710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="Snover">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="View Snover on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" alt="Snover" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">459</span>
                             Snover
@@ -4720,8 +4720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="Abomasnow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="View Abomasnow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" alt="Abomasnow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">460</span>
                             Abomasnow
@@ -4730,8 +4730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="Weavile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="View Weavile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" alt="Weavile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">461</span>
                             Weavile
@@ -4740,8 +4740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="Magnezone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="View Magnezone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" alt="Magnezone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">462</span>
                             Magnezone
@@ -4750,8 +4750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="Lickilicky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="View Lickilicky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" alt="Lickilicky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">463</span>
                             Lickilicky
@@ -4760,8 +4760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="Rhyperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="View Rhyperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" alt="Rhyperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">464</span>
                             Rhyperior
@@ -4770,8 +4770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="Tangrowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="View Tangrowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" alt="Tangrowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">465</span>
                             Tangrowth
@@ -4780,8 +4780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="Electivire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="View Electivire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" alt="Electivire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">466</span>
                             Electivire
@@ -4790,8 +4790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="Magmortar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="View Magmortar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" alt="Magmortar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">467</span>
                             Magmortar
@@ -4800,8 +4800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="Togekiss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="View Togekiss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" alt="Togekiss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">468</span>
                             Togekiss
@@ -4810,8 +4810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="Yanmega">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="View Yanmega on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" alt="Yanmega" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">469</span>
                             Yanmega
@@ -4820,8 +4820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="Leafeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="View Leafeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" alt="Leafeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">470</span>
                             Leafeon
@@ -4830,8 +4830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="Glaceon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="View Glaceon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" alt="Glaceon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">471</span>
                             Glaceon
@@ -4840,8 +4840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="Gliscor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="View Gliscor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" alt="Gliscor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">472</span>
                             Gliscor
@@ -4850,8 +4850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="Mamoswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="View Mamoswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" alt="Mamoswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">473</span>
                             Mamoswine
@@ -4860,8 +4860,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="Porygon-Z">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="View Porygon-Z on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" alt="Porygon-Z" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">474</span>
                             Porygon-Z
@@ -4870,8 +4870,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="Gallade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="View Gallade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" alt="Gallade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">475</span>
                             Gallade
@@ -4880,8 +4880,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="Probopass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="View Probopass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" alt="Probopass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">476</span>
                             Probopass
@@ -4890,8 +4890,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="Dusknoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="View Dusknoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" alt="Dusknoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">477</span>
                             Dusknoir
@@ -4900,8 +4900,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="Froslass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="View Froslass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" alt="Froslass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">478</span>
                             Froslass
@@ -4910,8 +4910,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="Rotom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="View Rotom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" alt="Rotom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">479</span>
                             Rotom
@@ -4920,8 +4920,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="Uxie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="View Uxie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" alt="Uxie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">480</span>
                             Uxie
@@ -4937,8 +4937,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="Mesprit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="View Mesprit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" alt="Mesprit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">481</span>
                             Mesprit
@@ -4947,8 +4947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="Azelf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="View Azelf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" alt="Azelf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">482</span>
                             Azelf
@@ -4957,8 +4957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="Dialga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="View Dialga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" alt="Dialga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">483</span>
                             Dialga
@@ -4967,8 +4967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="Palkia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="View Palkia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" alt="Palkia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">484</span>
                             Palkia
@@ -4977,8 +4977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="Heatran">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="View Heatran on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" alt="Heatran" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">485</span>
                             Heatran
@@ -4987,8 +4987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="Regigigas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="View Regigigas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" alt="Regigigas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">486</span>
                             Regigigas
@@ -4997,8 +4997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="Giratina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="View Giratina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" alt="Giratina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">487</span>
                             Giratina
@@ -5007,8 +5007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="Cresselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="View Cresselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" alt="Cresselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">488</span>
                             Cresselia
@@ -5017,8 +5017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="Phione">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="View Phione on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" alt="Phione" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">489</span>
                             Phione
@@ -5027,8 +5027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="Manaphy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="View Manaphy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" alt="Manaphy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">490</span>
                             Manaphy
@@ -5037,8 +5037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darkrai/" title="Darkrai">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/491.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darkrai/" title="View Darkrai on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/491.png" alt="Darkrai" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">491</span>
                             Darkrai
@@ -5047,8 +5047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shaymin/" title="Shaymin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/492.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shaymin/" title="View Shaymin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/492.png" alt="Shaymin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">492</span>
                             Shaymin
@@ -5057,8 +5057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arceus/" title="Arceus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/493.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arceus/" title="View Arceus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/493.png" alt="Arceus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">493</span>
                             Arceus
@@ -5067,8 +5067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victini/" title="Victini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/494.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victini/" title="View Victini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/494.png" alt="Victini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">494</span>
                             Victini
@@ -5077,8 +5077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snivy/" title="Snivy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/495.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snivy/" title="View Snivy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/495.png" alt="Snivy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">495</span>
                             Snivy
@@ -5087,8 +5087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/servine/" title="Servine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/496.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/servine/" title="View Servine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/496.png" alt="Servine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">496</span>
                             Servine
@@ -5097,8 +5097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/serperior/" title="Serperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/497.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/serperior/" title="View Serperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/497.png" alt="Serperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">497</span>
                             Serperior
@@ -5107,8 +5107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tepig/" title="Tepig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/498.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tepig/" title="View Tepig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/498.png" alt="Tepig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">498</span>
                             Tepig
@@ -5117,8 +5117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pignite/" title="Pignite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/499.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pignite/" title="View Pignite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/499.png" alt="Pignite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">499</span>
                             Pignite
@@ -5127,8 +5127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/emboar/" title="Emboar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/500.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/emboar/" title="View Emboar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/500.png" alt="Emboar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">500</span>
                             Emboar
@@ -5137,8 +5137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oshawott/" title="Oshawott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/501.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oshawott/" title="View Oshawott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/501.png" alt="Oshawott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">501</span>
                             Oshawott
@@ -5147,8 +5147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewott/" title="Dewott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/502.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewott/" title="View Dewott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/502.png" alt="Dewott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">502</span>
                             Dewott
@@ -5157,8 +5157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/samurott/" title="Samurott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/503.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/samurott/" title="View Samurott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/503.png" alt="Samurott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">503</span>
                             Samurott
@@ -5167,8 +5167,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/patrat/" title="Patrat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/504.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/patrat/" title="View Patrat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/504.png" alt="Patrat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">504</span>
                             Patrat
@@ -5177,8 +5177,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/watchog/" title="Watchog">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/505.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/watchog/" title="View Watchog on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/505.png" alt="Watchog" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">505</span>
                             Watchog
@@ -5187,8 +5187,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="Lillipup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="View Lillipup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" alt="Lillipup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">506</span>
                             Lillipup
@@ -5197,8 +5197,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="Herdier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="View Herdier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" alt="Herdier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">507</span>
                             Herdier
@@ -5207,8 +5207,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="Stoutland">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="View Stoutland on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" alt="Stoutland" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">508</span>
                             Stoutland
@@ -5217,8 +5217,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="Purrloin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="View Purrloin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" alt="Purrloin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">509</span>
                             Purrloin
@@ -5227,8 +5227,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="Liepard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="View Liepard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" alt="Liepard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">510</span>
                             Liepard
@@ -5244,8 +5244,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pansage/" title="Pansage">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/511.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pansage/" title="View Pansage on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/511.png" alt="Pansage" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">511</span>
                             Pansage
@@ -5254,8 +5254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simisage/" title="Simisage">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/512.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simisage/" title="View Simisage on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/512.png" alt="Simisage" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">512</span>
                             Simisage
@@ -5264,8 +5264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pansear/" title="Pansear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/513.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pansear/" title="View Pansear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/513.png" alt="Pansear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">513</span>
                             Pansear
@@ -5274,8 +5274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simisear/" title="Simisear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/514.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simisear/" title="View Simisear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/514.png" alt="Simisear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">514</span>
                             Simisear
@@ -5284,8 +5284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/panpour/" title="Panpour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/515.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/panpour/" title="View Panpour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/515.png" alt="Panpour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">515</span>
                             Panpour
@@ -5294,8 +5294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simipour/" title="Simipour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/516.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simipour/" title="View Simipour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/516.png" alt="Simipour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">516</span>
                             Simipour
@@ -5304,8 +5304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="Munna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="View Munna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" alt="Munna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">517</span>
                             Munna
@@ -5314,8 +5314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="Musharna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="View Musharna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" alt="Musharna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">518</span>
                             Musharna
@@ -5324,8 +5324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="Pidove">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="View Pidove on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" alt="Pidove" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">519</span>
                             Pidove
@@ -5334,8 +5334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="Tranquill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="View Tranquill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" alt="Tranquill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">520</span>
                             Tranquill
@@ -5344,8 +5344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="Unfezant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="View Unfezant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" alt="Unfezant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">521</span>
                             Unfezant
@@ -5354,8 +5354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blitzle/" title="Blitzle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/522.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blitzle/" title="View Blitzle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/522.png" alt="Blitzle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">522</span>
                             Blitzle
@@ -5364,8 +5364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zebstrika/" title="Zebstrika">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/523.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zebstrika/" title="View Zebstrika on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/523.png" alt="Zebstrika" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">523</span>
                             Zebstrika
@@ -5374,8 +5374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="Roggenrola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="View Roggenrola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" alt="Roggenrola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">524</span>
                             Roggenrola
@@ -5384,8 +5384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="Boldore">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="View Boldore on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" alt="Boldore" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">525</span>
                             Boldore
@@ -5394,8 +5394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="Gigalith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="View Gigalith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" alt="Gigalith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">526</span>
                             Gigalith
@@ -5404,8 +5404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="Woobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="View Woobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" alt="Woobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">527</span>
                             Woobat
@@ -5414,8 +5414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="Swoobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="View Swoobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" alt="Swoobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">528</span>
                             Swoobat
@@ -5424,8 +5424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="Drilbur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="View Drilbur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" alt="Drilbur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">529</span>
                             Drilbur
@@ -5434,8 +5434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="Excadrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="View Excadrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" alt="Excadrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">530</span>
                             Excadrill
@@ -5444,8 +5444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/audino/" title="Audino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/531.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/audino/" title="View Audino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/531.png" alt="Audino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">531</span>
                             Audino
@@ -5454,8 +5454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="Timburr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="View Timburr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" alt="Timburr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">532</span>
                             Timburr
@@ -5464,8 +5464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="Gurdurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="View Gurdurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" alt="Gurdurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">533</span>
                             Gurdurr
@@ -5474,8 +5474,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="Conkeldurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="View Conkeldurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" alt="Conkeldurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">534</span>
                             Conkeldurr
@@ -5484,8 +5484,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="Tympole">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="View Tympole on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" alt="Tympole" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">535</span>
                             Tympole
@@ -5494,8 +5494,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="Palpitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="View Palpitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" alt="Palpitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">536</span>
                             Palpitoad
@@ -5504,8 +5504,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="Seismitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="View Seismitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" alt="Seismitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">537</span>
                             Seismitoad
@@ -5514,8 +5514,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="Throh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="View Throh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" alt="Throh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">538</span>
                             Throh
@@ -5524,8 +5524,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="Sawk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="View Sawk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" alt="Sawk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">539</span>
                             Sawk
@@ -5534,8 +5534,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sewaddle/" title="Sewaddle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/540.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sewaddle/" title="View Sewaddle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/540.png" alt="Sewaddle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">540</span>
                             Sewaddle
@@ -5551,8 +5551,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swadloon/" title="Swadloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/541.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swadloon/" title="View Swadloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/541.png" alt="Swadloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">541</span>
                             Swadloon
@@ -5561,8 +5561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leavanny/" title="Leavanny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/542.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leavanny/" title="View Leavanny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/542.png" alt="Leavanny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">542</span>
                             Leavanny
@@ -5571,8 +5571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="Venipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="View Venipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" alt="Venipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">543</span>
                             Venipede
@@ -5581,8 +5581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="Whirlipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="View Whirlipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" alt="Whirlipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">544</span>
                             Whirlipede
@@ -5591,8 +5591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="Scolipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="View Scolipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" alt="Scolipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">545</span>
                             Scolipede
@@ -5601,8 +5601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="Cottonee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="View Cottonee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" alt="Cottonee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">546</span>
                             Cottonee
@@ -5611,8 +5611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="Whimsicott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="View Whimsicott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" alt="Whimsicott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">547</span>
                             Whimsicott
@@ -5621,8 +5621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="Petilil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="View Petilil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" alt="Petilil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">548</span>
                             Petilil
@@ -5631,8 +5631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="Lilligant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="View Lilligant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" alt="Lilligant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">549</span>
                             Lilligant
@@ -5641,8 +5641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="Basculin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="View Basculin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" alt="Basculin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">550</span>
                             Basculin
@@ -5651,8 +5651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="Sandile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="View Sandile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" alt="Sandile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">551</span>
                             Sandile
@@ -5661,8 +5661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="Krokorok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="View Krokorok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" alt="Krokorok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">552</span>
                             Krokorok
@@ -5671,8 +5671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="Krookodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="View Krookodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" alt="Krookodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">553</span>
                             Krookodile
@@ -5681,8 +5681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="Darumaka">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="View Darumaka on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" alt="Darumaka" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">554</span>
                             Darumaka
@@ -5691,8 +5691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="Darmanitan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="View Darmanitan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" alt="Darmanitan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">555</span>
                             Darmanitan
@@ -5701,8 +5701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="Maractus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="View Maractus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" alt="Maractus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">556</span>
                             Maractus
@@ -5711,8 +5711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="Dwebble">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="View Dwebble on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" alt="Dwebble" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">557</span>
                             Dwebble
@@ -5721,8 +5721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="Crustle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="View Crustle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" alt="Crustle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">558</span>
                             Crustle
@@ -5731,8 +5731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="Scraggy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="View Scraggy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" alt="Scraggy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">559</span>
                             Scraggy
@@ -5741,8 +5741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="Scrafty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="View Scrafty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" alt="Scrafty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">560</span>
                             Scrafty
@@ -5751,8 +5751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="Sigilyph">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="View Sigilyph on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" alt="Sigilyph" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">561</span>
                             Sigilyph
@@ -5761,8 +5761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="Yamask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="View Yamask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" alt="Yamask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">562</span>
                             Yamask
@@ -5771,8 +5771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="Cofagrigus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="View Cofagrigus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" alt="Cofagrigus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">563</span>
                             Cofagrigus
@@ -5781,8 +5781,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tirtouga/" title="Tirtouga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/564.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tirtouga/" title="View Tirtouga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/564.png" alt="Tirtouga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">564</span>
                             Tirtouga
@@ -5791,8 +5791,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carracosta/" title="Carracosta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/565.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carracosta/" title="View Carracosta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/565.png" alt="Carracosta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">565</span>
                             Carracosta
@@ -5801,8 +5801,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/archen/" title="Archen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/566.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/archen/" title="View Archen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/566.png" alt="Archen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">566</span>
                             Archen
@@ -5811,8 +5811,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/archeops/" title="Archeops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/567.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/archeops/" title="View Archeops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/567.png" alt="Archeops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">567</span>
                             Archeops
@@ -5821,8 +5821,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="Trubbish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="View Trubbish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" alt="Trubbish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">568</span>
                             Trubbish
@@ -5831,8 +5831,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="Garbodor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="View Garbodor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" alt="Garbodor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">569</span>
                             Garbodor
@@ -5841,8 +5841,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="Zorua">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="View Zorua on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" alt="Zorua" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">570</span>
                             Zorua
@@ -5858,8 +5858,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="Zoroark">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="View Zoroark on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" alt="Zoroark" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">571</span>
                             Zoroark
@@ -5868,8 +5868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="Minccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="View Minccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" alt="Minccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">572</span>
                             Minccino
@@ -5878,8 +5878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="Cinccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="View Cinccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" alt="Cinccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">573</span>
                             Cinccino
@@ -5888,8 +5888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="Gothita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="View Gothita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" alt="Gothita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">574</span>
                             Gothita
@@ -5898,8 +5898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="Gothorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="View Gothorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" alt="Gothorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">575</span>
                             Gothorita
@@ -5908,8 +5908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="Gothitelle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="View Gothitelle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" alt="Gothitelle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">576</span>
                             Gothitelle
@@ -5918,8 +5918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="Solosis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="View Solosis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" alt="Solosis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">577</span>
                             Solosis
@@ -5928,8 +5928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="Duosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="View Duosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" alt="Duosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">578</span>
                             Duosion
@@ -5938,8 +5938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="Reuniclus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="View Reuniclus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" alt="Reuniclus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">579</span>
                             Reuniclus
@@ -5948,8 +5948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ducklett/" title="Ducklett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/580.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ducklett/" title="View Ducklett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/580.png" alt="Ducklett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">580</span>
                             Ducklett
@@ -5958,8 +5958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swanna/" title="Swanna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/581.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swanna/" title="View Swanna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/581.png" alt="Swanna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">581</span>
                             Swanna
@@ -5968,8 +5968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="Vanillite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="View Vanillite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" alt="Vanillite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">582</span>
                             Vanillite
@@ -5978,8 +5978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="Vanillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="View Vanillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" alt="Vanillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">583</span>
                             Vanillish
@@ -5988,8 +5988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="Vanilluxe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="View Vanilluxe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" alt="Vanilluxe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">584</span>
                             Vanilluxe
@@ -5998,8 +5998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deerling/" title="Deerling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/585.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deerling/" title="View Deerling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/585.png" alt="Deerling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">585</span>
                             Deerling
@@ -6008,8 +6008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sawsbuck/" title="Sawsbuck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/586.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sawsbuck/" title="View Sawsbuck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/586.png" alt="Sawsbuck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">586</span>
                             Sawsbuck
@@ -6018,8 +6018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="Emolga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="View Emolga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" alt="Emolga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">587</span>
                             Emolga
@@ -6028,8 +6028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="Karrablast">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="View Karrablast on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" alt="Karrablast" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">588</span>
                             Karrablast
@@ -6038,8 +6038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="Escavalier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="View Escavalier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" alt="Escavalier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">589</span>
                             Escavalier
@@ -6048,8 +6048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="Foongus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="View Foongus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" alt="Foongus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">590</span>
                             Foongus
@@ -6058,8 +6058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="Amoonguss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="View Amoonguss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" alt="Amoonguss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">591</span>
                             Amoonguss
@@ -6068,8 +6068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="Frillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="View Frillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" alt="Frillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">592</span>
                             Frillish
@@ -6078,8 +6078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="Jellicent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="View Jellicent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" alt="Jellicent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">593</span>
                             Jellicent
@@ -6088,8 +6088,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alomomola/" title="Alomomola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/594.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alomomola/" title="View Alomomola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/594.png" alt="Alomomola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">594</span>
                             Alomomola
@@ -6098,8 +6098,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="Joltik">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="View Joltik on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" alt="Joltik" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">595</span>
                             Joltik
@@ -6108,8 +6108,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="Galvantula">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="View Galvantula on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" alt="Galvantula" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">596</span>
                             Galvantula
@@ -6118,8 +6118,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="Ferroseed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="View Ferroseed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" alt="Ferroseed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">597</span>
                             Ferroseed
@@ -6128,8 +6128,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="Ferrothorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="View Ferrothorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" alt="Ferrothorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">598</span>
                             Ferrothorn
@@ -6138,8 +6138,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="Klink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="View Klink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" alt="Klink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">599</span>
                             Klink
@@ -6148,8 +6148,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="Klang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="View Klang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" alt="Klang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">600</span>
                             Klang
@@ -6165,8 +6165,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="Klinklang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="View Klinklang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" alt="Klinklang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">601</span>
                             Klinklang
@@ -6175,8 +6175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tynamo/" title="Tynamo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/602.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tynamo/" title="View Tynamo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/602.png" alt="Tynamo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">602</span>
                             Tynamo
@@ -6185,8 +6185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eelektrik/" title="Eelektrik">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/603.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eelektrik/" title="View Eelektrik on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/603.png" alt="Eelektrik" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">603</span>
                             Eelektrik
@@ -6195,8 +6195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eelektross/" title="Eelektross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/604.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eelektross/" title="View Eelektross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/604.png" alt="Eelektross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">604</span>
                             Eelektross
@@ -6205,8 +6205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="Elgyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="View Elgyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" alt="Elgyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">605</span>
                             Elgyem
@@ -6215,8 +6215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="Beheeyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="View Beheeyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" alt="Beheeyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">606</span>
                             Beheeyem
@@ -6225,8 +6225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="Litwick">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="View Litwick on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" alt="Litwick" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">607</span>
                             Litwick
@@ -6235,8 +6235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="Lampent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="View Lampent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" alt="Lampent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">608</span>
                             Lampent
@@ -6245,8 +6245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="Chandelure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="View Chandelure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" alt="Chandelure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">609</span>
                             Chandelure
@@ -6255,8 +6255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="Axew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="View Axew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" alt="Axew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">610</span>
                             Axew
@@ -6265,8 +6265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="Fraxure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="View Fraxure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" alt="Fraxure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">611</span>
                             Fraxure
@@ -6275,8 +6275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="Haxorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="View Haxorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" alt="Haxorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">612</span>
                             Haxorus
@@ -6285,8 +6285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="Cubchoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="View Cubchoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" alt="Cubchoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">613</span>
                             Cubchoo
@@ -6295,8 +6295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="Beartic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="View Beartic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" alt="Beartic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">614</span>
                             Beartic
@@ -6305,8 +6305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cryogonal/" title="Cryogonal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/615.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cryogonal/" title="View Cryogonal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/615.png" alt="Cryogonal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">615</span>
                             Cryogonal
@@ -6315,8 +6315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="Shelmet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="View Shelmet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" alt="Shelmet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">616</span>
                             Shelmet
@@ -6325,8 +6325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="Accelgor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="View Accelgor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" alt="Accelgor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">617</span>
                             Accelgor
@@ -6335,8 +6335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="Stunfisk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="View Stunfisk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" alt="Stunfisk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">618</span>
                             Stunfisk
@@ -6345,8 +6345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="Mienfoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="View Mienfoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" alt="Mienfoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">619</span>
                             Mienfoo
@@ -6355,8 +6355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="Mienshao">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="View Mienshao on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" alt="Mienshao" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">620</span>
                             Mienshao
@@ -6365,8 +6365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="Druddigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="View Druddigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" alt="Druddigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">621</span>
                             Druddigon
@@ -6375,8 +6375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="Golett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="View Golett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" alt="Golett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">622</span>
                             Golett
@@ -6385,8 +6385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="Golurk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="View Golurk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" alt="Golurk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">623</span>
                             Golurk
@@ -6395,8 +6395,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="Pawniard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="View Pawniard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" alt="Pawniard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">624</span>
                             Pawniard
@@ -6405,8 +6405,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="Bisharp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="View Bisharp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" alt="Bisharp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">625</span>
                             Bisharp
@@ -6415,8 +6415,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="Bouffalant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="View Bouffalant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" alt="Bouffalant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">626</span>
                             Bouffalant
@@ -6425,8 +6425,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="Rufflet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="View Rufflet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" alt="Rufflet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">627</span>
                             Rufflet
@@ -6435,8 +6435,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="Braviary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="View Braviary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" alt="Braviary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">628</span>
                             Braviary
@@ -6445,8 +6445,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="Vullaby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="View Vullaby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" alt="Vullaby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">629</span>
                             Vullaby
@@ -6455,8 +6455,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="Mandibuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="View Mandibuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" alt="Mandibuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">630</span>
                             Mandibuzz
@@ -6472,8 +6472,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="Heatmor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="View Heatmor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" alt="Heatmor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">631</span>
                             Heatmor
@@ -6482,8 +6482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="Durant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="View Durant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" alt="Durant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">632</span>
                             Durant
@@ -6492,8 +6492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="Deino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="View Deino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" alt="Deino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">633</span>
                             Deino
@@ -6502,8 +6502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="Zweilous">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="View Zweilous on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" alt="Zweilous" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">634</span>
                             Zweilous
@@ -6512,8 +6512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="Hydreigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="View Hydreigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" alt="Hydreigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">635</span>
                             Hydreigon
@@ -6522,8 +6522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="Larvesta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="View Larvesta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" alt="Larvesta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">636</span>
                             Larvesta
@@ -6532,8 +6532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="Volcarona">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="View Volcarona on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" alt="Volcarona" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">637</span>
                             Volcarona
@@ -6542,8 +6542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cobalion/" title="Cobalion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/638.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cobalion/" title="View Cobalion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/638.png" alt="Cobalion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">638</span>
                             Cobalion
@@ -6552,8 +6552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/terrakion/" title="Terrakion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/639.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/terrakion/" title="View Terrakion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/639.png" alt="Terrakion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">639</span>
                             Terrakion
@@ -6562,8 +6562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/virizion/" title="Virizion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/640.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/virizion/" title="View Virizion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/640.png" alt="Virizion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">640</span>
                             Virizion
@@ -6572,8 +6572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tornadus/" title="Tornadus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/641.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tornadus/" title="View Tornadus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/641.png" alt="Tornadus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">641</span>
                             Tornadus
@@ -6582,8 +6582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/thundurus/" title="Thundurus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/642.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/thundurus/" title="View Thundurus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/642.png" alt="Thundurus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">642</span>
                             Thundurus
@@ -6592,8 +6592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/reshiram/" title="Reshiram">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/643.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/reshiram/" title="View Reshiram on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/643.png" alt="Reshiram" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">643</span>
                             Reshiram
@@ -6602,8 +6602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zekrom/" title="Zekrom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/644.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zekrom/" title="View Zekrom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/644.png" alt="Zekrom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">644</span>
                             Zekrom
@@ -6612,8 +6612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/landorus/" title="Landorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/645.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/landorus/" title="View Landorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/645.png" alt="Landorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">645</span>
                             Landorus
@@ -6622,8 +6622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyurem/" title="Kyurem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/646.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyurem/" title="View Kyurem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/646.png" alt="Kyurem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">646</span>
                             Kyurem
@@ -6632,8 +6632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/keldeo/" title="Keldeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/647.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/keldeo/" title="View Keldeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/647.png" alt="Keldeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">647</span>
                             Keldeo
@@ -6642,8 +6642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meloetta/" title="Meloetta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/648.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meloetta/" title="View Meloetta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/648.png" alt="Meloetta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">648</span>
                             Meloetta
@@ -6652,8 +6652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/genesect/" title="Genesect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/649.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/genesect/" title="View Genesect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/649.png" alt="Genesect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">649</span>
                             Genesect
@@ -6662,8 +6662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chespin/" title="Chespin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/650.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chespin/" title="View Chespin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/650.png" alt="Chespin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">650</span>
                             Chespin
@@ -6672,8 +6672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilladin/" title="Quilladin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/651.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilladin/" title="View Quilladin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/651.png" alt="Quilladin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">651</span>
                             Quilladin
@@ -6682,8 +6682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chesnaught/" title="Chesnaught">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/652.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chesnaught/" title="View Chesnaught on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/652.png" alt="Chesnaught" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">652</span>
                             Chesnaught
@@ -6692,8 +6692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fennekin/" title="Fennekin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/653.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fennekin/" title="View Fennekin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/653.png" alt="Fennekin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">653</span>
                             Fennekin
@@ -6702,8 +6702,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/braixen/" title="Braixen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/654.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/braixen/" title="View Braixen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/654.png" alt="Braixen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">654</span>
                             Braixen
@@ -6712,8 +6712,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delphox/" title="Delphox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/655.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delphox/" title="View Delphox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/655.png" alt="Delphox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">655</span>
                             Delphox
@@ -6722,8 +6722,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froakie/" title="Froakie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/656.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froakie/" title="View Froakie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/656.png" alt="Froakie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">656</span>
                             Froakie
@@ -6732,8 +6732,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frogadier/" title="Frogadier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/657.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frogadier/" title="View Frogadier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/657.png" alt="Frogadier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">657</span>
                             Frogadier
@@ -6742,8 +6742,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/greninja/" title="Greninja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/658.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/greninja/" title="View Greninja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/658.png" alt="Greninja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">658</span>
                             Greninja
@@ -6752,8 +6752,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bunnelby/" title="Bunnelby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/659.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bunnelby/" title="View Bunnelby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/659.png" alt="Bunnelby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">659</span>
                             Bunnelby
@@ -6762,8 +6762,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diggersby/" title="Diggersby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/660.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diggersby/" title="View Diggersby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/660.png" alt="Diggersby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">660</span>
                             Diggersby
@@ -6779,8 +6779,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fletchling/" title="Fletchling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/661.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fletchling/" title="View Fletchling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/661.png" alt="Fletchling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">661</span>
                             Fletchling
@@ -6789,8 +6789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fletchinder/" title="Fletchinder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/662.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fletchinder/" title="View Fletchinder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/662.png" alt="Fletchinder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">662</span>
                             Fletchinder
@@ -6799,8 +6799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/talonflame/" title="Talonflame">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/663.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/talonflame/" title="View Talonflame on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/663.png" alt="Talonflame" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">663</span>
                             Talonflame
@@ -6809,8 +6809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scatterbug/" title="Scatterbug">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/664.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scatterbug/" title="View Scatterbug on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/664.png" alt="Scatterbug" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">664</span>
                             Scatterbug
@@ -6819,8 +6819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spewpa/" title="Spewpa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/665.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spewpa/" title="View Spewpa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/665.png" alt="Spewpa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">665</span>
                             Spewpa
@@ -6829,8 +6829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vivillon/" title="Vivillon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/666.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vivillon/" title="View Vivillon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/666.png" alt="Vivillon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">666</span>
                             Vivillon
@@ -6839,8 +6839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litleo/" title="Litleo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/667.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litleo/" title="View Litleo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/667.png" alt="Litleo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">667</span>
                             Litleo
@@ -6849,8 +6849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pyroar/" title="Pyroar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/668.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pyroar/" title="View Pyroar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/668.png" alt="Pyroar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">668</span>
                             Pyroar
@@ -6859,8 +6859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flabebe/" title="Flabébé">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/669.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flabebe/" title="View Flabébé on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/669.png" alt="Flabébé" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">669</span>
                             Flabébé
@@ -6869,8 +6869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/floette/" title="Floette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/670.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/floette/" title="View Floette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/670.png" alt="Floette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">670</span>
                             Floette
@@ -6879,8 +6879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/florges/" title="Florges">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/671.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/florges/" title="View Florges on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/671.png" alt="Florges" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">671</span>
                             Florges
@@ -6889,8 +6889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiddo/" title="Skiddo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/672.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiddo/" title="View Skiddo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/672.png" alt="Skiddo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">672</span>
                             Skiddo
@@ -6899,8 +6899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gogoat/" title="Gogoat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/673.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gogoat/" title="View Gogoat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/673.png" alt="Gogoat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">673</span>
                             Gogoat
@@ -6909,8 +6909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pancham/" title="Pancham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/674.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pancham/" title="View Pancham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/674.png" alt="Pancham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">674</span>
                             Pancham
@@ -6919,8 +6919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pangoro/" title="Pangoro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/675.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pangoro/" title="View Pangoro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/675.png" alt="Pangoro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">675</span>
                             Pangoro
@@ -6929,8 +6929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furfrou/" title="Furfrou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/676.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furfrou/" title="View Furfrou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/676.png" alt="Furfrou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">676</span>
                             Furfrou
@@ -6939,8 +6939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espurr/" title="Espurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/677.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espurr/" title="View Espurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/677.png" alt="Espurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">677</span>
                             Espurr
@@ -6949,8 +6949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowstic/" title="Meowstic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/678.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowstic/" title="View Meowstic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/678.png" alt="Meowstic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">678</span>
                             Meowstic
@@ -6959,8 +6959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honedge/" title="Honedge">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/679.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honedge/" title="View Honedge on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/679.png" alt="Honedge" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">679</span>
                             Honedge
@@ -6969,8 +6969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doublade/" title="Doublade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/680.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doublade/" title="View Doublade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/680.png" alt="Doublade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">680</span>
                             Doublade
@@ -6979,8 +6979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aegislash/" title="Aegislash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/681.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aegislash/" title="View Aegislash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/681.png" alt="Aegislash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">681</span>
                             Aegislash
@@ -6989,8 +6989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spritzee/" title="Spritzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/682.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spritzee/" title="View Spritzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/682.png" alt="Spritzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">682</span>
                             Spritzee
@@ -6999,8 +6999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aromatisse/" title="Aromatisse">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/683.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aromatisse/" title="View Aromatisse on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/683.png" alt="Aromatisse" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">683</span>
                             Aromatisse
@@ -7009,8 +7009,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swirlix/" title="Swirlix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/684.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swirlix/" title="View Swirlix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/684.png" alt="Swirlix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">684</span>
                             Swirlix
@@ -7019,8 +7019,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slurpuff/" title="Slurpuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/685.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slurpuff/" title="View Slurpuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/685.png" alt="Slurpuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">685</span>
                             Slurpuff
@@ -7029,8 +7029,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="Inkay">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="View Inkay on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" alt="Inkay" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">686</span>
                             Inkay
@@ -7039,8 +7039,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="Malamar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="View Malamar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" alt="Malamar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">687</span>
                             Malamar
@@ -7049,8 +7049,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/binacle/" title="Binacle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/688.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/binacle/" title="View Binacle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/688.png" alt="Binacle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">688</span>
                             Binacle
@@ -7059,8 +7059,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barbaracle/" title="Barbaracle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/689.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barbaracle/" title="View Barbaracle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/689.png" alt="Barbaracle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">689</span>
                             Barbaracle
@@ -7069,8 +7069,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skrelp/" title="Skrelp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/690.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skrelp/" title="View Skrelp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/690.png" alt="Skrelp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">690</span>
                             Skrelp
@@ -7086,8 +7086,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragalge/" title="Dragalge">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/691.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragalge/" title="View Dragalge on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/691.png" alt="Dragalge" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">691</span>
                             Dragalge
@@ -7096,8 +7096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clauncher/" title="Clauncher">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/692.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clauncher/" title="View Clauncher on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/692.png" alt="Clauncher" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">692</span>
                             Clauncher
@@ -7106,8 +7106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clawitzer/" title="Clawitzer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/693.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clawitzer/" title="View Clawitzer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/693.png" alt="Clawitzer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">693</span>
                             Clawitzer
@@ -7116,8 +7116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/helioptile/" title="Helioptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/694.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/helioptile/" title="View Helioptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/694.png" alt="Helioptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">694</span>
                             Helioptile
@@ -7126,8 +7126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heliolisk/" title="Heliolisk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/695.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heliolisk/" title="View Heliolisk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/695.png" alt="Heliolisk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">695</span>
                             Heliolisk
@@ -7136,8 +7136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrunt/" title="Tyrunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/696.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrunt/" title="View Tyrunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/696.png" alt="Tyrunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">696</span>
                             Tyrunt
@@ -7146,8 +7146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrantrum/" title="Tyrantrum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/697.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrantrum/" title="View Tyrantrum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/697.png" alt="Tyrantrum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">697</span>
                             Tyrantrum
@@ -7156,8 +7156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/amaura/" title="Amaura">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/698.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/amaura/" title="View Amaura on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/698.png" alt="Amaura" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">698</span>
                             Amaura
@@ -7166,8 +7166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aurorus/" title="Aurorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/699.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aurorus/" title="View Aurorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/699.png" alt="Aurorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">699</span>
                             Aurorus
@@ -7176,8 +7176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sylveon/" title="Sylveon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/700.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sylveon/" title="View Sylveon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/700.png" alt="Sylveon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">700</span>
                             Sylveon
@@ -7186,8 +7186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hawlucha/" title="Hawlucha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/701.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hawlucha/" title="View Hawlucha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/701.png" alt="Hawlucha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">701</span>
                             Hawlucha
@@ -7196,8 +7196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dedenne/" title="Dedenne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/702.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dedenne/" title="View Dedenne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/702.png" alt="Dedenne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">702</span>
                             Dedenne
@@ -7206,8 +7206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carbink/" title="Carbink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/703.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carbink/" title="View Carbink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/703.png" alt="Carbink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">703</span>
                             Carbink
@@ -7216,8 +7216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="Goomy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="View Goomy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" alt="Goomy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">704</span>
                             Goomy
@@ -7226,8 +7226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="Sliggoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="View Sliggoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" alt="Sliggoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">705</span>
                             Sliggoo
@@ -7236,8 +7236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="Goodra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="View Goodra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" alt="Goodra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">706</span>
                             Goodra
@@ -7246,8 +7246,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klefki/" title="Klefki">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/707.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klefki/" title="View Klefki on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/707.png" alt="Klefki" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">707</span>
                             Klefki
@@ -7256,8 +7256,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phantump/" title="Phantump">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/708.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phantump/" title="View Phantump on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/708.png" alt="Phantump" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">708</span>
                             Phantump
@@ -7266,8 +7266,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trevenant/" title="Trevenant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/709.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trevenant/" title="View Trevenant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/709.png" alt="Trevenant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">709</span>
                             Trevenant
@@ -7276,8 +7276,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pumpkaboo/" title="Pumpkaboo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/710.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pumpkaboo/" title="View Pumpkaboo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/710.png" alt="Pumpkaboo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">710</span>
                             Pumpkaboo
@@ -7286,8 +7286,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gourgeist/" title="Gourgeist">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/711.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gourgeist/" title="View Gourgeist on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/711.png" alt="Gourgeist" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">711</span>
                             Gourgeist
@@ -7296,8 +7296,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bergmite/" title="Bergmite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/712.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bergmite/" title="View Bergmite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/712.png" alt="Bergmite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">712</span>
                             Bergmite
@@ -7306,8 +7306,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/avalugg/" title="Avalugg">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/713.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/avalugg/" title="View Avalugg on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/713.png" alt="Avalugg" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">713</span>
                             Avalugg
@@ -7316,8 +7316,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noibat/" title="Noibat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/714.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noibat/" title="View Noibat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/714.png" alt="Noibat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">714</span>
                             Noibat
@@ -7326,8 +7326,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noivern/" title="Noivern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/715.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noivern/" title="View Noivern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/715.png" alt="Noivern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">715</span>
                             Noivern
@@ -7336,8 +7336,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xerneas/" title="Xerneas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/716.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xerneas/" title="View Xerneas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/716.png" alt="Xerneas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">716</span>
                             Xerneas
@@ -7346,8 +7346,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yveltal/" title="Yveltal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/717.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yveltal/" title="View Yveltal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/717.png" alt="Yveltal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">717</span>
                             Yveltal
@@ -7356,8 +7356,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zygarde/" title="Zygarde">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/718.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zygarde/" title="View Zygarde on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/718.png" alt="Zygarde" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">718</span>
                             Zygarde
@@ -7366,8 +7366,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diancie/" title="Diancie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/719.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diancie/" title="View Diancie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/719.png" alt="Diancie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">719</span>
                             Diancie
@@ -7376,8 +7376,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoopa/" title="Hoopa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/720.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoopa/" title="View Hoopa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/720.png" alt="Hoopa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">720</span>
                             Hoopa
@@ -7393,8 +7393,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volcanion/" title="Volcanion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/721.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volcanion/" title="View Volcanion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/721.png" alt="Volcanion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">721</span>
                             Volcanion
@@ -7403,8 +7403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rowlet/" title="Rowlet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/722.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rowlet/" title="View Rowlet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/722.png" alt="Rowlet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">722</span>
                             Rowlet
@@ -7413,8 +7413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dartrix/" title="Dartrix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/723.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dartrix/" title="View Dartrix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/723.png" alt="Dartrix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">723</span>
                             Dartrix
@@ -7423,8 +7423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/decidueye/" title="Decidueye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/724.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/decidueye/" title="View Decidueye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/724.png" alt="Decidueye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">724</span>
                             Decidueye
@@ -7433,8 +7433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litten/" title="Litten">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/725.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litten/" title="View Litten on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/725.png" alt="Litten" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">725</span>
                             Litten
@@ -7443,8 +7443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torracat/" title="Torracat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/726.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torracat/" title="View Torracat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/726.png" alt="Torracat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">726</span>
                             Torracat
@@ -7453,8 +7453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/incineroar/" title="Incineroar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/727.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/incineroar/" title="View Incineroar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/727.png" alt="Incineroar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">727</span>
                             Incineroar
@@ -7463,8 +7463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/popplio/" title="Popplio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/728.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/popplio/" title="View Popplio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/728.png" alt="Popplio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">728</span>
                             Popplio
@@ -7473,8 +7473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/brionne/" title="Brionne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/729.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/brionne/" title="View Brionne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/729.png" alt="Brionne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">729</span>
                             Brionne
@@ -7483,8 +7483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primarina/" title="Primarina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/730.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primarina/" title="View Primarina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/730.png" alt="Primarina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">730</span>
                             Primarina
@@ -7493,8 +7493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikipek/" title="Pikipek">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/731.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikipek/" title="View Pikipek on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/731.png" alt="Pikipek" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">731</span>
                             Pikipek
@@ -7503,8 +7503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trumbeak/" title="Trumbeak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/732.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trumbeak/" title="View Trumbeak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/732.png" alt="Trumbeak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">732</span>
                             Trumbeak
@@ -7513,8 +7513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toucannon/" title="Toucannon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/733.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toucannon/" title="View Toucannon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/733.png" alt="Toucannon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">733</span>
                             Toucannon
@@ -7523,8 +7523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yungoos/" title="Yungoos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/734.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yungoos/" title="View Yungoos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/734.png" alt="Yungoos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">734</span>
                             Yungoos
@@ -7533,8 +7533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gumshoos/" title="Gumshoos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/735.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gumshoos/" title="View Gumshoos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/735.png" alt="Gumshoos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">735</span>
                             Gumshoos
@@ -7543,8 +7543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grubbin/" title="Grubbin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/736.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grubbin/" title="View Grubbin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/736.png" alt="Grubbin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">736</span>
                             Grubbin
@@ -7553,8 +7553,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charjabug/" title="Charjabug">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/737.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charjabug/" title="View Charjabug on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/737.png" alt="Charjabug" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">737</span>
                             Charjabug
@@ -7563,8 +7563,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vikavolt/" title="Vikavolt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/738.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vikavolt/" title="View Vikavolt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/738.png" alt="Vikavolt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">738</span>
                             Vikavolt
@@ -7573,8 +7573,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crabrawler/" title="Crabrawler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/739.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crabrawler/" title="View Crabrawler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/739.png" alt="Crabrawler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">739</span>
                             Crabrawler
@@ -7583,8 +7583,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crabominable/" title="Crabominable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/740.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crabominable/" title="View Crabominable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/740.png" alt="Crabominable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">740</span>
                             Crabominable
@@ -7593,8 +7593,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oricorio/" title="Oricorio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/741.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oricorio/" title="View Oricorio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/741.png" alt="Oricorio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">741</span>
                             Oricorio
@@ -7603,8 +7603,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cutiefly/" title="Cutiefly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/742.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cutiefly/" title="View Cutiefly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/742.png" alt="Cutiefly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">742</span>
                             Cutiefly
@@ -7613,8 +7613,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ribombee/" title="Ribombee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/743.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ribombee/" title="View Ribombee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/743.png" alt="Ribombee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">743</span>
                             Ribombee
@@ -7623,8 +7623,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rockruff/" title="Rockruff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/744.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rockruff/" title="View Rockruff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/744.png" alt="Rockruff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">744</span>
                             Rockruff
@@ -7633,8 +7633,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lycanroc/" title="Lycanroc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/745.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lycanroc/" title="View Lycanroc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/745.png" alt="Lycanroc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">745</span>
                             Lycanroc
@@ -7643,8 +7643,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wishiwashi/" title="Wishiwashi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/746.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wishiwashi/" title="View Wishiwashi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/746.png" alt="Wishiwashi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">746</span>
                             Wishiwashi
@@ -7653,8 +7653,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareanie/" title="Mareanie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/747.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareanie/" title="View Mareanie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/747.png" alt="Mareanie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">747</span>
                             Mareanie
@@ -7663,8 +7663,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxapex/" title="Toxapex">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/748.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxapex/" title="View Toxapex on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/748.png" alt="Toxapex" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">748</span>
                             Toxapex
@@ -7673,8 +7673,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudbray/" title="Mudbray">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/749.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudbray/" title="View Mudbray on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/749.png" alt="Mudbray" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">749</span>
                             Mudbray
@@ -7683,8 +7683,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudsdale/" title="Mudsdale">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/750.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudsdale/" title="View Mudsdale on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/750.png" alt="Mudsdale" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">750</span>
                             Mudsdale
@@ -7700,8 +7700,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewpider/" title="Dewpider">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/751.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewpider/" title="View Dewpider on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/751.png" alt="Dewpider" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">751</span>
                             Dewpider
@@ -7710,8 +7710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/araquanid/" title="Araquanid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/752.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/araquanid/" title="View Araquanid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/752.png" alt="Araquanid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">752</span>
                             Araquanid
@@ -7720,8 +7720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fomantis/" title="Fomantis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/753.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fomantis/" title="View Fomantis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/753.png" alt="Fomantis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">753</span>
                             Fomantis
@@ -7730,8 +7730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lurantis/" title="Lurantis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/754.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lurantis/" title="View Lurantis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/754.png" alt="Lurantis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">754</span>
                             Lurantis
@@ -7740,8 +7740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/morelull/" title="Morelull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/755.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/morelull/" title="View Morelull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/755.png" alt="Morelull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">755</span>
                             Morelull
@@ -7750,8 +7750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiinotic/" title="Shiinotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/756.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiinotic/" title="View Shiinotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/756.png" alt="Shiinotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">756</span>
                             Shiinotic
@@ -7760,8 +7760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salandit/" title="Salandit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/757.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salandit/" title="View Salandit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/757.png" alt="Salandit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">757</span>
                             Salandit
@@ -7770,8 +7770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salazzle/" title="Salazzle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/758.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salazzle/" title="View Salazzle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/758.png" alt="Salazzle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">758</span>
                             Salazzle
@@ -7780,8 +7780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stufful/" title="Stufful">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/759.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stufful/" title="View Stufful on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/759.png" alt="Stufful" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">759</span>
                             Stufful
@@ -7790,8 +7790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bewear/" title="Bewear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/760.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bewear/" title="View Bewear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/760.png" alt="Bewear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">760</span>
                             Bewear
@@ -7800,8 +7800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bounsweet/" title="Bounsweet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/761.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bounsweet/" title="View Bounsweet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/761.png" alt="Bounsweet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">761</span>
                             Bounsweet
@@ -7810,8 +7810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steenee/" title="Steenee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/762.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steenee/" title="View Steenee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/762.png" alt="Steenee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">762</span>
                             Steenee
@@ -7820,8 +7820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tsareena/" title="Tsareena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/763.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tsareena/" title="View Tsareena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/763.png" alt="Tsareena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">763</span>
                             Tsareena
@@ -7830,8 +7830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/comfey/" title="Comfey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/764.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/comfey/" title="View Comfey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/764.png" alt="Comfey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">764</span>
                             Comfey
@@ -7840,8 +7840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oranguru/" title="Oranguru">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/765.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oranguru/" title="View Oranguru on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/765.png" alt="Oranguru" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">765</span>
                             Oranguru
@@ -7850,8 +7850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/passimian/" title="Passimian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/766.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/passimian/" title="View Passimian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/766.png" alt="Passimian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">766</span>
                             Passimian
@@ -7860,8 +7860,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wimpod/" title="Wimpod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/767.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wimpod/" title="View Wimpod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/767.png" alt="Wimpod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">767</span>
                             Wimpod
@@ -7870,8 +7870,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golisopod/" title="Golisopod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/768.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golisopod/" title="View Golisopod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/768.png" alt="Golisopod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">768</span>
                             Golisopod
@@ -7880,8 +7880,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandygast/" title="Sandygast">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/769.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandygast/" title="View Sandygast on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/769.png" alt="Sandygast" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">769</span>
                             Sandygast
@@ -7890,8 +7890,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palossand/" title="Palossand">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/770.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palossand/" title="View Palossand on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/770.png" alt="Palossand" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">770</span>
                             Palossand
@@ -7900,8 +7900,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pyukumuku/" title="Pyukumuku">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/771.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pyukumuku/" title="View Pyukumuku on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/771.png" alt="Pyukumuku" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">771</span>
                             Pyukumuku
@@ -7910,8 +7910,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/type-null/" title="Type: Null">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/772.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/type-null/" title="View Type: Null on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/772.png" alt="Type: Null" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">772</span>
                             Type: Null
@@ -7920,8 +7920,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silvally/" title="Silvally">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/773.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silvally/" title="View Silvally on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/773.png" alt="Silvally" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">773</span>
                             Silvally
@@ -7930,8 +7930,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minior/" title="Minior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/774.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minior/" title="View Minior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/774.png" alt="Minior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">774</span>
                             Minior
@@ -7940,8 +7940,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/komala/" title="Komala">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/775.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/komala/" title="View Komala on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/775.png" alt="Komala" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">775</span>
                             Komala
@@ -7950,8 +7950,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/turtonator/" title="Turtonator">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/776.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/turtonator/" title="View Turtonator on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/776.png" alt="Turtonator" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">776</span>
                             Turtonator
@@ -7960,8 +7960,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togedemaru/" title="Togedemaru">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/777.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togedemaru/" title="View Togedemaru on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/777.png" alt="Togedemaru" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">777</span>
                             Togedemaru
@@ -7970,8 +7970,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mimikyu/" title="Mimikyu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/778.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mimikyu/" title="View Mimikyu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/778.png" alt="Mimikyu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">778</span>
                             Mimikyu
@@ -7980,8 +7980,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bruxish/" title="Bruxish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/779.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bruxish/" title="View Bruxish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/779.png" alt="Bruxish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">779</span>
                             Bruxish
@@ -7990,8 +7990,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drampa/" title="Drampa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/780.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drampa/" title="View Drampa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/780.png" alt="Drampa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">780</span>
                             Drampa
@@ -8007,8 +8007,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dhelmise/" title="Dhelmise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/781.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dhelmise/" title="View Dhelmise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/781.png" alt="Dhelmise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">781</span>
                             Dhelmise
@@ -8017,8 +8017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jangmo-o/" title="Jangmo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/782.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jangmo-o/" title="View Jangmo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/782.png" alt="Jangmo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">782</span>
                             Jangmo-o
@@ -8027,8 +8027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hakamo-o/" title="Hakamo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/783.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hakamo-o/" title="View Hakamo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/783.png" alt="Hakamo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">783</span>
                             Hakamo-o
@@ -8037,8 +8037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kommo-o/" title="Kommo-o">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/784.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kommo-o/" title="View Kommo-o on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/784.png" alt="Kommo-o" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">784</span>
                             Kommo-o
@@ -8047,8 +8047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tapu-koko/" title="Tapu Koko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/785.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tapu-koko/" title="View Tapu Koko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/785.png" alt="Tapu Koko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">785</span>
                             Tapu Koko
@@ -8057,8 +8057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tapu-lele/" title="Tapu Lele">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/786.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tapu-lele/" title="View Tapu Lele on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/786.png" alt="Tapu Lele" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">786</span>
                             Tapu Lele
@@ -8067,8 +8067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tapu-bulu/" title="Tapu Bulu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/787.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tapu-bulu/" title="View Tapu Bulu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/787.png" alt="Tapu Bulu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">787</span>
                             Tapu Bulu
@@ -8077,8 +8077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tapu-fini/" title="Tapu Fini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/788.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tapu-fini/" title="View Tapu Fini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/788.png" alt="Tapu Fini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">788</span>
                             Tapu Fini
@@ -8087,8 +8087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cosmog/" title="Cosmog">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/789.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cosmog/" title="View Cosmog on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/789.png" alt="Cosmog" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">789</span>
                             Cosmog
@@ -8097,8 +8097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cosmoem/" title="Cosmoem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/790.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cosmoem/" title="View Cosmoem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/790.png" alt="Cosmoem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">790</span>
                             Cosmoem
@@ -8107,8 +8107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solgaleo/" title="Solgaleo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/791.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solgaleo/" title="View Solgaleo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/791.png" alt="Solgaleo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">791</span>
                             Solgaleo
@@ -8117,8 +8117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunala/" title="Lunala">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/792.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunala/" title="View Lunala on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/792.png" alt="Lunala" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">792</span>
                             Lunala
@@ -8127,8 +8127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nihilego/" title="Nihilego">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/793.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nihilego/" title="View Nihilego on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/793.png" alt="Nihilego" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">793</span>
                             Nihilego
@@ -8137,8 +8137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buzzwole/" title="Buzzwole">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/794.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buzzwole/" title="View Buzzwole on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/794.png" alt="Buzzwole" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">794</span>
                             Buzzwole
@@ -8147,8 +8147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pheromosa/" title="Pheromosa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/795.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pheromosa/" title="View Pheromosa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/795.png" alt="Pheromosa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">795</span>
                             Pheromosa
@@ -8157,8 +8157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xurkitree/" title="Xurkitree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/796.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xurkitree/" title="View Xurkitree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/796.png" alt="Xurkitree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">796</span>
                             Xurkitree
@@ -8167,8 +8167,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celesteela/" title="Celesteela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/797.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celesteela/" title="View Celesteela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/797.png" alt="Celesteela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">797</span>
                             Celesteela
@@ -8177,8 +8177,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kartana/" title="Kartana">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/798.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kartana/" title="View Kartana on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/798.png" alt="Kartana" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">798</span>
                             Kartana
@@ -8187,8 +8187,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/guzzlord/" title="Guzzlord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/799.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/guzzlord/" title="View Guzzlord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/799.png" alt="Guzzlord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">799</span>
                             Guzzlord
@@ -8197,8 +8197,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/necrozma/" title="Necrozma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/800.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/necrozma/" title="View Necrozma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/800.png" alt="Necrozma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">800</span>
                             Necrozma
@@ -8207,8 +8207,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magearna/" title="Magearna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/801.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magearna/" title="View Magearna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/801.png" alt="Magearna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">801</span>
                             Magearna
@@ -8217,8 +8217,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marshadow/" title="Marshadow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/802.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marshadow/" title="View Marshadow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/802.png" alt="Marshadow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">802</span>
                             Marshadow
@@ -8227,8 +8227,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poipole/" title="Poipole">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/803.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poipole/" title="View Poipole on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/803.png" alt="Poipole" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">803</span>
                             Poipole
@@ -8237,8 +8237,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/naganadel/" title="Naganadel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/804.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/naganadel/" title="View Naganadel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/804.png" alt="Naganadel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">804</span>
                             Naganadel
@@ -8247,8 +8247,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stakataka/" title="Stakataka">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/805.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stakataka/" title="View Stakataka on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/805.png" alt="Stakataka" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">805</span>
                             Stakataka
@@ -8257,8 +8257,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blacephalon/" title="Blacephalon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/806.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blacephalon/" title="View Blacephalon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/806.png" alt="Blacephalon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">806</span>
                             Blacephalon
@@ -8267,8 +8267,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zeraora/" title="Zeraora">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/807.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zeraora/" title="View Zeraora on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/807.png" alt="Zeraora" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">807</span>
                             Zeraora
@@ -8282,8 +8282,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/docs/x-y.html
+++ b/docs/x-y.html
@@ -25,8 +25,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="Bulbasaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bulbasaur/" title="View Bulbasaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/001.png" alt="Bulbasaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">1</span>
                             Bulbasaur
@@ -35,8 +35,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="Ivysaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ivysaur/" title="View Ivysaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/002.png" alt="Ivysaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">2</span>
                             Ivysaur
@@ -45,8 +45,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="Venusaur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venusaur/" title="View Venusaur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/003.png" alt="Venusaur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">3</span>
                             Venusaur
@@ -55,8 +55,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="Charmander">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmander/" title="View Charmander on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/004.png" alt="Charmander" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">4</span>
                             Charmander
@@ -65,8 +65,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="Charmeleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charmeleon/" title="View Charmeleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/005.png" alt="Charmeleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">5</span>
                             Charmeleon
@@ -75,8 +75,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="Charizard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/charizard/" title="View Charizard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/006.png" alt="Charizard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">6</span>
                             Charizard
@@ -85,8 +85,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="Squirtle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/squirtle/" title="View Squirtle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/007.png" alt="Squirtle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">7</span>
                             Squirtle
@@ -95,8 +95,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="Wartortle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wartortle/" title="View Wartortle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/008.png" alt="Wartortle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">8</span>
                             Wartortle
@@ -105,8 +105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="Blastoise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blastoise/" title="View Blastoise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/009.png" alt="Blastoise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">9</span>
                             Blastoise
@@ -115,8 +115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="Caterpie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/caterpie/" title="View Caterpie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/010.png" alt="Caterpie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">10</span>
                             Caterpie
@@ -125,8 +125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="Metapod">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metapod/" title="View Metapod on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/011.png" alt="Metapod" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">11</span>
                             Metapod
@@ -135,8 +135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="Butterfree">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/butterfree/" title="View Butterfree on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/012.png" alt="Butterfree" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">12</span>
                             Butterfree
@@ -145,8 +145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="Weedle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weedle/" title="View Weedle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/013.png" alt="Weedle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">13</span>
                             Weedle
@@ -155,8 +155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="Kakuna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kakuna/" title="View Kakuna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/014.png" alt="Kakuna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">14</span>
                             Kakuna
@@ -165,8 +165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="Beedrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beedrill/" title="View Beedrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/015.png" alt="Beedrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">15</span>
                             Beedrill
@@ -175,8 +175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="Pidgey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgey/" title="View Pidgey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/016.png" alt="Pidgey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">16</span>
                             Pidgey
@@ -185,8 +185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="Pidgeotto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeotto/" title="View Pidgeotto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/017.png" alt="Pidgeotto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">17</span>
                             Pidgeotto
@@ -195,8 +195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="Pidgeot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidgeot/" title="View Pidgeot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/018.png" alt="Pidgeot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">18</span>
                             Pidgeot
@@ -205,8 +205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="Rattata">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rattata/" title="View Rattata on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/019.png" alt="Rattata" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">19</span>
                             Rattata
@@ -215,8 +215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="Raticate">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raticate/" title="View Raticate on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/020.png" alt="Raticate" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">20</span>
                             Raticate
@@ -225,8 +225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="Spearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spearow/" title="View Spearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/021.png" alt="Spearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">21</span>
                             Spearow
@@ -235,8 +235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="Fearow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fearow/" title="View Fearow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/022.png" alt="Fearow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">22</span>
                             Fearow
@@ -245,8 +245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="Ekans">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ekans/" title="View Ekans on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/023.png" alt="Ekans" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">23</span>
                             Ekans
@@ -255,8 +255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="Arbok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arbok/" title="View Arbok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/024.png" alt="Arbok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">24</span>
                             Arbok
@@ -265,8 +265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="Pikachu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pikachu/" title="View Pikachu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/025.png" alt="Pikachu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">25</span>
                             Pikachu
@@ -275,8 +275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="Raichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raichu/" title="View Raichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/026.png" alt="Raichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">26</span>
                             Raichu
@@ -285,8 +285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="Sandshrew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandshrew/" title="View Sandshrew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/027.png" alt="Sandshrew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">27</span>
                             Sandshrew
@@ -295,8 +295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="Sandslash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandslash/" title="View Sandslash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/028.png" alt="Sandslash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">28</span>
                             Sandslash
@@ -305,8 +305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="Nidoran♀">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-f/" title="View Nidoran♀ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/029.png" alt="Nidoran♀" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">29</span>
                             Nidoran♀
@@ -315,8 +315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="Nidorina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorina/" title="View Nidorina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/030.png" alt="Nidorina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">30</span>
                             Nidorina
@@ -332,8 +332,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="Nidoqueen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoqueen/" title="View Nidoqueen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/031.png" alt="Nidoqueen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">31</span>
                             Nidoqueen
@@ -342,8 +342,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="Nidoran♂">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoran-m/" title="View Nidoran♂ on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/032.png" alt="Nidoran♂" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">32</span>
                             Nidoran♂
@@ -352,8 +352,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="Nidorino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidorino/" title="View Nidorino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/033.png" alt="Nidorino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">33</span>
                             Nidorino
@@ -362,8 +362,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="Nidoking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nidoking/" title="View Nidoking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/034.png" alt="Nidoking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">34</span>
                             Nidoking
@@ -372,8 +372,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="Clefairy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefairy/" title="View Clefairy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/035.png" alt="Clefairy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">35</span>
                             Clefairy
@@ -382,8 +382,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="Clefable">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clefable/" title="View Clefable on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/036.png" alt="Clefable" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">36</span>
                             Clefable
@@ -392,8 +392,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="Vulpix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vulpix/" title="View Vulpix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/037.png" alt="Vulpix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">37</span>
                             Vulpix
@@ -402,8 +402,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="Ninetales">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninetales/" title="View Ninetales on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/038.png" alt="Ninetales" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">38</span>
                             Ninetales
@@ -412,8 +412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="Jigglypuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jigglypuff/" title="View Jigglypuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/039.png" alt="Jigglypuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">39</span>
                             Jigglypuff
@@ -422,8 +422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="Wigglytuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wigglytuff/" title="View Wigglytuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/040.png" alt="Wigglytuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">40</span>
                             Wigglytuff
@@ -432,8 +432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="Zubat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zubat/" title="View Zubat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/041.png" alt="Zubat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">41</span>
                             Zubat
@@ -442,8 +442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="Golbat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golbat/" title="View Golbat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/042.png" alt="Golbat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">42</span>
                             Golbat
@@ -452,8 +452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="Oddish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oddish/" title="View Oddish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/043.png" alt="Oddish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">43</span>
                             Oddish
@@ -462,8 +462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="Gloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gloom/" title="View Gloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/044.png" alt="Gloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">44</span>
                             Gloom
@@ -472,8 +472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="Vileplume">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vileplume/" title="View Vileplume on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/045.png" alt="Vileplume" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">45</span>
                             Vileplume
@@ -482,8 +482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="Paras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/paras/" title="View Paras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/046.png" alt="Paras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">46</span>
                             Paras
@@ -492,8 +492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="Parasect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/parasect/" title="View Parasect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/047.png" alt="Parasect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">47</span>
                             Parasect
@@ -502,8 +502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="Venonat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venonat/" title="View Venonat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/048.png" alt="Venonat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">48</span>
                             Venonat
@@ -512,8 +512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="Venomoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venomoth/" title="View Venomoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/049.png" alt="Venomoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">49</span>
                             Venomoth
@@ -522,8 +522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="Diglett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diglett/" title="View Diglett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/050.png" alt="Diglett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">50</span>
                             Diglett
@@ -532,8 +532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="Dugtrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dugtrio/" title="View Dugtrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/051.png" alt="Dugtrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">51</span>
                             Dugtrio
@@ -542,8 +542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="Meowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowth/" title="View Meowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/052.png" alt="Meowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">52</span>
                             Meowth
@@ -552,8 +552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="Persian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/persian/" title="View Persian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/053.png" alt="Persian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">53</span>
                             Persian
@@ -562,8 +562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="Psyduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/psyduck/" title="View Psyduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/054.png" alt="Psyduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">54</span>
                             Psyduck
@@ -572,8 +572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="Golduck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golduck/" title="View Golduck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/055.png" alt="Golduck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">55</span>
                             Golduck
@@ -582,8 +582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="Mankey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mankey/" title="View Mankey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/056.png" alt="Mankey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">56</span>
                             Mankey
@@ -592,8 +592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="Primeape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/primeape/" title="View Primeape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/057.png" alt="Primeape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">57</span>
                             Primeape
@@ -602,8 +602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="Growlithe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/growlithe/" title="View Growlithe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/058.png" alt="Growlithe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">58</span>
                             Growlithe
@@ -612,8 +612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="Arcanine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arcanine/" title="View Arcanine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/059.png" alt="Arcanine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">59</span>
                             Arcanine
@@ -622,8 +622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="Poliwag">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwag/" title="View Poliwag on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/060.png" alt="Poliwag" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">60</span>
                             Poliwag
@@ -639,8 +639,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="Poliwhirl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwhirl/" title="View Poliwhirl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/061.png" alt="Poliwhirl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">61</span>
                             Poliwhirl
@@ -649,8 +649,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="Poliwrath">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poliwrath/" title="View Poliwrath on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/062.png" alt="Poliwrath" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">62</span>
                             Poliwrath
@@ -659,8 +659,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="Abra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abra/" title="View Abra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/063.png" alt="Abra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">63</span>
                             Abra
@@ -669,8 +669,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="Kadabra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kadabra/" title="View Kadabra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/064.png" alt="Kadabra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">64</span>
                             Kadabra
@@ -679,8 +679,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="Alakazam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alakazam/" title="View Alakazam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/065.png" alt="Alakazam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">65</span>
                             Alakazam
@@ -689,8 +689,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="Machop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machop/" title="View Machop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/066.png" alt="Machop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">66</span>
                             Machop
@@ -699,8 +699,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="Machoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machoke/" title="View Machoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/067.png" alt="Machoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">67</span>
                             Machoke
@@ -709,8 +709,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="Machamp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/machamp/" title="View Machamp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/068.png" alt="Machamp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">68</span>
                             Machamp
@@ -719,8 +719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="Bellsprout">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellsprout/" title="View Bellsprout on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/069.png" alt="Bellsprout" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">69</span>
                             Bellsprout
@@ -729,8 +729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="Weepinbell">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weepinbell/" title="View Weepinbell on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/070.png" alt="Weepinbell" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">70</span>
                             Weepinbell
@@ -739,8 +739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="Victreebel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victreebel/" title="View Victreebel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/071.png" alt="Victreebel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">71</span>
                             Victreebel
@@ -749,8 +749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="Tentacool">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacool/" title="View Tentacool on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/072.png" alt="Tentacool" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">72</span>
                             Tentacool
@@ -759,8 +759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="Tentacruel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tentacruel/" title="View Tentacruel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/073.png" alt="Tentacruel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">73</span>
                             Tentacruel
@@ -769,8 +769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="Geodude">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/geodude/" title="View Geodude on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/074.png" alt="Geodude" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">74</span>
                             Geodude
@@ -779,8 +779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="Graveler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/graveler/" title="View Graveler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/075.png" alt="Graveler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">75</span>
                             Graveler
@@ -789,8 +789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="Golem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golem/" title="View Golem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/076.png" alt="Golem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">76</span>
                             Golem
@@ -799,8 +799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="Ponyta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ponyta/" title="View Ponyta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/077.png" alt="Ponyta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">77</span>
                             Ponyta
@@ -809,8 +809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="Rapidash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rapidash/" title="View Rapidash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/078.png" alt="Rapidash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">78</span>
                             Rapidash
@@ -819,8 +819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="Slowpoke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowpoke/" title="View Slowpoke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/079.png" alt="Slowpoke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">79</span>
                             Slowpoke
@@ -829,8 +829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="Slowbro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowbro/" title="View Slowbro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/080.png" alt="Slowbro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">80</span>
                             Slowbro
@@ -839,8 +839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="Magnemite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnemite/" title="View Magnemite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/081.png" alt="Magnemite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">81</span>
                             Magnemite
@@ -849,8 +849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="Magneton">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magneton/" title="View Magneton on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/082.png" alt="Magneton" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">82</span>
                             Magneton
@@ -859,8 +859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="Farfetch’d">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/farfetchd/" title="View Farfetch’d on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/083.png" alt="Farfetch’d" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">83</span>
                             Farfetch’d
@@ -869,8 +869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="Doduo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doduo/" title="View Doduo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/084.png" alt="Doduo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">84</span>
                             Doduo
@@ -879,8 +879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="Dodrio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dodrio/" title="View Dodrio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/085.png" alt="Dodrio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">85</span>
                             Dodrio
@@ -889,8 +889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="Seel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seel/" title="View Seel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/086.png" alt="Seel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">86</span>
                             Seel
@@ -899,8 +899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="Dewgong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewgong/" title="View Dewgong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/087.png" alt="Dewgong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">87</span>
                             Dewgong
@@ -909,8 +909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="Grimer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grimer/" title="View Grimer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/088.png" alt="Grimer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">88</span>
                             Grimer
@@ -919,8 +919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="Muk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/muk/" title="View Muk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/089.png" alt="Muk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">89</span>
                             Muk
@@ -929,8 +929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="Shellder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellder/" title="View Shellder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/090.png" alt="Shellder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">90</span>
                             Shellder
@@ -946,8 +946,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="Cloyster">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cloyster/" title="View Cloyster on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/091.png" alt="Cloyster" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">91</span>
                             Cloyster
@@ -956,8 +956,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="Gastly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastly/" title="View Gastly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/092.png" alt="Gastly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">92</span>
                             Gastly
@@ -966,8 +966,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="Haunter">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haunter/" title="View Haunter on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/093.png" alt="Haunter" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">93</span>
                             Haunter
@@ -976,8 +976,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="Gengar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gengar/" title="View Gengar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/094.png" alt="Gengar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">94</span>
                             Gengar
@@ -986,8 +986,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="Onix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/onix/" title="View Onix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/095.png" alt="Onix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">95</span>
                             Onix
@@ -996,8 +996,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="Drowzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drowzee/" title="View Drowzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/096.png" alt="Drowzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">96</span>
                             Drowzee
@@ -1006,8 +1006,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="Hypno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hypno/" title="View Hypno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/097.png" alt="Hypno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">97</span>
                             Hypno
@@ -1016,8 +1016,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="Krabby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krabby/" title="View Krabby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/098.png" alt="Krabby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">98</span>
                             Krabby
@@ -1026,8 +1026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="Kingler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingler/" title="View Kingler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/099.png" alt="Kingler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">99</span>
                             Kingler
@@ -1036,8 +1036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="Voltorb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/voltorb/" title="View Voltorb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/100.png" alt="Voltorb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">100</span>
                             Voltorb
@@ -1046,8 +1046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="Electrode">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrode/" title="View Electrode on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/101.png" alt="Electrode" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">101</span>
                             Electrode
@@ -1056,8 +1056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="Exeggcute">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggcute/" title="View Exeggcute on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/102.png" alt="Exeggcute" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">102</span>
                             Exeggcute
@@ -1066,8 +1066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="Exeggutor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exeggutor/" title="View Exeggutor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/103.png" alt="Exeggutor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">103</span>
                             Exeggutor
@@ -1076,8 +1076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="Cubone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubone/" title="View Cubone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/104.png" alt="Cubone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">104</span>
                             Cubone
@@ -1086,8 +1086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="Marowak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marowak/" title="View Marowak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/105.png" alt="Marowak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">105</span>
                             Marowak
@@ -1096,8 +1096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="Hitmonlee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonlee/" title="View Hitmonlee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/106.png" alt="Hitmonlee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">106</span>
                             Hitmonlee
@@ -1106,8 +1106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="Hitmonchan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmonchan/" title="View Hitmonchan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/107.png" alt="Hitmonchan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">107</span>
                             Hitmonchan
@@ -1116,8 +1116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="Lickitung">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickitung/" title="View Lickitung on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/108.png" alt="Lickitung" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">108</span>
                             Lickitung
@@ -1126,8 +1126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="Koffing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/koffing/" title="View Koffing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/109.png" alt="Koffing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">109</span>
                             Koffing
@@ -1136,8 +1136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="Weezing">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weezing/" title="View Weezing on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/110.png" alt="Weezing" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">110</span>
                             Weezing
@@ -1146,8 +1146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="Rhyhorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyhorn/" title="View Rhyhorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/111.png" alt="Rhyhorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">111</span>
                             Rhyhorn
@@ -1156,8 +1156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="Rhydon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhydon/" title="View Rhydon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/112.png" alt="Rhydon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">112</span>
                             Rhydon
@@ -1166,8 +1166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="Chansey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chansey/" title="View Chansey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/113.png" alt="Chansey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">113</span>
                             Chansey
@@ -1176,8 +1176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="Tangela">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangela/" title="View Tangela on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/114.png" alt="Tangela" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">114</span>
                             Tangela
@@ -1186,8 +1186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="Kangaskhan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kangaskhan/" title="View Kangaskhan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/115.png" alt="Kangaskhan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">115</span>
                             Kangaskhan
@@ -1196,8 +1196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="Horsea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/horsea/" title="View Horsea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/116.png" alt="Horsea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">116</span>
                             Horsea
@@ -1206,8 +1206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="Seadra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seadra/" title="View Seadra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/117.png" alt="Seadra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">117</span>
                             Seadra
@@ -1216,8 +1216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="Goldeen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goldeen/" title="View Goldeen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/118.png" alt="Goldeen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">118</span>
                             Goldeen
@@ -1226,8 +1226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="Seaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seaking/" title="View Seaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/119.png" alt="Seaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">119</span>
                             Seaking
@@ -1236,8 +1236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="Staryu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staryu/" title="View Staryu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/120.png" alt="Staryu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">120</span>
                             Staryu
@@ -1253,8 +1253,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="Starmie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starmie/" title="View Starmie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/121.png" alt="Starmie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">121</span>
                             Starmie
@@ -1263,8 +1263,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="Mr. Mime">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mr-mime/" title="View Mr. Mime on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/122.png" alt="Mr. Mime" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">122</span>
                             Mr. Mime
@@ -1273,8 +1273,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="Scyther">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scyther/" title="View Scyther on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/123.png" alt="Scyther" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">123</span>
                             Scyther
@@ -1283,8 +1283,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="Jynx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jynx/" title="View Jynx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/124.png" alt="Jynx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">124</span>
                             Jynx
@@ -1293,8 +1293,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="Electabuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electabuzz/" title="View Electabuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/125.png" alt="Electabuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">125</span>
                             Electabuzz
@@ -1303,8 +1303,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="Magmar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmar/" title="View Magmar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/126.png" alt="Magmar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">126</span>
                             Magmar
@@ -1313,8 +1313,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="Pinsir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pinsir/" title="View Pinsir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/127.png" alt="Pinsir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">127</span>
                             Pinsir
@@ -1323,8 +1323,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="Tauros">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tauros/" title="View Tauros on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/128.png" alt="Tauros" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">128</span>
                             Tauros
@@ -1333,8 +1333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="Magikarp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magikarp/" title="View Magikarp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/129.png" alt="Magikarp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">129</span>
                             Magikarp
@@ -1343,8 +1343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="Gyarados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gyarados/" title="View Gyarados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/130.png" alt="Gyarados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">130</span>
                             Gyarados
@@ -1353,8 +1353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="Lapras">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lapras/" title="View Lapras on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/131.png" alt="Lapras" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">131</span>
                             Lapras
@@ -1363,8 +1363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="Ditto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ditto/" title="View Ditto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/132.png" alt="Ditto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">132</span>
                             Ditto
@@ -1373,8 +1373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="Eevee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eevee/" title="View Eevee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/133.png" alt="Eevee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">133</span>
                             Eevee
@@ -1383,8 +1383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="Vaporeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vaporeon/" title="View Vaporeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/134.png" alt="Vaporeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">134</span>
                             Vaporeon
@@ -1393,8 +1393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="Jolteon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jolteon/" title="View Jolteon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/135.png" alt="Jolteon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">135</span>
                             Jolteon
@@ -1403,8 +1403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="Flareon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flareon/" title="View Flareon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/136.png" alt="Flareon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">136</span>
                             Flareon
@@ -1413,8 +1413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="Porygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon/" title="View Porygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/137.png" alt="Porygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">137</span>
                             Porygon
@@ -1423,8 +1423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="Omanyte">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omanyte/" title="View Omanyte on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/138.png" alt="Omanyte" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">138</span>
                             Omanyte
@@ -1433,8 +1433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="Omastar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/omastar/" title="View Omastar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/139.png" alt="Omastar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">139</span>
                             Omastar
@@ -1443,8 +1443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="Kabuto">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabuto/" title="View Kabuto on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/140.png" alt="Kabuto" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">140</span>
                             Kabuto
@@ -1453,8 +1453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="Kabutops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kabutops/" title="View Kabutops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/141.png" alt="Kabutops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">141</span>
                             Kabutops
@@ -1463,8 +1463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="Aerodactyl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aerodactyl/" title="View Aerodactyl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/142.png" alt="Aerodactyl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">142</span>
                             Aerodactyl
@@ -1473,8 +1473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="Snorlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorlax/" title="View Snorlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/143.png" alt="Snorlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">143</span>
                             Snorlax
@@ -1483,8 +1483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="Articuno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/articuno/" title="View Articuno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/144.png" alt="Articuno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">144</span>
                             Articuno
@@ -1493,8 +1493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="Zapdos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zapdos/" title="View Zapdos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/145.png" alt="Zapdos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">145</span>
                             Zapdos
@@ -1503,8 +1503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="Moltres">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/moltres/" title="View Moltres on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/146.png" alt="Moltres" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">146</span>
                             Moltres
@@ -1513,8 +1513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="Dratini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dratini/" title="View Dratini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/147.png" alt="Dratini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">147</span>
                             Dratini
@@ -1523,8 +1523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="Dragonair">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonair/" title="View Dragonair on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/148.png" alt="Dragonair" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">148</span>
                             Dragonair
@@ -1533,8 +1533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="Dragonite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragonite/" title="View Dragonite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/149.png" alt="Dragonite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">149</span>
                             Dragonite
@@ -1543,8 +1543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="Mewtwo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mewtwo/" title="View Mewtwo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/150.png" alt="Mewtwo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">150</span>
                             Mewtwo
@@ -1560,8 +1560,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="Mew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mew/" title="View Mew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/151.png" alt="Mew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">151</span>
                             Mew
@@ -1570,8 +1570,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="Chikorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chikorita/" title="View Chikorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/152.png" alt="Chikorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">152</span>
                             Chikorita
@@ -1580,8 +1580,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="Bayleef">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bayleef/" title="View Bayleef on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/153.png" alt="Bayleef" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">153</span>
                             Bayleef
@@ -1590,8 +1590,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="Meganium">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meganium/" title="View Meganium on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/154.png" alt="Meganium" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">154</span>
                             Meganium
@@ -1600,8 +1600,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="Cyndaquil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cyndaquil/" title="View Cyndaquil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/155.png" alt="Cyndaquil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">155</span>
                             Cyndaquil
@@ -1610,8 +1610,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="Quilava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilava/" title="View Quilava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/156.png" alt="Quilava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">156</span>
                             Quilava
@@ -1620,8 +1620,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="Typhlosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/typhlosion/" title="View Typhlosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/157.png" alt="Typhlosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">157</span>
                             Typhlosion
@@ -1630,8 +1630,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="Totodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/totodile/" title="View Totodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/158.png" alt="Totodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">158</span>
                             Totodile
@@ -1640,8 +1640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="Croconaw">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croconaw/" title="View Croconaw on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/159.png" alt="Croconaw" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">159</span>
                             Croconaw
@@ -1650,8 +1650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="Feraligatr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feraligatr/" title="View Feraligatr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/160.png" alt="Feraligatr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">160</span>
                             Feraligatr
@@ -1660,8 +1660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="Sentret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sentret/" title="View Sentret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/161.png" alt="Sentret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">161</span>
                             Sentret
@@ -1670,8 +1670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="Furret">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furret/" title="View Furret on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/162.png" alt="Furret" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">162</span>
                             Furret
@@ -1680,8 +1680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="Hoothoot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoothoot/" title="View Hoothoot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/163.png" alt="Hoothoot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">163</span>
                             Hoothoot
@@ -1690,8 +1690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="Noctowl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noctowl/" title="View Noctowl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/164.png" alt="Noctowl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">164</span>
                             Noctowl
@@ -1700,8 +1700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="Ledyba">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledyba/" title="View Ledyba on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/165.png" alt="Ledyba" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">165</span>
                             Ledyba
@@ -1710,8 +1710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="Ledian">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ledian/" title="View Ledian on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/166.png" alt="Ledian" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">166</span>
                             Ledian
@@ -1720,8 +1720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="Spinarak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinarak/" title="View Spinarak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/167.png" alt="Spinarak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">167</span>
                             Spinarak
@@ -1730,8 +1730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="Ariados">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ariados/" title="View Ariados on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/168.png" alt="Ariados" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">168</span>
                             Ariados
@@ -1740,8 +1740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="Crobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crobat/" title="View Crobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/169.png" alt="Crobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">169</span>
                             Crobat
@@ -1750,8 +1750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="Chinchou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chinchou/" title="View Chinchou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/170.png" alt="Chinchou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">170</span>
                             Chinchou
@@ -1760,8 +1760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="Lanturn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lanturn/" title="View Lanturn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/171.png" alt="Lanturn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">171</span>
                             Lanturn
@@ -1770,8 +1770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="Pichu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pichu/" title="View Pichu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/172.png" alt="Pichu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">172</span>
                             Pichu
@@ -1780,8 +1780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="Cleffa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cleffa/" title="View Cleffa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/173.png" alt="Cleffa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">173</span>
                             Cleffa
@@ -1790,8 +1790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="Igglybuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/igglybuff/" title="View Igglybuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/174.png" alt="Igglybuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">174</span>
                             Igglybuff
@@ -1800,8 +1800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="Togepi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togepi/" title="View Togepi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/175.png" alt="Togepi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">175</span>
                             Togepi
@@ -1810,8 +1810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="Togetic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togetic/" title="View Togetic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/176.png" alt="Togetic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">176</span>
                             Togetic
@@ -1820,8 +1820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="Natu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/natu/" title="View Natu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/177.png" alt="Natu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">177</span>
                             Natu
@@ -1830,8 +1830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="Xatu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xatu/" title="View Xatu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/178.png" alt="Xatu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">178</span>
                             Xatu
@@ -1840,8 +1840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="Mareep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mareep/" title="View Mareep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/179.png" alt="Mareep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">179</span>
                             Mareep
@@ -1850,8 +1850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="Flaaffy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flaaffy/" title="View Flaaffy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/180.png" alt="Flaaffy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">180</span>
                             Flaaffy
@@ -1867,8 +1867,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="Ampharos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ampharos/" title="View Ampharos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/181.png" alt="Ampharos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">181</span>
                             Ampharos
@@ -1877,8 +1877,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="Bellossom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bellossom/" title="View Bellossom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/182.png" alt="Bellossom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">182</span>
                             Bellossom
@@ -1887,8 +1887,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="Marill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marill/" title="View Marill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/183.png" alt="Marill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">183</span>
                             Marill
@@ -1897,8 +1897,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="Azumarill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azumarill/" title="View Azumarill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/184.png" alt="Azumarill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">184</span>
                             Azumarill
@@ -1907,8 +1907,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="Sudowoodo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sudowoodo/" title="View Sudowoodo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/185.png" alt="Sudowoodo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">185</span>
                             Sudowoodo
@@ -1917,8 +1917,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="Politoed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/politoed/" title="View Politoed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/186.png" alt="Politoed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">186</span>
                             Politoed
@@ -1927,8 +1927,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="Hoppip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hoppip/" title="View Hoppip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/187.png" alt="Hoppip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">187</span>
                             Hoppip
@@ -1937,8 +1937,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="Skiploom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiploom/" title="View Skiploom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/188.png" alt="Skiploom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">188</span>
                             Skiploom
@@ -1947,8 +1947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="Jumpluff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jumpluff/" title="View Jumpluff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/189.png" alt="Jumpluff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">189</span>
                             Jumpluff
@@ -1957,8 +1957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="Aipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aipom/" title="View Aipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/190.png" alt="Aipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">190</span>
                             Aipom
@@ -1967,8 +1967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="Sunkern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunkern/" title="View Sunkern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/191.png" alt="Sunkern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">191</span>
                             Sunkern
@@ -1977,8 +1977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="Sunflora">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sunflora/" title="View Sunflora on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/192.png" alt="Sunflora" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">192</span>
                             Sunflora
@@ -1987,8 +1987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="Yanma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanma/" title="View Yanma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/193.png" alt="Yanma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">193</span>
                             Yanma
@@ -1997,8 +1997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="Wooper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wooper/" title="View Wooper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/194.png" alt="Wooper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">194</span>
                             Wooper
@@ -2007,8 +2007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="Quagsire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quagsire/" title="View Quagsire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/195.png" alt="Quagsire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">195</span>
                             Quagsire
@@ -2017,8 +2017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="Espeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espeon/" title="View Espeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/196.png" alt="Espeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">196</span>
                             Espeon
@@ -2027,8 +2027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="Umbreon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/umbreon/" title="View Umbreon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/197.png" alt="Umbreon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">197</span>
                             Umbreon
@@ -2037,8 +2037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="Murkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/murkrow/" title="View Murkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/198.png" alt="Murkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">198</span>
                             Murkrow
@@ -2047,8 +2047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="Slowking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slowking/" title="View Slowking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/199.png" alt="Slowking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">199</span>
                             Slowking
@@ -2057,8 +2057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="Misdreavus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/misdreavus/" title="View Misdreavus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/200.png" alt="Misdreavus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">200</span>
                             Misdreavus
@@ -2067,8 +2067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="Unown">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unown/" title="View Unown on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/201.png" alt="Unown" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">201</span>
                             Unown
@@ -2077,8 +2077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="Wobbuffet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wobbuffet/" title="View Wobbuffet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/202.png" alt="Wobbuffet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">202</span>
                             Wobbuffet
@@ -2087,8 +2087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="Girafarig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/girafarig/" title="View Girafarig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/203.png" alt="Girafarig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">203</span>
                             Girafarig
@@ -2097,8 +2097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="Pineco">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pineco/" title="View Pineco on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/204.png" alt="Pineco" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">204</span>
                             Pineco
@@ -2107,8 +2107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="Forretress">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/forretress/" title="View Forretress on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/205.png" alt="Forretress" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">205</span>
                             Forretress
@@ -2117,8 +2117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="Dunsparce">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dunsparce/" title="View Dunsparce on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/206.png" alt="Dunsparce" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">206</span>
                             Dunsparce
@@ -2127,8 +2127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="Gligar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gligar/" title="View Gligar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/207.png" alt="Gligar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">207</span>
                             Gligar
@@ -2137,8 +2137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="Steelix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/steelix/" title="View Steelix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/208.png" alt="Steelix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">208</span>
                             Steelix
@@ -2147,8 +2147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="Snubbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snubbull/" title="View Snubbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/209.png" alt="Snubbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">209</span>
                             Snubbull
@@ -2157,8 +2157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="Granbull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/granbull/" title="View Granbull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/210.png" alt="Granbull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">210</span>
                             Granbull
@@ -2174,8 +2174,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="Qwilfish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/qwilfish/" title="View Qwilfish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/211.png" alt="Qwilfish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">211</span>
                             Qwilfish
@@ -2184,8 +2184,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="Scizor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scizor/" title="View Scizor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/212.png" alt="Scizor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">212</span>
                             Scizor
@@ -2194,8 +2194,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="Shuckle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuckle/" title="View Shuckle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/213.png" alt="Shuckle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">213</span>
                             Shuckle
@@ -2204,8 +2204,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="Heracross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heracross/" title="View Heracross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/214.png" alt="Heracross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">214</span>
                             Heracross
@@ -2214,8 +2214,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="Sneasel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sneasel/" title="View Sneasel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/215.png" alt="Sneasel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">215</span>
                             Sneasel
@@ -2224,8 +2224,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="Teddiursa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/teddiursa/" title="View Teddiursa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/216.png" alt="Teddiursa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">216</span>
                             Teddiursa
@@ -2234,8 +2234,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="Ursaring">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ursaring/" title="View Ursaring on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/217.png" alt="Ursaring" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">217</span>
                             Ursaring
@@ -2244,8 +2244,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="Slugma">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slugma/" title="View Slugma on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/218.png" alt="Slugma" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">218</span>
                             Slugma
@@ -2254,8 +2254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="Magcargo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magcargo/" title="View Magcargo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/219.png" alt="Magcargo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">219</span>
                             Magcargo
@@ -2264,8 +2264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="Swinub">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swinub/" title="View Swinub on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/220.png" alt="Swinub" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">220</span>
                             Swinub
@@ -2274,8 +2274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="Piloswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piloswine/" title="View Piloswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/221.png" alt="Piloswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">221</span>
                             Piloswine
@@ -2284,8 +2284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="Corsola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corsola/" title="View Corsola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/222.png" alt="Corsola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">222</span>
                             Corsola
@@ -2294,8 +2294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="Remoraid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/remoraid/" title="View Remoraid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/223.png" alt="Remoraid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">223</span>
                             Remoraid
@@ -2304,8 +2304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="Octillery">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/octillery/" title="View Octillery on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/224.png" alt="Octillery" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">224</span>
                             Octillery
@@ -2314,8 +2314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="Delibird">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delibird/" title="View Delibird on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/225.png" alt="Delibird" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">225</span>
                             Delibird
@@ -2324,8 +2324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="Mantine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantine/" title="View Mantine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/226.png" alt="Mantine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">226</span>
                             Mantine
@@ -2334,8 +2334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="Skarmory">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skarmory/" title="View Skarmory on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/227.png" alt="Skarmory" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">227</span>
                             Skarmory
@@ -2344,8 +2344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="Houndour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndour/" title="View Houndour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/228.png" alt="Houndour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">228</span>
                             Houndour
@@ -2354,8 +2354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="Houndoom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/houndoom/" title="View Houndoom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/229.png" alt="Houndoom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">229</span>
                             Houndoom
@@ -2364,8 +2364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="Kingdra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kingdra/" title="View Kingdra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/230.png" alt="Kingdra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">230</span>
                             Kingdra
@@ -2374,8 +2374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="Phanpy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phanpy/" title="View Phanpy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/231.png" alt="Phanpy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">231</span>
                             Phanpy
@@ -2384,8 +2384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="Donphan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/donphan/" title="View Donphan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/232.png" alt="Donphan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">232</span>
                             Donphan
@@ -2394,8 +2394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="Porygon2">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon2/" title="View Porygon2 on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/233.png" alt="Porygon2" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">233</span>
                             Porygon2
@@ -2404,8 +2404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="Stantler">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stantler/" title="View Stantler on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/234.png" alt="Stantler" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">234</span>
                             Stantler
@@ -2414,8 +2414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="Smeargle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smeargle/" title="View Smeargle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/235.png" alt="Smeargle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">235</span>
                             Smeargle
@@ -2424,8 +2424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="Tyrogue">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrogue/" title="View Tyrogue on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/236.png" alt="Tyrogue" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">236</span>
                             Tyrogue
@@ -2434,8 +2434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="Hitmontop">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hitmontop/" title="View Hitmontop on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/237.png" alt="Hitmontop" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">237</span>
                             Hitmontop
@@ -2444,8 +2444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="Smoochum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/smoochum/" title="View Smoochum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/238.png" alt="Smoochum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">238</span>
                             Smoochum
@@ -2454,8 +2454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="Elekid">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elekid/" title="View Elekid on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/239.png" alt="Elekid" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">239</span>
                             Elekid
@@ -2464,8 +2464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="Magby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magby/" title="View Magby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/240.png" alt="Magby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">240</span>
                             Magby
@@ -2481,8 +2481,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="Miltank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/miltank/" title="View Miltank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/241.png" alt="Miltank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">241</span>
                             Miltank
@@ -2491,8 +2491,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="Blissey">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blissey/" title="View Blissey on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/242.png" alt="Blissey" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">242</span>
                             Blissey
@@ -2501,8 +2501,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="Raikou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/raikou/" title="View Raikou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/243.png" alt="Raikou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">243</span>
                             Raikou
@@ -2511,8 +2511,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="Entei">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/entei/" title="View Entei on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/244.png" alt="Entei" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">244</span>
                             Entei
@@ -2521,8 +2521,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="Suicune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/suicune/" title="View Suicune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/245.png" alt="Suicune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">245</span>
                             Suicune
@@ -2531,8 +2531,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="Larvitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvitar/" title="View Larvitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/246.png" alt="Larvitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">246</span>
                             Larvitar
@@ -2541,8 +2541,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="Pupitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pupitar/" title="View Pupitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/247.png" alt="Pupitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">247</span>
                             Pupitar
@@ -2551,8 +2551,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="Tyranitar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyranitar/" title="View Tyranitar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/248.png" alt="Tyranitar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">248</span>
                             Tyranitar
@@ -2561,8 +2561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="Lugia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lugia/" title="View Lugia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/249.png" alt="Lugia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">249</span>
                             Lugia
@@ -2571,8 +2571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="Ho-Oh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ho-oh/" title="View Ho-Oh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/250.png" alt="Ho-Oh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">250</span>
                             Ho-Oh
@@ -2581,8 +2581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="Celebi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/celebi/" title="View Celebi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/251.png" alt="Celebi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">251</span>
                             Celebi
@@ -2591,8 +2591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="Treecko">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/treecko/" title="View Treecko on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/252.png" alt="Treecko" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">252</span>
                             Treecko
@@ -2601,8 +2601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="Grovyle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grovyle/" title="View Grovyle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/253.png" alt="Grovyle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">253</span>
                             Grovyle
@@ -2611,8 +2611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="Sceptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sceptile/" title="View Sceptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/254.png" alt="Sceptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">254</span>
                             Sceptile
@@ -2621,8 +2621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="Torchic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torchic/" title="View Torchic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/255.png" alt="Torchic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">255</span>
                             Torchic
@@ -2631,8 +2631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="Combusken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combusken/" title="View Combusken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/256.png" alt="Combusken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">256</span>
                             Combusken
@@ -2641,8 +2641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="Blaziken">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blaziken/" title="View Blaziken on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/257.png" alt="Blaziken" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">257</span>
                             Blaziken
@@ -2651,8 +2651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="Mudkip">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mudkip/" title="View Mudkip on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/258.png" alt="Mudkip" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">258</span>
                             Mudkip
@@ -2661,8 +2661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="Marshtomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/marshtomp/" title="View Marshtomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/259.png" alt="Marshtomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">259</span>
                             Marshtomp
@@ -2671,8 +2671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="Swampert">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swampert/" title="View Swampert on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/260.png" alt="Swampert" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">260</span>
                             Swampert
@@ -2681,8 +2681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="Poochyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/poochyena/" title="View Poochyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/261.png" alt="Poochyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">261</span>
                             Poochyena
@@ -2691,8 +2691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="Mightyena">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mightyena/" title="View Mightyena on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/262.png" alt="Mightyena" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">262</span>
                             Mightyena
@@ -2701,8 +2701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="Zigzagoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zigzagoon/" title="View Zigzagoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/263.png" alt="Zigzagoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">263</span>
                             Zigzagoon
@@ -2711,8 +2711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="Linoone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/linoone/" title="View Linoone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/264.png" alt="Linoone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">264</span>
                             Linoone
@@ -2721,8 +2721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="Wurmple">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wurmple/" title="View Wurmple on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/265.png" alt="Wurmple" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">265</span>
                             Wurmple
@@ -2731,8 +2731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="Silcoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/silcoon/" title="View Silcoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/266.png" alt="Silcoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">266</span>
                             Silcoon
@@ -2741,8 +2741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="Beautifly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beautifly/" title="View Beautifly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/267.png" alt="Beautifly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">267</span>
                             Beautifly
@@ -2751,8 +2751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="Cascoon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cascoon/" title="View Cascoon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/268.png" alt="Cascoon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">268</span>
                             Cascoon
@@ -2761,8 +2761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="Dustox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dustox/" title="View Dustox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/269.png" alt="Dustox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">269</span>
                             Dustox
@@ -2771,8 +2771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="Lotad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lotad/" title="View Lotad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/270.png" alt="Lotad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">270</span>
                             Lotad
@@ -2788,8 +2788,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="Lombre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lombre/" title="View Lombre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/271.png" alt="Lombre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">271</span>
                             Lombre
@@ -2798,8 +2798,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="Ludicolo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ludicolo/" title="View Ludicolo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/272.png" alt="Ludicolo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">272</span>
                             Ludicolo
@@ -2808,8 +2808,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="Seedot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seedot/" title="View Seedot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/273.png" alt="Seedot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">273</span>
                             Seedot
@@ -2818,8 +2818,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="Nuzleaf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nuzleaf/" title="View Nuzleaf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/274.png" alt="Nuzleaf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">274</span>
                             Nuzleaf
@@ -2828,8 +2828,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="Shiftry">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shiftry/" title="View Shiftry on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/275.png" alt="Shiftry" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">275</span>
                             Shiftry
@@ -2838,8 +2838,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="Taillow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/taillow/" title="View Taillow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/276.png" alt="Taillow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">276</span>
                             Taillow
@@ -2848,8 +2848,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="Swellow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swellow/" title="View Swellow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/277.png" alt="Swellow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">277</span>
                             Swellow
@@ -2858,8 +2858,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="Wingull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wingull/" title="View Wingull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/278.png" alt="Wingull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">278</span>
                             Wingull
@@ -2868,8 +2868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="Pelipper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pelipper/" title="View Pelipper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/279.png" alt="Pelipper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">279</span>
                             Pelipper
@@ -2878,8 +2878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="Ralts">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ralts/" title="View Ralts on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/280.png" alt="Ralts" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">280</span>
                             Ralts
@@ -2888,8 +2888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="Kirlia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kirlia/" title="View Kirlia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/281.png" alt="Kirlia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">281</span>
                             Kirlia
@@ -2898,8 +2898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="Gardevoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gardevoir/" title="View Gardevoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/282.png" alt="Gardevoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">282</span>
                             Gardevoir
@@ -2908,8 +2908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="Surskit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/surskit/" title="View Surskit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/283.png" alt="Surskit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">283</span>
                             Surskit
@@ -2918,8 +2918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="Masquerain">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/masquerain/" title="View Masquerain on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/284.png" alt="Masquerain" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">284</span>
                             Masquerain
@@ -2928,8 +2928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="Shroomish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shroomish/" title="View Shroomish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/285.png" alt="Shroomish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">285</span>
                             Shroomish
@@ -2938,8 +2938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="Breloom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/breloom/" title="View Breloom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/286.png" alt="Breloom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">286</span>
                             Breloom
@@ -2948,8 +2948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="Slakoth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slakoth/" title="View Slakoth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/287.png" alt="Slakoth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">287</span>
                             Slakoth
@@ -2958,8 +2958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="Vigoroth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vigoroth/" title="View Vigoroth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/288.png" alt="Vigoroth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">288</span>
                             Vigoroth
@@ -2968,8 +2968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="Slaking">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slaking/" title="View Slaking on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/289.png" alt="Slaking" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">289</span>
                             Slaking
@@ -2978,8 +2978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="Nincada">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nincada/" title="View Nincada on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/290.png" alt="Nincada" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">290</span>
                             Nincada
@@ -2988,8 +2988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="Ninjask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ninjask/" title="View Ninjask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/291.png" alt="Ninjask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">291</span>
                             Ninjask
@@ -2998,8 +2998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="Shedinja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shedinja/" title="View Shedinja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/292.png" alt="Shedinja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">292</span>
                             Shedinja
@@ -3008,8 +3008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="Whismur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whismur/" title="View Whismur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/293.png" alt="Whismur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">293</span>
                             Whismur
@@ -3018,8 +3018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="Loudred">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/loudred/" title="View Loudred on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/294.png" alt="Loudred" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">294</span>
                             Loudred
@@ -3028,8 +3028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="Exploud">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/exploud/" title="View Exploud on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/295.png" alt="Exploud" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">295</span>
                             Exploud
@@ -3038,8 +3038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="Makuhita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/makuhita/" title="View Makuhita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/296.png" alt="Makuhita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">296</span>
                             Makuhita
@@ -3048,8 +3048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="Hariyama">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hariyama/" title="View Hariyama on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/297.png" alt="Hariyama" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">297</span>
                             Hariyama
@@ -3058,8 +3058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="Azurill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azurill/" title="View Azurill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/298.png" alt="Azurill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">298</span>
                             Azurill
@@ -3068,8 +3068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="Nosepass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/nosepass/" title="View Nosepass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/299.png" alt="Nosepass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">299</span>
                             Nosepass
@@ -3078,8 +3078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="Skitty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skitty/" title="View Skitty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/300.png" alt="Skitty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">300</span>
                             Skitty
@@ -3095,8 +3095,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="Delcatty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delcatty/" title="View Delcatty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/301.png" alt="Delcatty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">301</span>
                             Delcatty
@@ -3105,8 +3105,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="Sableye">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sableye/" title="View Sableye on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/302.png" alt="Sableye" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">302</span>
                             Sableye
@@ -3115,8 +3115,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="Mawile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mawile/" title="View Mawile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/303.png" alt="Mawile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">303</span>
                             Mawile
@@ -3125,8 +3125,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="Aron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aron/" title="View Aron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/304.png" alt="Aron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">304</span>
                             Aron
@@ -3135,8 +3135,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="Lairon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lairon/" title="View Lairon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/305.png" alt="Lairon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">305</span>
                             Lairon
@@ -3145,8 +3145,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="Aggron">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aggron/" title="View Aggron on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/306.png" alt="Aggron" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">306</span>
                             Aggron
@@ -3155,8 +3155,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="Meditite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meditite/" title="View Meditite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/307.png" alt="Meditite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">307</span>
                             Meditite
@@ -3165,8 +3165,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="Medicham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/medicham/" title="View Medicham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/308.png" alt="Medicham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">308</span>
                             Medicham
@@ -3175,8 +3175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="Electrike">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electrike/" title="View Electrike on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/309.png" alt="Electrike" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">309</span>
                             Electrike
@@ -3185,8 +3185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="Manectric">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manectric/" title="View Manectric on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/310.png" alt="Manectric" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">310</span>
                             Manectric
@@ -3195,8 +3195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="Plusle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/plusle/" title="View Plusle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/311.png" alt="Plusle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">311</span>
                             Plusle
@@ -3205,8 +3205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="Minun">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minun/" title="View Minun on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/312.png" alt="Minun" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">312</span>
                             Minun
@@ -3215,8 +3215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="Volbeat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volbeat/" title="View Volbeat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/313.png" alt="Volbeat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">313</span>
                             Volbeat
@@ -3225,8 +3225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="Illumise">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/illumise/" title="View Illumise on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/314.png" alt="Illumise" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">314</span>
                             Illumise
@@ -3235,8 +3235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="Roselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roselia/" title="View Roselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/315.png" alt="Roselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">315</span>
                             Roselia
@@ -3245,8 +3245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="Gulpin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gulpin/" title="View Gulpin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/316.png" alt="Gulpin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">316</span>
                             Gulpin
@@ -3255,8 +3255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="Swalot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swalot/" title="View Swalot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/317.png" alt="Swalot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">317</span>
                             Swalot
@@ -3265,8 +3265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="Carvanha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carvanha/" title="View Carvanha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/318.png" alt="Carvanha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">318</span>
                             Carvanha
@@ -3275,8 +3275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="Sharpedo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sharpedo/" title="View Sharpedo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/319.png" alt="Sharpedo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">319</span>
                             Sharpedo
@@ -3285,8 +3285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="Wailmer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailmer/" title="View Wailmer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/320.png" alt="Wailmer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">320</span>
                             Wailmer
@@ -3295,8 +3295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="Wailord">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wailord/" title="View Wailord on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/321.png" alt="Wailord" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">321</span>
                             Wailord
@@ -3305,8 +3305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="Numel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/numel/" title="View Numel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/322.png" alt="Numel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">322</span>
                             Numel
@@ -3315,8 +3315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="Camerupt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/camerupt/" title="View Camerupt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/323.png" alt="Camerupt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">323</span>
                             Camerupt
@@ -3325,8 +3325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="Torkoal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torkoal/" title="View Torkoal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/324.png" alt="Torkoal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">324</span>
                             Torkoal
@@ -3335,8 +3335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="Spoink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spoink/" title="View Spoink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/325.png" alt="Spoink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">325</span>
                             Spoink
@@ -3345,8 +3345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="Grumpig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grumpig/" title="View Grumpig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/326.png" alt="Grumpig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">326</span>
                             Grumpig
@@ -3355,8 +3355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="Spinda">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spinda/" title="View Spinda on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/327.png" alt="Spinda" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">327</span>
                             Spinda
@@ -3365,8 +3365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="Trapinch">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trapinch/" title="View Trapinch on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/328.png" alt="Trapinch" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">328</span>
                             Trapinch
@@ -3375,8 +3375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="Vibrava">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vibrava/" title="View Vibrava on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/329.png" alt="Vibrava" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">329</span>
                             Vibrava
@@ -3385,8 +3385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="Flygon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flygon/" title="View Flygon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/330.png" alt="Flygon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">330</span>
                             Flygon
@@ -3402,8 +3402,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="Cacnea">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacnea/" title="View Cacnea on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/331.png" alt="Cacnea" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">331</span>
                             Cacnea
@@ -3412,8 +3412,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="Cacturne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cacturne/" title="View Cacturne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/332.png" alt="Cacturne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">332</span>
                             Cacturne
@@ -3422,8 +3422,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="Swablu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swablu/" title="View Swablu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/333.png" alt="Swablu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">333</span>
                             Swablu
@@ -3432,8 +3432,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="Altaria">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/altaria/" title="View Altaria on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/334.png" alt="Altaria" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">334</span>
                             Altaria
@@ -3442,8 +3442,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="Zangoose">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zangoose/" title="View Zangoose on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/335.png" alt="Zangoose" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">335</span>
                             Zangoose
@@ -3452,8 +3452,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="Seviper">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seviper/" title="View Seviper on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/336.png" alt="Seviper" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">336</span>
                             Seviper
@@ -3462,8 +3462,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="Lunatone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lunatone/" title="View Lunatone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/337.png" alt="Lunatone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">337</span>
                             Lunatone
@@ -3472,8 +3472,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="Solrock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solrock/" title="View Solrock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/338.png" alt="Solrock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">338</span>
                             Solrock
@@ -3482,8 +3482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="Barboach">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barboach/" title="View Barboach on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/339.png" alt="Barboach" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">339</span>
                             Barboach
@@ -3492,8 +3492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="Whiscash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whiscash/" title="View Whiscash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/340.png" alt="Whiscash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">340</span>
                             Whiscash
@@ -3502,8 +3502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="Corphish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/corphish/" title="View Corphish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/341.png" alt="Corphish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">341</span>
                             Corphish
@@ -3512,8 +3512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="Crawdaunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crawdaunt/" title="View Crawdaunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/342.png" alt="Crawdaunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">342</span>
                             Crawdaunt
@@ -3522,8 +3522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="Baltoy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/baltoy/" title="View Baltoy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/343.png" alt="Baltoy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">343</span>
                             Baltoy
@@ -3532,8 +3532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="Claydol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/claydol/" title="View Claydol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/344.png" alt="Claydol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">344</span>
                             Claydol
@@ -3542,8 +3542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="Lileep">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lileep/" title="View Lileep on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/345.png" alt="Lileep" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">345</span>
                             Lileep
@@ -3552,8 +3552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="Cradily">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cradily/" title="View Cradily on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/346.png" alt="Cradily" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">346</span>
                             Cradily
@@ -3562,8 +3562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="Anorith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/anorith/" title="View Anorith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/347.png" alt="Anorith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">347</span>
                             Anorith
@@ -3572,8 +3572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="Armaldo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/armaldo/" title="View Armaldo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/348.png" alt="Armaldo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">348</span>
                             Armaldo
@@ -3582,8 +3582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="Feebas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/feebas/" title="View Feebas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/349.png" alt="Feebas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">349</span>
                             Feebas
@@ -3592,8 +3592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="Milotic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/milotic/" title="View Milotic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/350.png" alt="Milotic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">350</span>
                             Milotic
@@ -3602,8 +3602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="Castform">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/castform/" title="View Castform on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/351.png" alt="Castform" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">351</span>
                             Castform
@@ -3612,8 +3612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="Kecleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kecleon/" title="View Kecleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/352.png" alt="Kecleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">352</span>
                             Kecleon
@@ -3622,8 +3622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="Shuppet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shuppet/" title="View Shuppet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/353.png" alt="Shuppet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">353</span>
                             Shuppet
@@ -3632,8 +3632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="Banette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/banette/" title="View Banette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/354.png" alt="Banette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">354</span>
                             Banette
@@ -3642,8 +3642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="Duskull">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duskull/" title="View Duskull on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/355.png" alt="Duskull" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">355</span>
                             Duskull
@@ -3652,8 +3652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="Dusclops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusclops/" title="View Dusclops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/356.png" alt="Dusclops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">356</span>
                             Dusclops
@@ -3662,8 +3662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="Tropius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tropius/" title="View Tropius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/357.png" alt="Tropius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">357</span>
                             Tropius
@@ -3672,8 +3672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="Chimecho">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimecho/" title="View Chimecho on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/358.png" alt="Chimecho" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">358</span>
                             Chimecho
@@ -3682,8 +3682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="Absol">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/absol/" title="View Absol on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/359.png" alt="Absol" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">359</span>
                             Absol
@@ -3692,8 +3692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="Wynaut">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wynaut/" title="View Wynaut on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/360.png" alt="Wynaut" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">360</span>
                             Wynaut
@@ -3709,8 +3709,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="Snorunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snorunt/" title="View Snorunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/361.png" alt="Snorunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">361</span>
                             Snorunt
@@ -3719,8 +3719,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="Glalie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glalie/" title="View Glalie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/362.png" alt="Glalie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">362</span>
                             Glalie
@@ -3729,8 +3729,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="Spheal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spheal/" title="View Spheal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/363.png" alt="Spheal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">363</span>
                             Spheal
@@ -3739,8 +3739,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="Sealeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sealeo/" title="View Sealeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/364.png" alt="Sealeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">364</span>
                             Sealeo
@@ -3749,8 +3749,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="Walrein">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/walrein/" title="View Walrein on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/365.png" alt="Walrein" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">365</span>
                             Walrein
@@ -3759,8 +3759,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="Clamperl">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clamperl/" title="View Clamperl on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/366.png" alt="Clamperl" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">366</span>
                             Clamperl
@@ -3769,8 +3769,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="Huntail">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/huntail/" title="View Huntail on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/367.png" alt="Huntail" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">367</span>
                             Huntail
@@ -3779,8 +3779,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="Gorebyss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gorebyss/" title="View Gorebyss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/368.png" alt="Gorebyss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">368</span>
                             Gorebyss
@@ -3789,8 +3789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="Relicanth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/relicanth/" title="View Relicanth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/369.png" alt="Relicanth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">369</span>
                             Relicanth
@@ -3799,8 +3799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="Luvdisc">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luvdisc/" title="View Luvdisc on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/370.png" alt="Luvdisc" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">370</span>
                             Luvdisc
@@ -3809,8 +3809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="Bagon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bagon/" title="View Bagon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/371.png" alt="Bagon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">371</span>
                             Bagon
@@ -3819,8 +3819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="Shelgon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelgon/" title="View Shelgon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/372.png" alt="Shelgon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">372</span>
                             Shelgon
@@ -3829,8 +3829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="Salamence">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/salamence/" title="View Salamence on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/373.png" alt="Salamence" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">373</span>
                             Salamence
@@ -3839,8 +3839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="Beldum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beldum/" title="View Beldum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/374.png" alt="Beldum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">374</span>
                             Beldum
@@ -3849,8 +3849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="Metang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metang/" title="View Metang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/375.png" alt="Metang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">375</span>
                             Metang
@@ -3859,8 +3859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="Metagross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/metagross/" title="View Metagross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/376.png" alt="Metagross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">376</span>
                             Metagross
@@ -3869,8 +3869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="Regirock">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regirock/" title="View Regirock on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/377.png" alt="Regirock" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">377</span>
                             Regirock
@@ -3879,8 +3879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="Regice">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regice/" title="View Regice on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/378.png" alt="Regice" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">378</span>
                             Regice
@@ -3889,8 +3889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="Registeel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/registeel/" title="View Registeel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/379.png" alt="Registeel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">379</span>
                             Registeel
@@ -3899,8 +3899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="Latias">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latias/" title="View Latias on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/380.png" alt="Latias" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">380</span>
                             Latias
@@ -3909,8 +3909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="Latios">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/latios/" title="View Latios on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/381.png" alt="Latios" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">381</span>
                             Latios
@@ -3919,8 +3919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="Kyogre">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyogre/" title="View Kyogre on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/382.png" alt="Kyogre" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">382</span>
                             Kyogre
@@ -3929,8 +3929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="Groudon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/groudon/" title="View Groudon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/383.png" alt="Groudon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">383</span>
                             Groudon
@@ -3939,8 +3939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="Rayquaza">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rayquaza/" title="View Rayquaza on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/384.png" alt="Rayquaza" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">384</span>
                             Rayquaza
@@ -3949,8 +3949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="Jirachi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jirachi/" title="View Jirachi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/385.png" alt="Jirachi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">385</span>
                             Jirachi
@@ -3959,8 +3959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="Deoxys">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deoxys/" title="View Deoxys on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/386.png" alt="Deoxys" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">386</span>
                             Deoxys
@@ -3969,8 +3969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="Turtwig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/turtwig/" title="View Turtwig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/387.png" alt="Turtwig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">387</span>
                             Turtwig
@@ -3979,8 +3979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="Grotle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/grotle/" title="View Grotle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/388.png" alt="Grotle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">388</span>
                             Grotle
@@ -3989,8 +3989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="Torterra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/torterra/" title="View Torterra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/389.png" alt="Torterra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">389</span>
                             Torterra
@@ -3999,8 +3999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="Chimchar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chimchar/" title="View Chimchar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/390.png" alt="Chimchar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">390</span>
                             Chimchar
@@ -4016,8 +4016,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="Monferno">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/monferno/" title="View Monferno on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/391.png" alt="Monferno" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">391</span>
                             Monferno
@@ -4026,8 +4026,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="Infernape">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/infernape/" title="View Infernape on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/392.png" alt="Infernape" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">392</span>
                             Infernape
@@ -4036,8 +4036,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="Piplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/piplup/" title="View Piplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/393.png" alt="Piplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">393</span>
                             Piplup
@@ -4046,8 +4046,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="Prinplup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/prinplup/" title="View Prinplup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/394.png" alt="Prinplup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">394</span>
                             Prinplup
@@ -4056,8 +4056,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="Empoleon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/empoleon/" title="View Empoleon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/395.png" alt="Empoleon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">395</span>
                             Empoleon
@@ -4066,8 +4066,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="Starly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/starly/" title="View Starly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/396.png" alt="Starly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">396</span>
                             Starly
@@ -4076,8 +4076,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="Staravia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staravia/" title="View Staravia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/397.png" alt="Staravia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">397</span>
                             Staravia
@@ -4086,8 +4086,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="Staraptor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/staraptor/" title="View Staraptor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/398.png" alt="Staraptor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">398</span>
                             Staraptor
@@ -4096,8 +4096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="Bidoof">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bidoof/" title="View Bidoof on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/399.png" alt="Bidoof" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">399</span>
                             Bidoof
@@ -4106,8 +4106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="Bibarel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bibarel/" title="View Bibarel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/400.png" alt="Bibarel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">400</span>
                             Bibarel
@@ -4116,8 +4116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="Kricketot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketot/" title="View Kricketot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/401.png" alt="Kricketot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">401</span>
                             Kricketot
@@ -4126,8 +4126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="Kricketune">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kricketune/" title="View Kricketune on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/402.png" alt="Kricketune" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">402</span>
                             Kricketune
@@ -4136,8 +4136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="Shinx">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shinx/" title="View Shinx on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/403.png" alt="Shinx" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">403</span>
                             Shinx
@@ -4146,8 +4146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="Luxio">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxio/" title="View Luxio on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/404.png" alt="Luxio" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">404</span>
                             Luxio
@@ -4156,8 +4156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="Luxray">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/luxray/" title="View Luxray on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/405.png" alt="Luxray" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">405</span>
                             Luxray
@@ -4166,8 +4166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="Budew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/budew/" title="View Budew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/406.png" alt="Budew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">406</span>
                             Budew
@@ -4176,8 +4176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="Roserade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roserade/" title="View Roserade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/407.png" alt="Roserade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">407</span>
                             Roserade
@@ -4186,8 +4186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="Cranidos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cranidos/" title="View Cranidos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/408.png" alt="Cranidos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">408</span>
                             Cranidos
@@ -4196,8 +4196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="Rampardos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rampardos/" title="View Rampardos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/409.png" alt="Rampardos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">409</span>
                             Rampardos
@@ -4206,8 +4206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="Shieldon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shieldon/" title="View Shieldon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/410.png" alt="Shieldon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">410</span>
                             Shieldon
@@ -4216,8 +4216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="Bastiodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bastiodon/" title="View Bastiodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/411.png" alt="Bastiodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">411</span>
                             Bastiodon
@@ -4226,8 +4226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="Burmy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/burmy/" title="View Burmy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/412.png" alt="Burmy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">412</span>
                             Burmy
@@ -4236,8 +4236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="Wormadam">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/wormadam/" title="View Wormadam on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/413.png" alt="Wormadam" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">413</span>
                             Wormadam
@@ -4246,8 +4246,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="Mothim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mothim/" title="View Mothim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/414.png" alt="Mothim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">414</span>
                             Mothim
@@ -4256,8 +4256,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="Combee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/combee/" title="View Combee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/415.png" alt="Combee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">415</span>
                             Combee
@@ -4266,8 +4266,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="Vespiquen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vespiquen/" title="View Vespiquen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/416.png" alt="Vespiquen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">416</span>
                             Vespiquen
@@ -4276,8 +4276,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="Pachirisu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pachirisu/" title="View Pachirisu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/417.png" alt="Pachirisu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">417</span>
                             Pachirisu
@@ -4286,8 +4286,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="Buizel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buizel/" title="View Buizel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/418.png" alt="Buizel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">418</span>
                             Buizel
@@ -4296,8 +4296,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="Floatzel">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/floatzel/" title="View Floatzel on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/419.png" alt="Floatzel" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">419</span>
                             Floatzel
@@ -4306,8 +4306,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="Cherubi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherubi/" title="View Cherubi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/420.png" alt="Cherubi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">420</span>
                             Cherubi
@@ -4323,8 +4323,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="Cherrim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cherrim/" title="View Cherrim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/421.png" alt="Cherrim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">421</span>
                             Cherrim
@@ -4333,8 +4333,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="Shellos">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shellos/" title="View Shellos on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/422.png" alt="Shellos" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">422</span>
                             Shellos
@@ -4343,8 +4343,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="Gastrodon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gastrodon/" title="View Gastrodon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/423.png" alt="Gastrodon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">423</span>
                             Gastrodon
@@ -4353,8 +4353,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="Ambipom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ambipom/" title="View Ambipom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/424.png" alt="Ambipom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">424</span>
                             Ambipom
@@ -4363,8 +4363,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="Drifloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifloon/" title="View Drifloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/425.png" alt="Drifloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">425</span>
                             Drifloon
@@ -4373,8 +4373,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="Drifblim">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drifblim/" title="View Drifblim on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/426.png" alt="Drifblim" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">426</span>
                             Drifblim
@@ -4383,8 +4383,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="Buneary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/buneary/" title="View Buneary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/427.png" alt="Buneary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">427</span>
                             Buneary
@@ -4393,8 +4393,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="Lopunny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lopunny/" title="View Lopunny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/428.png" alt="Lopunny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">428</span>
                             Lopunny
@@ -4403,8 +4403,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="Mismagius">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mismagius/" title="View Mismagius on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/429.png" alt="Mismagius" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">429</span>
                             Mismagius
@@ -4413,8 +4413,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="Honchkrow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honchkrow/" title="View Honchkrow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/430.png" alt="Honchkrow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">430</span>
                             Honchkrow
@@ -4423,8 +4423,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="Glameow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glameow/" title="View Glameow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/431.png" alt="Glameow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">431</span>
                             Glameow
@@ -4433,8 +4433,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="Purugly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purugly/" title="View Purugly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/432.png" alt="Purugly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">432</span>
                             Purugly
@@ -4443,8 +4443,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="Chingling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chingling/" title="View Chingling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/433.png" alt="Chingling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">433</span>
                             Chingling
@@ -4453,8 +4453,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="Stunky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunky/" title="View Stunky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/434.png" alt="Stunky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">434</span>
                             Stunky
@@ -4463,8 +4463,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="Skuntank">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skuntank/" title="View Skuntank on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/435.png" alt="Skuntank" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">435</span>
                             Skuntank
@@ -4473,8 +4473,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="Bronzor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzor/" title="View Bronzor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/436.png" alt="Bronzor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">436</span>
                             Bronzor
@@ -4483,8 +4483,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="Bronzong">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bronzong/" title="View Bronzong on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/437.png" alt="Bronzong" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">437</span>
                             Bronzong
@@ -4493,8 +4493,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="Bonsly">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bonsly/" title="View Bonsly on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/438.png" alt="Bonsly" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">438</span>
                             Bonsly
@@ -4503,8 +4503,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="Mime Jr.">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mime-jr/" title="View Mime Jr. on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/439.png" alt="Mime Jr." loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">439</span>
                             Mime Jr.
@@ -4513,8 +4513,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="Happiny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/happiny/" title="View Happiny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/440.png" alt="Happiny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">440</span>
                             Happiny
@@ -4523,8 +4523,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="Chatot">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chatot/" title="View Chatot on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/441.png" alt="Chatot" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">441</span>
                             Chatot
@@ -4533,8 +4533,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="Spiritomb">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spiritomb/" title="View Spiritomb on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/442.png" alt="Spiritomb" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">442</span>
                             Spiritomb
@@ -4543,8 +4543,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="Gible">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gible/" title="View Gible on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/443.png" alt="Gible" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">443</span>
                             Gible
@@ -4553,8 +4553,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="Gabite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gabite/" title="View Gabite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/444.png" alt="Gabite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">444</span>
                             Gabite
@@ -4563,8 +4563,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="Garchomp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garchomp/" title="View Garchomp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/445.png" alt="Garchomp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">445</span>
                             Garchomp
@@ -4573,8 +4573,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="Munchlax">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munchlax/" title="View Munchlax on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/446.png" alt="Munchlax" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">446</span>
                             Munchlax
@@ -4583,8 +4583,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="Riolu">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/riolu/" title="View Riolu on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/447.png" alt="Riolu" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">447</span>
                             Riolu
@@ -4593,8 +4593,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="Lucario">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lucario/" title="View Lucario on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/448.png" alt="Lucario" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">448</span>
                             Lucario
@@ -4603,8 +4603,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="Hippopotas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippopotas/" title="View Hippopotas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/449.png" alt="Hippopotas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">449</span>
                             Hippopotas
@@ -4613,8 +4613,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="Hippowdon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hippowdon/" title="View Hippowdon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/450.png" alt="Hippowdon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">450</span>
                             Hippowdon
@@ -4630,8 +4630,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="Skorupi">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skorupi/" title="View Skorupi on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/451.png" alt="Skorupi" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">451</span>
                             Skorupi
@@ -4640,8 +4640,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="Drapion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drapion/" title="View Drapion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/452.png" alt="Drapion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">452</span>
                             Drapion
@@ -4650,8 +4650,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="Croagunk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/croagunk/" title="View Croagunk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/453.png" alt="Croagunk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">453</span>
                             Croagunk
@@ -4660,8 +4660,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="Toxicroak">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/toxicroak/" title="View Toxicroak on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/454.png" alt="Toxicroak" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">454</span>
                             Toxicroak
@@ -4670,8 +4670,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="Carnivine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carnivine/" title="View Carnivine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/455.png" alt="Carnivine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">455</span>
                             Carnivine
@@ -4680,8 +4680,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="Finneon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/finneon/" title="View Finneon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/456.png" alt="Finneon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">456</span>
                             Finneon
@@ -4690,8 +4690,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="Lumineon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lumineon/" title="View Lumineon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/457.png" alt="Lumineon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">457</span>
                             Lumineon
@@ -4700,8 +4700,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="Mantyke">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mantyke/" title="View Mantyke on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/458.png" alt="Mantyke" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">458</span>
                             Mantyke
@@ -4710,8 +4710,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="Snover">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snover/" title="View Snover on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/459.png" alt="Snover" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">459</span>
                             Snover
@@ -4720,8 +4720,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="Abomasnow">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/abomasnow/" title="View Abomasnow on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/460.png" alt="Abomasnow" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">460</span>
                             Abomasnow
@@ -4730,8 +4730,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="Weavile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/weavile/" title="View Weavile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/461.png" alt="Weavile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">461</span>
                             Weavile
@@ -4740,8 +4740,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="Magnezone">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magnezone/" title="View Magnezone on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/462.png" alt="Magnezone" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">462</span>
                             Magnezone
@@ -4750,8 +4750,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="Lickilicky">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lickilicky/" title="View Lickilicky on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/463.png" alt="Lickilicky" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">463</span>
                             Lickilicky
@@ -4760,8 +4760,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="Rhyperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rhyperior/" title="View Rhyperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/464.png" alt="Rhyperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">464</span>
                             Rhyperior
@@ -4770,8 +4770,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="Tangrowth">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tangrowth/" title="View Tangrowth on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/465.png" alt="Tangrowth" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">465</span>
                             Tangrowth
@@ -4780,8 +4780,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="Electivire">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/electivire/" title="View Electivire on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/466.png" alt="Electivire" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">466</span>
                             Electivire
@@ -4790,8 +4790,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="Magmortar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/magmortar/" title="View Magmortar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/467.png" alt="Magmortar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">467</span>
                             Magmortar
@@ -4800,8 +4800,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="Togekiss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/togekiss/" title="View Togekiss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/468.png" alt="Togekiss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">468</span>
                             Togekiss
@@ -4810,8 +4810,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="Yanmega">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yanmega/" title="View Yanmega on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/469.png" alt="Yanmega" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">469</span>
                             Yanmega
@@ -4820,8 +4820,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="Leafeon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leafeon/" title="View Leafeon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/470.png" alt="Leafeon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">470</span>
                             Leafeon
@@ -4830,8 +4830,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="Glaceon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/glaceon/" title="View Glaceon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/471.png" alt="Glaceon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">471</span>
                             Glaceon
@@ -4840,8 +4840,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="Gliscor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gliscor/" title="View Gliscor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/472.png" alt="Gliscor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">472</span>
                             Gliscor
@@ -4850,8 +4850,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="Mamoswine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mamoswine/" title="View Mamoswine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/473.png" alt="Mamoswine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">473</span>
                             Mamoswine
@@ -4860,8 +4860,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="Porygon-Z">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/porygon-z/" title="View Porygon-Z on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/474.png" alt="Porygon-Z" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">474</span>
                             Porygon-Z
@@ -4870,8 +4870,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="Gallade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gallade/" title="View Gallade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/475.png" alt="Gallade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">475</span>
                             Gallade
@@ -4880,8 +4880,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="Probopass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/probopass/" title="View Probopass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/476.png" alt="Probopass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">476</span>
                             Probopass
@@ -4890,8 +4890,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="Dusknoir">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dusknoir/" title="View Dusknoir on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/477.png" alt="Dusknoir" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">477</span>
                             Dusknoir
@@ -4900,8 +4900,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="Froslass">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froslass/" title="View Froslass on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/478.png" alt="Froslass" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">478</span>
                             Froslass
@@ -4910,8 +4910,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="Rotom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rotom/" title="View Rotom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/479.png" alt="Rotom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">479</span>
                             Rotom
@@ -4920,8 +4920,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="Uxie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/uxie/" title="View Uxie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/480.png" alt="Uxie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">480</span>
                             Uxie
@@ -4937,8 +4937,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="Mesprit">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mesprit/" title="View Mesprit on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/481.png" alt="Mesprit" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">481</span>
                             Mesprit
@@ -4947,8 +4947,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="Azelf">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/azelf/" title="View Azelf on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/482.png" alt="Azelf" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">482</span>
                             Azelf
@@ -4957,8 +4957,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="Dialga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dialga/" title="View Dialga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/483.png" alt="Dialga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">483</span>
                             Dialga
@@ -4967,8 +4967,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="Palkia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palkia/" title="View Palkia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/484.png" alt="Palkia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">484</span>
                             Palkia
@@ -4977,8 +4977,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="Heatran">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatran/" title="View Heatran on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/485.png" alt="Heatran" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">485</span>
                             Heatran
@@ -4987,8 +4987,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="Regigigas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/regigigas/" title="View Regigigas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/486.png" alt="Regigigas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">486</span>
                             Regigigas
@@ -4997,8 +4997,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="Giratina">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/giratina/" title="View Giratina on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/487.png" alt="Giratina" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">487</span>
                             Giratina
@@ -5007,8 +5007,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="Cresselia">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cresselia/" title="View Cresselia on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/488.png" alt="Cresselia" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">488</span>
                             Cresselia
@@ -5017,8 +5017,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="Phione">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phione/" title="View Phione on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/489.png" alt="Phione" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">489</span>
                             Phione
@@ -5027,8 +5027,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="Manaphy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/manaphy/" title="View Manaphy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/490.png" alt="Manaphy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">490</span>
                             Manaphy
@@ -5037,8 +5037,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darkrai/" title="Darkrai">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/491.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darkrai/" title="View Darkrai on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/491.png" alt="Darkrai" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">491</span>
                             Darkrai
@@ -5047,8 +5047,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shaymin/" title="Shaymin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/492.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shaymin/" title="View Shaymin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/492.png" alt="Shaymin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">492</span>
                             Shaymin
@@ -5057,8 +5057,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/arceus/" title="Arceus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/493.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/arceus/" title="View Arceus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/493.png" alt="Arceus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">493</span>
                             Arceus
@@ -5067,8 +5067,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/victini/" title="Victini">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/494.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/victini/" title="View Victini on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/494.png" alt="Victini" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">494</span>
                             Victini
@@ -5077,8 +5077,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/snivy/" title="Snivy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/495.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/snivy/" title="View Snivy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/495.png" alt="Snivy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">495</span>
                             Snivy
@@ -5087,8 +5087,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/servine/" title="Servine">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/496.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/servine/" title="View Servine on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/496.png" alt="Servine" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">496</span>
                             Servine
@@ -5097,8 +5097,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/serperior/" title="Serperior">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/497.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/serperior/" title="View Serperior on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/497.png" alt="Serperior" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">497</span>
                             Serperior
@@ -5107,8 +5107,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tepig/" title="Tepig">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/498.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tepig/" title="View Tepig on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/498.png" alt="Tepig" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">498</span>
                             Tepig
@@ -5117,8 +5117,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pignite/" title="Pignite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/499.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pignite/" title="View Pignite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/499.png" alt="Pignite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">499</span>
                             Pignite
@@ -5127,8 +5127,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/emboar/" title="Emboar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/500.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/emboar/" title="View Emboar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/500.png" alt="Emboar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">500</span>
                             Emboar
@@ -5137,8 +5137,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/oshawott/" title="Oshawott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/501.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/oshawott/" title="View Oshawott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/501.png" alt="Oshawott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">501</span>
                             Oshawott
@@ -5147,8 +5147,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dewott/" title="Dewott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/502.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dewott/" title="View Dewott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/502.png" alt="Dewott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">502</span>
                             Dewott
@@ -5157,8 +5157,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/samurott/" title="Samurott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/503.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/samurott/" title="View Samurott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/503.png" alt="Samurott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">503</span>
                             Samurott
@@ -5167,8 +5167,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/patrat/" title="Patrat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/504.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/patrat/" title="View Patrat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/504.png" alt="Patrat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">504</span>
                             Patrat
@@ -5177,8 +5177,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/watchog/" title="Watchog">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/505.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/watchog/" title="View Watchog on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/505.png" alt="Watchog" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">505</span>
                             Watchog
@@ -5187,8 +5187,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="Lillipup">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lillipup/" title="View Lillipup on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/506.png" alt="Lillipup" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">506</span>
                             Lillipup
@@ -5197,8 +5197,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="Herdier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/herdier/" title="View Herdier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/507.png" alt="Herdier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">507</span>
                             Herdier
@@ -5207,8 +5207,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="Stoutland">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stoutland/" title="View Stoutland on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/508.png" alt="Stoutland" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">508</span>
                             Stoutland
@@ -5217,8 +5217,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="Purrloin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/purrloin/" title="View Purrloin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/509.png" alt="Purrloin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">509</span>
                             Purrloin
@@ -5227,8 +5227,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="Liepard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/liepard/" title="View Liepard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/510.png" alt="Liepard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">510</span>
                             Liepard
@@ -5244,8 +5244,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pansage/" title="Pansage">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/511.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pansage/" title="View Pansage on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/511.png" alt="Pansage" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">511</span>
                             Pansage
@@ -5254,8 +5254,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simisage/" title="Simisage">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/512.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simisage/" title="View Simisage on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/512.png" alt="Simisage" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">512</span>
                             Simisage
@@ -5264,8 +5264,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pansear/" title="Pansear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/513.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pansear/" title="View Pansear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/513.png" alt="Pansear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">513</span>
                             Pansear
@@ -5274,8 +5274,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simisear/" title="Simisear">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/514.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simisear/" title="View Simisear on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/514.png" alt="Simisear" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">514</span>
                             Simisear
@@ -5284,8 +5284,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/panpour/" title="Panpour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/515.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/panpour/" title="View Panpour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/515.png" alt="Panpour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">515</span>
                             Panpour
@@ -5294,8 +5294,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/simipour/" title="Simipour">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/516.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/simipour/" title="View Simipour on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/516.png" alt="Simipour" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">516</span>
                             Simipour
@@ -5304,8 +5304,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="Munna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/munna/" title="View Munna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/517.png" alt="Munna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">517</span>
                             Munna
@@ -5314,8 +5314,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="Musharna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/musharna/" title="View Musharna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/518.png" alt="Musharna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">518</span>
                             Musharna
@@ -5324,8 +5324,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="Pidove">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pidove/" title="View Pidove on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/519.png" alt="Pidove" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">519</span>
                             Pidove
@@ -5334,8 +5334,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="Tranquill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tranquill/" title="View Tranquill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/520.png" alt="Tranquill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">520</span>
                             Tranquill
@@ -5344,8 +5344,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="Unfezant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/unfezant/" title="View Unfezant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/521.png" alt="Unfezant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">521</span>
                             Unfezant
@@ -5354,8 +5354,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/blitzle/" title="Blitzle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/522.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/blitzle/" title="View Blitzle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/522.png" alt="Blitzle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">522</span>
                             Blitzle
@@ -5364,8 +5364,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zebstrika/" title="Zebstrika">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/523.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zebstrika/" title="View Zebstrika on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/523.png" alt="Zebstrika" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">523</span>
                             Zebstrika
@@ -5374,8 +5374,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="Roggenrola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/roggenrola/" title="View Roggenrola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/524.png" alt="Roggenrola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">524</span>
                             Roggenrola
@@ -5384,8 +5384,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="Boldore">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/boldore/" title="View Boldore on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/525.png" alt="Boldore" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">525</span>
                             Boldore
@@ -5394,8 +5394,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="Gigalith">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gigalith/" title="View Gigalith on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/526.png" alt="Gigalith" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">526</span>
                             Gigalith
@@ -5404,8 +5404,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="Woobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/woobat/" title="View Woobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/527.png" alt="Woobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">527</span>
                             Woobat
@@ -5414,8 +5414,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="Swoobat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swoobat/" title="View Swoobat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/528.png" alt="Swoobat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">528</span>
                             Swoobat
@@ -5424,8 +5424,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="Drilbur">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/drilbur/" title="View Drilbur on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/529.png" alt="Drilbur" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">529</span>
                             Drilbur
@@ -5434,8 +5434,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="Excadrill">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/excadrill/" title="View Excadrill on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/530.png" alt="Excadrill" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">530</span>
                             Excadrill
@@ -5444,8 +5444,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/audino/" title="Audino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/531.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/audino/" title="View Audino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/531.png" alt="Audino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">531</span>
                             Audino
@@ -5454,8 +5454,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="Timburr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/timburr/" title="View Timburr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/532.png" alt="Timburr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">532</span>
                             Timburr
@@ -5464,8 +5464,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="Gurdurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gurdurr/" title="View Gurdurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/533.png" alt="Gurdurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">533</span>
                             Gurdurr
@@ -5474,8 +5474,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="Conkeldurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/conkeldurr/" title="View Conkeldurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/534.png" alt="Conkeldurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">534</span>
                             Conkeldurr
@@ -5484,8 +5484,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="Tympole">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tympole/" title="View Tympole on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/535.png" alt="Tympole" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">535</span>
                             Tympole
@@ -5494,8 +5494,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="Palpitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/palpitoad/" title="View Palpitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/536.png" alt="Palpitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">536</span>
                             Palpitoad
@@ -5504,8 +5504,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="Seismitoad">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/seismitoad/" title="View Seismitoad on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/537.png" alt="Seismitoad" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">537</span>
                             Seismitoad
@@ -5514,8 +5514,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="Throh">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/throh/" title="View Throh on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/538.png" alt="Throh" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">538</span>
                             Throh
@@ -5524,8 +5524,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="Sawk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sawk/" title="View Sawk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/539.png" alt="Sawk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">539</span>
                             Sawk
@@ -5534,8 +5534,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sewaddle/" title="Sewaddle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/540.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sewaddle/" title="View Sewaddle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/540.png" alt="Sewaddle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">540</span>
                             Sewaddle
@@ -5551,8 +5551,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swadloon/" title="Swadloon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/541.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swadloon/" title="View Swadloon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/541.png" alt="Swadloon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">541</span>
                             Swadloon
@@ -5561,8 +5561,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/leavanny/" title="Leavanny">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/542.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/leavanny/" title="View Leavanny on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/542.png" alt="Leavanny" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">542</span>
                             Leavanny
@@ -5571,8 +5571,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="Venipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/venipede/" title="View Venipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/543.png" alt="Venipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">543</span>
                             Venipede
@@ -5581,8 +5581,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="Whirlipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whirlipede/" title="View Whirlipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/544.png" alt="Whirlipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">544</span>
                             Whirlipede
@@ -5591,8 +5591,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="Scolipede">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scolipede/" title="View Scolipede on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/545.png" alt="Scolipede" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">545</span>
                             Scolipede
@@ -5601,8 +5601,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="Cottonee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cottonee/" title="View Cottonee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/546.png" alt="Cottonee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">546</span>
                             Cottonee
@@ -5611,8 +5611,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="Whimsicott">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/whimsicott/" title="View Whimsicott on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/547.png" alt="Whimsicott" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">547</span>
                             Whimsicott
@@ -5621,8 +5621,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="Petilil">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/petilil/" title="View Petilil on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/548.png" alt="Petilil" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">548</span>
                             Petilil
@@ -5631,8 +5631,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="Lilligant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lilligant/" title="View Lilligant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/549.png" alt="Lilligant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">549</span>
                             Lilligant
@@ -5641,8 +5641,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="Basculin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/basculin/" title="View Basculin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/550.png" alt="Basculin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">550</span>
                             Basculin
@@ -5651,8 +5651,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="Sandile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sandile/" title="View Sandile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/551.png" alt="Sandile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">551</span>
                             Sandile
@@ -5661,8 +5661,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="Krokorok">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krokorok/" title="View Krokorok on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/552.png" alt="Krokorok" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">552</span>
                             Krokorok
@@ -5671,8 +5671,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="Krookodile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/krookodile/" title="View Krookodile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/553.png" alt="Krookodile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">553</span>
                             Krookodile
@@ -5681,8 +5681,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="Darumaka">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darumaka/" title="View Darumaka on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/554.png" alt="Darumaka" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">554</span>
                             Darumaka
@@ -5691,8 +5691,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="Darmanitan">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/darmanitan/" title="View Darmanitan on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/555.png" alt="Darmanitan" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">555</span>
                             Darmanitan
@@ -5701,8 +5701,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="Maractus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/maractus/" title="View Maractus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/556.png" alt="Maractus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">556</span>
                             Maractus
@@ -5711,8 +5711,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="Dwebble">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dwebble/" title="View Dwebble on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/557.png" alt="Dwebble" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">557</span>
                             Dwebble
@@ -5721,8 +5721,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="Crustle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/crustle/" title="View Crustle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/558.png" alt="Crustle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">558</span>
                             Crustle
@@ -5731,8 +5731,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="Scraggy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scraggy/" title="View Scraggy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/559.png" alt="Scraggy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">559</span>
                             Scraggy
@@ -5741,8 +5741,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="Scrafty">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scrafty/" title="View Scrafty on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/560.png" alt="Scrafty" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">560</span>
                             Scrafty
@@ -5751,8 +5751,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="Sigilyph">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sigilyph/" title="View Sigilyph on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/561.png" alt="Sigilyph" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">561</span>
                             Sigilyph
@@ -5761,8 +5761,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="Yamask">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yamask/" title="View Yamask on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/562.png" alt="Yamask" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">562</span>
                             Yamask
@@ -5771,8 +5771,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="Cofagrigus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cofagrigus/" title="View Cofagrigus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/563.png" alt="Cofagrigus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">563</span>
                             Cofagrigus
@@ -5781,8 +5781,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tirtouga/" title="Tirtouga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/564.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tirtouga/" title="View Tirtouga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/564.png" alt="Tirtouga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">564</span>
                             Tirtouga
@@ -5791,8 +5791,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carracosta/" title="Carracosta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/565.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carracosta/" title="View Carracosta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/565.png" alt="Carracosta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">565</span>
                             Carracosta
@@ -5801,8 +5801,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/archen/" title="Archen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/566.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/archen/" title="View Archen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/566.png" alt="Archen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">566</span>
                             Archen
@@ -5811,8 +5811,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/archeops/" title="Archeops">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/567.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/archeops/" title="View Archeops on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/567.png" alt="Archeops" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">567</span>
                             Archeops
@@ -5821,8 +5821,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="Trubbish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trubbish/" title="View Trubbish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/568.png" alt="Trubbish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">568</span>
                             Trubbish
@@ -5831,8 +5831,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="Garbodor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/garbodor/" title="View Garbodor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/569.png" alt="Garbodor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">569</span>
                             Garbodor
@@ -5841,8 +5841,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="Zorua">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zorua/" title="View Zorua on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/570.png" alt="Zorua" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">570</span>
                             Zorua
@@ -5858,8 +5858,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="Zoroark">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zoroark/" title="View Zoroark on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/571.png" alt="Zoroark" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">571</span>
                             Zoroark
@@ -5868,8 +5868,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="Minccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/minccino/" title="View Minccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/572.png" alt="Minccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">572</span>
                             Minccino
@@ -5878,8 +5878,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="Cinccino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cinccino/" title="View Cinccino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/573.png" alt="Cinccino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">573</span>
                             Cinccino
@@ -5888,8 +5888,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="Gothita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothita/" title="View Gothita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/574.png" alt="Gothita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">574</span>
                             Gothita
@@ -5898,8 +5898,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="Gothorita">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothorita/" title="View Gothorita on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/575.png" alt="Gothorita" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">575</span>
                             Gothorita
@@ -5908,8 +5908,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="Gothitelle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gothitelle/" title="View Gothitelle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/576.png" alt="Gothitelle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">576</span>
                             Gothitelle
@@ -5918,8 +5918,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="Solosis">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/solosis/" title="View Solosis on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/577.png" alt="Solosis" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">577</span>
                             Solosis
@@ -5928,8 +5928,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="Duosion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/duosion/" title="View Duosion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/578.png" alt="Duosion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">578</span>
                             Duosion
@@ -5938,8 +5938,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="Reuniclus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/reuniclus/" title="View Reuniclus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/579.png" alt="Reuniclus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">579</span>
                             Reuniclus
@@ -5948,8 +5948,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ducklett/" title="Ducklett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/580.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ducklett/" title="View Ducklett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/580.png" alt="Ducklett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">580</span>
                             Ducklett
@@ -5958,8 +5958,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swanna/" title="Swanna">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/581.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swanna/" title="View Swanna on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/581.png" alt="Swanna" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">581</span>
                             Swanna
@@ -5968,8 +5968,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="Vanillite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillite/" title="View Vanillite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/582.png" alt="Vanillite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">582</span>
                             Vanillite
@@ -5978,8 +5978,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="Vanillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanillish/" title="View Vanillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/583.png" alt="Vanillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">583</span>
                             Vanillish
@@ -5988,8 +5988,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="Vanilluxe">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vanilluxe/" title="View Vanilluxe on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/584.png" alt="Vanilluxe" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">584</span>
                             Vanilluxe
@@ -5998,8 +5998,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deerling/" title="Deerling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/585.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deerling/" title="View Deerling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/585.png" alt="Deerling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">585</span>
                             Deerling
@@ -6008,8 +6008,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sawsbuck/" title="Sawsbuck">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/586.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sawsbuck/" title="View Sawsbuck on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/586.png" alt="Sawsbuck" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">586</span>
                             Sawsbuck
@@ -6018,8 +6018,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="Emolga">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/emolga/" title="View Emolga on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/587.png" alt="Emolga" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">587</span>
                             Emolga
@@ -6028,8 +6028,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="Karrablast">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/karrablast/" title="View Karrablast on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/588.png" alt="Karrablast" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">588</span>
                             Karrablast
@@ -6038,8 +6038,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="Escavalier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/escavalier/" title="View Escavalier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/589.png" alt="Escavalier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">589</span>
                             Escavalier
@@ -6048,8 +6048,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="Foongus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/foongus/" title="View Foongus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/590.png" alt="Foongus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">590</span>
                             Foongus
@@ -6058,8 +6058,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="Amoonguss">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/amoonguss/" title="View Amoonguss on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/591.png" alt="Amoonguss" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">591</span>
                             Amoonguss
@@ -6068,8 +6068,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="Frillish">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frillish/" title="View Frillish on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/592.png" alt="Frillish" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">592</span>
                             Frillish
@@ -6078,8 +6078,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="Jellicent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/jellicent/" title="View Jellicent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/593.png" alt="Jellicent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">593</span>
                             Jellicent
@@ -6088,8 +6088,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/alomomola/" title="Alomomola">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/594.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/alomomola/" title="View Alomomola on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/594.png" alt="Alomomola" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">594</span>
                             Alomomola
@@ -6098,8 +6098,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="Joltik">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/joltik/" title="View Joltik on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/595.png" alt="Joltik" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">595</span>
                             Joltik
@@ -6108,8 +6108,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="Galvantula">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/galvantula/" title="View Galvantula on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/596.png" alt="Galvantula" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">596</span>
                             Galvantula
@@ -6118,8 +6118,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="Ferroseed">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferroseed/" title="View Ferroseed on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/597.png" alt="Ferroseed" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">597</span>
                             Ferroseed
@@ -6128,8 +6128,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="Ferrothorn">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/ferrothorn/" title="View Ferrothorn on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/598.png" alt="Ferrothorn" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">598</span>
                             Ferrothorn
@@ -6138,8 +6138,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="Klink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klink/" title="View Klink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/599.png" alt="Klink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">599</span>
                             Klink
@@ -6148,8 +6148,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="Klang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klang/" title="View Klang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/600.png" alt="Klang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">600</span>
                             Klang
@@ -6165,8 +6165,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="Klinklang">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klinklang/" title="View Klinklang on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/601.png" alt="Klinklang" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">601</span>
                             Klinklang
@@ -6175,8 +6175,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tynamo/" title="Tynamo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/602.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tynamo/" title="View Tynamo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/602.png" alt="Tynamo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">602</span>
                             Tynamo
@@ -6185,8 +6185,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eelektrik/" title="Eelektrik">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/603.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eelektrik/" title="View Eelektrik on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/603.png" alt="Eelektrik" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">603</span>
                             Eelektrik
@@ -6195,8 +6195,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/eelektross/" title="Eelektross">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/604.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/eelektross/" title="View Eelektross on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/604.png" alt="Eelektross" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">604</span>
                             Eelektross
@@ -6205,8 +6205,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="Elgyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/elgyem/" title="View Elgyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/605.png" alt="Elgyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">605</span>
                             Elgyem
@@ -6215,8 +6215,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="Beheeyem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beheeyem/" title="View Beheeyem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/606.png" alt="Beheeyem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">606</span>
                             Beheeyem
@@ -6225,8 +6225,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="Litwick">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litwick/" title="View Litwick on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/607.png" alt="Litwick" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">607</span>
                             Litwick
@@ -6235,8 +6235,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="Lampent">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/lampent/" title="View Lampent on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/608.png" alt="Lampent" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">608</span>
                             Lampent
@@ -6245,8 +6245,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="Chandelure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chandelure/" title="View Chandelure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/609.png" alt="Chandelure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">609</span>
                             Chandelure
@@ -6255,8 +6255,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="Axew">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/axew/" title="View Axew on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/610.png" alt="Axew" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">610</span>
                             Axew
@@ -6265,8 +6265,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="Fraxure">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fraxure/" title="View Fraxure on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/611.png" alt="Fraxure" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">611</span>
                             Fraxure
@@ -6275,8 +6275,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="Haxorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/haxorus/" title="View Haxorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/612.png" alt="Haxorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">612</span>
                             Haxorus
@@ -6285,8 +6285,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="Cubchoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cubchoo/" title="View Cubchoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/613.png" alt="Cubchoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">613</span>
                             Cubchoo
@@ -6295,8 +6295,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="Beartic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/beartic/" title="View Beartic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/614.png" alt="Beartic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">614</span>
                             Beartic
@@ -6305,8 +6305,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cryogonal/" title="Cryogonal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/615.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cryogonal/" title="View Cryogonal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/615.png" alt="Cryogonal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">615</span>
                             Cryogonal
@@ -6315,8 +6315,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="Shelmet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/shelmet/" title="View Shelmet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/616.png" alt="Shelmet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">616</span>
                             Shelmet
@@ -6325,8 +6325,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="Accelgor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/accelgor/" title="View Accelgor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/617.png" alt="Accelgor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">617</span>
                             Accelgor
@@ -6335,8 +6335,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="Stunfisk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/stunfisk/" title="View Stunfisk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/618.png" alt="Stunfisk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">618</span>
                             Stunfisk
@@ -6345,8 +6345,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="Mienfoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienfoo/" title="View Mienfoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/619.png" alt="Mienfoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">619</span>
                             Mienfoo
@@ -6355,8 +6355,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="Mienshao">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mienshao/" title="View Mienshao on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/620.png" alt="Mienshao" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">620</span>
                             Mienshao
@@ -6365,8 +6365,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="Druddigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/druddigon/" title="View Druddigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/621.png" alt="Druddigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">621</span>
                             Druddigon
@@ -6375,8 +6375,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="Golett">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golett/" title="View Golett on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/622.png" alt="Golett" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">622</span>
                             Golett
@@ -6385,8 +6385,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="Golurk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/golurk/" title="View Golurk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/623.png" alt="Golurk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">623</span>
                             Golurk
@@ -6395,8 +6395,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="Pawniard">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pawniard/" title="View Pawniard on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/624.png" alt="Pawniard" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">624</span>
                             Pawniard
@@ -6405,8 +6405,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="Bisharp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bisharp/" title="View Bisharp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/625.png" alt="Bisharp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">625</span>
                             Bisharp
@@ -6415,8 +6415,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="Bouffalant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bouffalant/" title="View Bouffalant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/626.png" alt="Bouffalant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">626</span>
                             Bouffalant
@@ -6425,8 +6425,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="Rufflet">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/rufflet/" title="View Rufflet on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/627.png" alt="Rufflet" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">627</span>
                             Rufflet
@@ -6435,8 +6435,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="Braviary">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/braviary/" title="View Braviary on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/628.png" alt="Braviary" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">628</span>
                             Braviary
@@ -6445,8 +6445,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="Vullaby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vullaby/" title="View Vullaby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/629.png" alt="Vullaby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">629</span>
                             Vullaby
@@ -6455,8 +6455,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="Mandibuzz">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/mandibuzz/" title="View Mandibuzz on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/630.png" alt="Mandibuzz" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">630</span>
                             Mandibuzz
@@ -6472,8 +6472,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="Heatmor">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heatmor/" title="View Heatmor on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/631.png" alt="Heatmor" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">631</span>
                             Heatmor
@@ -6482,8 +6482,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="Durant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/durant/" title="View Durant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/632.png" alt="Durant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">632</span>
                             Durant
@@ -6492,8 +6492,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="Deino">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/deino/" title="View Deino on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/633.png" alt="Deino" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">633</span>
                             Deino
@@ -6502,8 +6502,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="Zweilous">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zweilous/" title="View Zweilous on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/634.png" alt="Zweilous" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">634</span>
                             Zweilous
@@ -6512,8 +6512,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="Hydreigon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hydreigon/" title="View Hydreigon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/635.png" alt="Hydreigon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">635</span>
                             Hydreigon
@@ -6522,8 +6522,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="Larvesta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/larvesta/" title="View Larvesta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/636.png" alt="Larvesta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">636</span>
                             Larvesta
@@ -6532,8 +6532,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="Volcarona">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/volcarona/" title="View Volcarona on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/637.png" alt="Volcarona" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">637</span>
                             Volcarona
@@ -6542,8 +6542,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/cobalion/" title="Cobalion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/638.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/cobalion/" title="View Cobalion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/638.png" alt="Cobalion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">638</span>
                             Cobalion
@@ -6552,8 +6552,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/terrakion/" title="Terrakion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/639.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/terrakion/" title="View Terrakion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/639.png" alt="Terrakion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">639</span>
                             Terrakion
@@ -6562,8 +6562,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/virizion/" title="Virizion">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/640.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/virizion/" title="View Virizion on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/640.png" alt="Virizion" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">640</span>
                             Virizion
@@ -6572,8 +6572,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tornadus/" title="Tornadus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/641.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tornadus/" title="View Tornadus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/641.png" alt="Tornadus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">641</span>
                             Tornadus
@@ -6582,8 +6582,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/thundurus/" title="Thundurus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/642.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/thundurus/" title="View Thundurus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/642.png" alt="Thundurus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">642</span>
                             Thundurus
@@ -6592,8 +6592,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/reshiram/" title="Reshiram">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/643.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/reshiram/" title="View Reshiram on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/643.png" alt="Reshiram" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">643</span>
                             Reshiram
@@ -6602,8 +6602,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zekrom/" title="Zekrom">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/644.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zekrom/" title="View Zekrom on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/644.png" alt="Zekrom" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">644</span>
                             Zekrom
@@ -6612,8 +6612,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/landorus/" title="Landorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/645.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/landorus/" title="View Landorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/645.png" alt="Landorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">645</span>
                             Landorus
@@ -6622,8 +6622,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/kyurem/" title="Kyurem">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/646.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/kyurem/" title="View Kyurem on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/646.png" alt="Kyurem" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">646</span>
                             Kyurem
@@ -6632,8 +6632,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/keldeo/" title="Keldeo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/647.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/keldeo/" title="View Keldeo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/647.png" alt="Keldeo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">647</span>
                             Keldeo
@@ -6642,8 +6642,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meloetta/" title="Meloetta">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/648.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meloetta/" title="View Meloetta on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/648.png" alt="Meloetta" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">648</span>
                             Meloetta
@@ -6652,8 +6652,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/genesect/" title="Genesect">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/649.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/genesect/" title="View Genesect on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/649.png" alt="Genesect" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">649</span>
                             Genesect
@@ -6662,8 +6662,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chespin/" title="Chespin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/650.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chespin/" title="View Chespin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/650.png" alt="Chespin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">650</span>
                             Chespin
@@ -6672,8 +6672,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/quilladin/" title="Quilladin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/651.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/quilladin/" title="View Quilladin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/651.png" alt="Quilladin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">651</span>
                             Quilladin
@@ -6682,8 +6682,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/chesnaught/" title="Chesnaught">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/652.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/chesnaught/" title="View Chesnaught on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/652.png" alt="Chesnaught" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">652</span>
                             Chesnaught
@@ -6692,8 +6692,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fennekin/" title="Fennekin">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/653.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fennekin/" title="View Fennekin on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/653.png" alt="Fennekin" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">653</span>
                             Fennekin
@@ -6702,8 +6702,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/braixen/" title="Braixen">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/654.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/braixen/" title="View Braixen on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/654.png" alt="Braixen" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">654</span>
                             Braixen
@@ -6712,8 +6712,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/delphox/" title="Delphox">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/655.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/delphox/" title="View Delphox on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/655.png" alt="Delphox" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">655</span>
                             Delphox
@@ -6722,8 +6722,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/froakie/" title="Froakie">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/656.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/froakie/" title="View Froakie on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/656.png" alt="Froakie" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">656</span>
                             Froakie
@@ -6732,8 +6732,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/frogadier/" title="Frogadier">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/657.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/frogadier/" title="View Frogadier on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/657.png" alt="Frogadier" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">657</span>
                             Frogadier
@@ -6742,8 +6742,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/greninja/" title="Greninja">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/658.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/greninja/" title="View Greninja on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/658.png" alt="Greninja" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">658</span>
                             Greninja
@@ -6752,8 +6752,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bunnelby/" title="Bunnelby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/659.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bunnelby/" title="View Bunnelby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/659.png" alt="Bunnelby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">659</span>
                             Bunnelby
@@ -6762,8 +6762,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/diggersby/" title="Diggersby">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/660.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/diggersby/" title="View Diggersby on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/660.png" alt="Diggersby" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">660</span>
                             Diggersby
@@ -6779,8 +6779,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fletchling/" title="Fletchling">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/661.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fletchling/" title="View Fletchling on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/661.png" alt="Fletchling" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">661</span>
                             Fletchling
@@ -6789,8 +6789,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/fletchinder/" title="Fletchinder">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/662.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/fletchinder/" title="View Fletchinder on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/662.png" alt="Fletchinder" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">662</span>
                             Fletchinder
@@ -6799,8 +6799,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/talonflame/" title="Talonflame">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/663.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/talonflame/" title="View Talonflame on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/663.png" alt="Talonflame" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">663</span>
                             Talonflame
@@ -6809,8 +6809,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/scatterbug/" title="Scatterbug">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/664.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/scatterbug/" title="View Scatterbug on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/664.png" alt="Scatterbug" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">664</span>
                             Scatterbug
@@ -6819,8 +6819,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spewpa/" title="Spewpa">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/665.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spewpa/" title="View Spewpa on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/665.png" alt="Spewpa" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">665</span>
                             Spewpa
@@ -6829,8 +6829,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/vivillon/" title="Vivillon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/666.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/vivillon/" title="View Vivillon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/666.png" alt="Vivillon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">666</span>
                             Vivillon
@@ -6839,8 +6839,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/litleo/" title="Litleo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/667.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/litleo/" title="View Litleo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/667.png" alt="Litleo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">667</span>
                             Litleo
@@ -6849,8 +6849,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pyroar/" title="Pyroar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/668.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pyroar/" title="View Pyroar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/668.png" alt="Pyroar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">668</span>
                             Pyroar
@@ -6859,8 +6859,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/flabebe/" title="Flabébé">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/669.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/flabebe/" title="View Flabébé on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/669.png" alt="Flabébé" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">669</span>
                             Flabébé
@@ -6869,8 +6869,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/floette/" title="Floette">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/670.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/floette/" title="View Floette on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/670.png" alt="Floette" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">670</span>
                             Floette
@@ -6879,8 +6879,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/florges/" title="Florges">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/671.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/florges/" title="View Florges on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/671.png" alt="Florges" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">671</span>
                             Florges
@@ -6889,8 +6889,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skiddo/" title="Skiddo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/672.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skiddo/" title="View Skiddo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/672.png" alt="Skiddo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">672</span>
                             Skiddo
@@ -6899,8 +6899,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gogoat/" title="Gogoat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/673.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gogoat/" title="View Gogoat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/673.png" alt="Gogoat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">673</span>
                             Gogoat
@@ -6909,8 +6909,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pancham/" title="Pancham">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/674.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pancham/" title="View Pancham on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/674.png" alt="Pancham" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">674</span>
                             Pancham
@@ -6919,8 +6919,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pangoro/" title="Pangoro">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/675.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pangoro/" title="View Pangoro on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/675.png" alt="Pangoro" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">675</span>
                             Pangoro
@@ -6929,8 +6929,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/furfrou/" title="Furfrou">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/676.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/furfrou/" title="View Furfrou on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/676.png" alt="Furfrou" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">676</span>
                             Furfrou
@@ -6939,8 +6939,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/espurr/" title="Espurr">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/677.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/espurr/" title="View Espurr on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/677.png" alt="Espurr" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">677</span>
                             Espurr
@@ -6949,8 +6949,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/meowstic/" title="Meowstic">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/678.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/meowstic/" title="View Meowstic on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/678.png" alt="Meowstic" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">678</span>
                             Meowstic
@@ -6959,8 +6959,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/honedge/" title="Honedge">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/679.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/honedge/" title="View Honedge on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/679.png" alt="Honedge" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">679</span>
                             Honedge
@@ -6969,8 +6969,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/doublade/" title="Doublade">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/680.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/doublade/" title="View Doublade on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/680.png" alt="Doublade" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">680</span>
                             Doublade
@@ -6979,8 +6979,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aegislash/" title="Aegislash">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/681.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aegislash/" title="View Aegislash on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/681.png" alt="Aegislash" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">681</span>
                             Aegislash
@@ -6989,8 +6989,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/spritzee/" title="Spritzee">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/682.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/spritzee/" title="View Spritzee on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/682.png" alt="Spritzee" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">682</span>
                             Spritzee
@@ -6999,8 +6999,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aromatisse/" title="Aromatisse">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/683.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aromatisse/" title="View Aromatisse on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/683.png" alt="Aromatisse" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">683</span>
                             Aromatisse
@@ -7009,8 +7009,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/swirlix/" title="Swirlix">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/684.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/swirlix/" title="View Swirlix on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/684.png" alt="Swirlix" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">684</span>
                             Swirlix
@@ -7019,8 +7019,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/slurpuff/" title="Slurpuff">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/685.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/slurpuff/" title="View Slurpuff on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/685.png" alt="Slurpuff" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">685</span>
                             Slurpuff
@@ -7029,8 +7029,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="Inkay">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/inkay/" title="View Inkay on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/686.png" alt="Inkay" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">686</span>
                             Inkay
@@ -7039,8 +7039,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="Malamar">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/malamar/" title="View Malamar on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/687.png" alt="Malamar" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">687</span>
                             Malamar
@@ -7049,8 +7049,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/binacle/" title="Binacle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/688.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/binacle/" title="View Binacle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/688.png" alt="Binacle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">688</span>
                             Binacle
@@ -7059,8 +7059,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/barbaracle/" title="Barbaracle">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/689.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/barbaracle/" title="View Barbaracle on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/689.png" alt="Barbaracle" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">689</span>
                             Barbaracle
@@ -7069,8 +7069,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/skrelp/" title="Skrelp">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/690.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/skrelp/" title="View Skrelp on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/690.png" alt="Skrelp" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">690</span>
                             Skrelp
@@ -7086,8 +7086,8 @@
             <div class="contents">
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dragalge/" title="Dragalge">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/691.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dragalge/" title="View Dragalge on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/691.png" alt="Dragalge" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">691</span>
                             Dragalge
@@ -7096,8 +7096,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clauncher/" title="Clauncher">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/692.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clauncher/" title="View Clauncher on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/692.png" alt="Clauncher" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">692</span>
                             Clauncher
@@ -7106,8 +7106,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/clawitzer/" title="Clawitzer">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/693.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/clawitzer/" title="View Clawitzer on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/693.png" alt="Clawitzer" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">693</span>
                             Clawitzer
@@ -7116,8 +7116,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/helioptile/" title="Helioptile">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/694.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/helioptile/" title="View Helioptile on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/694.png" alt="Helioptile" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">694</span>
                             Helioptile
@@ -7126,8 +7126,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/heliolisk/" title="Heliolisk">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/695.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/heliolisk/" title="View Heliolisk on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/695.png" alt="Heliolisk" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">695</span>
                             Heliolisk
@@ -7136,8 +7136,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrunt/" title="Tyrunt">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/696.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrunt/" title="View Tyrunt on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/696.png" alt="Tyrunt" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">696</span>
                             Tyrunt
@@ -7146,8 +7146,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/tyrantrum/" title="Tyrantrum">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/697.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/tyrantrum/" title="View Tyrantrum on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/697.png" alt="Tyrantrum" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">697</span>
                             Tyrantrum
@@ -7156,8 +7156,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/amaura/" title="Amaura">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/698.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/amaura/" title="View Amaura on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/698.png" alt="Amaura" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">698</span>
                             Amaura
@@ -7166,8 +7166,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/aurorus/" title="Aurorus">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/699.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/aurorus/" title="View Aurorus on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/699.png" alt="Aurorus" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">699</span>
                             Aurorus
@@ -7176,8 +7176,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sylveon/" title="Sylveon">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/700.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sylveon/" title="View Sylveon on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/700.png" alt="Sylveon" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">700</span>
                             Sylveon
@@ -7186,8 +7186,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/hawlucha/" title="Hawlucha">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/701.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/hawlucha/" title="View Hawlucha on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/701.png" alt="Hawlucha" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">701</span>
                             Hawlucha
@@ -7196,8 +7196,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/dedenne/" title="Dedenne">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/702.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/dedenne/" title="View Dedenne on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/702.png" alt="Dedenne" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">702</span>
                             Dedenne
@@ -7206,8 +7206,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/carbink/" title="Carbink">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/703.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/carbink/" title="View Carbink on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/703.png" alt="Carbink" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">703</span>
                             Carbink
@@ -7216,8 +7216,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="Goomy">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goomy/" title="View Goomy on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/704.png" alt="Goomy" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">704</span>
                             Goomy
@@ -7226,8 +7226,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="Sliggoo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/sliggoo/" title="View Sliggoo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/705.png" alt="Sliggoo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">705</span>
                             Sliggoo
@@ -7236,8 +7236,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="Goodra">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/goodra/" title="View Goodra on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/706.png" alt="Goodra" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">706</span>
                             Goodra
@@ -7246,8 +7246,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/klefki/" title="Klefki">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/707.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/klefki/" title="View Klefki on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/707.png" alt="Klefki" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">707</span>
                             Klefki
@@ -7256,8 +7256,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/phantump/" title="Phantump">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/708.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/phantump/" title="View Phantump on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/708.png" alt="Phantump" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">708</span>
                             Phantump
@@ -7266,8 +7266,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/trevenant/" title="Trevenant">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/709.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/trevenant/" title="View Trevenant on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/709.png" alt="Trevenant" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">709</span>
                             Trevenant
@@ -7276,8 +7276,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/pumpkaboo/" title="Pumpkaboo">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/710.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/pumpkaboo/" title="View Pumpkaboo on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/710.png" alt="Pumpkaboo" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">710</span>
                             Pumpkaboo
@@ -7286,8 +7286,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/gourgeist/" title="Gourgeist">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/711.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/gourgeist/" title="View Gourgeist on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/711.png" alt="Gourgeist" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">711</span>
                             Gourgeist
@@ -7296,8 +7296,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/bergmite/" title="Bergmite">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/712.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/bergmite/" title="View Bergmite on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/712.png" alt="Bergmite" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">712</span>
                             Bergmite
@@ -7306,8 +7306,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/avalugg/" title="Avalugg">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/713.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/avalugg/" title="View Avalugg on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/713.png" alt="Avalugg" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">713</span>
                             Avalugg
@@ -7316,8 +7316,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noibat/" title="Noibat">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/714.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noibat/" title="View Noibat on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/714.png" alt="Noibat" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">714</span>
                             Noibat
@@ -7326,8 +7326,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/noivern/" title="Noivern">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/715.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/noivern/" title="View Noivern on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/715.png" alt="Noivern" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">715</span>
                             Noivern
@@ -7336,8 +7336,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/xerneas/" title="Xerneas">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/716.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/xerneas/" title="View Xerneas on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/716.png" alt="Xerneas" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">716</span>
                             Xerneas
@@ -7346,8 +7346,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/yveltal/" title="Yveltal">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/717.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/yveltal/" title="View Yveltal on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/717.png" alt="Yveltal" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">717</span>
                             Yveltal
@@ -7356,8 +7356,8 @@
                 </div>
                 
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/zygarde/" title="Zygarde">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/718.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/zygarde/" title="View Zygarde on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/718.png" alt="Zygarde" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">718</span>
                             Zygarde
@@ -7371,8 +7371,8 @@
     </section>
 
     
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/templates/index.gohtml
+++ b/templates/index.gohtml
@@ -35,8 +35,8 @@
     </section>
 
     <!-- Github Corner: https://gist.github.com/cmckee-dev/7a6291d06220a2180c2efbeb948649f7 -->
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"

--- a/templates/pokedex.gohtml
+++ b/templates/pokedex.gohtml
@@ -25,8 +25,8 @@
             <div class="contents">
                 {{range .Pokemon}}
                 <div class="monster">
-                    <a href="https://www.serebii.net/pokedex-swsh/{{ .Identifier }}/" title="{{ .Name }}">
-                        <img src="https://www.serebii.net/swordshield/pokemon/small/{{printf "%03d" .NationalDexNumber}}.png" loading="lazy"/>
+                    <a href="https://www.serebii.net/pokedex-swsh/{{ .Identifier }}/" title="View {{ .Name }} on Serebii">
+                        <img src="https://www.serebii.net/swordshield/pokemon/small/{{printf "%03d" .NationalDexNumber}}.png" alt="{{ .Name }}" loading="lazy"/>
                         <span class="name">
                             <span class="pokedex-number">{{ .DexNumber }}</span>
                             {{ .Name }}
@@ -40,8 +40,8 @@
     </section>
 
     <!-- Github Corner: https://gist.github.com/cmckee-dev/7a6291d06220a2180c2efbeb948649f7 -->
-    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner">
-      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;">
+    <a href="https://github.com/timoschinkel/living-pokedex-templates" class="github-corner" rel="noopener">
+      <svg width="80" height="80" viewBox="0 0 250 250" style="position: absolute; top: 0; border: 0; right: 0;" alt="Github logo">
         <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
         <path
           d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"


### PR DESCRIPTION
Lighthouse was complaining about missing alt attributes. As we already have the names of the Pokemon it was an easy fix